### PR TITLE
2021 Landingssider, listevisning og gridvisning

### DIFF
--- a/Assessments.Frontend.Web/Controllers/TestController.cs
+++ b/Assessments.Frontend.Web/Controllers/TestController.cs
@@ -110,11 +110,11 @@ namespace Assessments.Frontend.Web.Controllers
             {
                 switch (year)
                 {
-                    //case 2021:
+                    case 2021:
 
-                      //  var RL2021 = await _assessmentApi.Redlist2021.ByKey(Convert.ToInt32(id), vurderingscontext).GetValueAsync();
+                        var RL2021 = await _assessmentApi.Redlist2015.ByKey(Convert.ToInt32(id), vurderingscontext).GetValueAsync();
 
-                        //return View("SpeciesAssessment2021", RL2021);
+                        return View("SpeciesAssessment2021", RL2021);
 
                     case 2015:
 

--- a/Assessments.Frontend.Web/Controllers/TestController.cs
+++ b/Assessments.Frontend.Web/Controllers/TestController.cs
@@ -112,7 +112,7 @@ namespace Assessments.Frontend.Web.Controllers
                 {
                     case 2021:
 
-                        var RL2021 = await _assessmentApi.Redlist2015.ByKey(Convert.ToInt32(id), vurderingscontext).GetValueAsync();
+                        var RL2021 = await _assessmentApi.Redlist2021.ByKey(Convert.ToInt32(id), vurderingscontext).GetValueAsync();
 
                         return View("SpeciesAssessment2021", RL2021);
 

--- a/Assessments.Frontend.Web/Controllers/TestController.cs
+++ b/Assessments.Frontend.Web/Controllers/TestController.cs
@@ -112,7 +112,7 @@ namespace Assessments.Frontend.Web.Controllers
                 {
                     case 2021:
 
-                        var RL2021 = await _assessmentApi.Redlist2021.ByKey(Convert.ToInt32(id), vurderingscontext).GetValueAsync();
+                        var RL2021 = await _assessmentApi.Redlist2021.ByKey(Convert.ToInt32(id)).GetValueAsync();
 
                         return View("SpeciesAssessment2021", RL2021);
 

--- a/Assessments.Frontend.Web/Controllers/TestController.cs
+++ b/Assessments.Frontend.Web/Controllers/TestController.cs
@@ -32,6 +32,29 @@ namespace Assessments.Frontend.Web.Controllers
             return View(viewModel);
         }
 
+        [Route("2021")]
+        public IActionResult Index2021(int? page, string name)
+        {
+            // Pageination
+            const int pageSize = 25;
+            var pageNumber = page ?? 1;
+
+            // Filter
+            IQueryable<RL2021> query = _assessmentApi.Redlist2021;
+            if (!string.IsNullOrEmpty(name))
+                query = query.Where(x => x.VurdertVitenskapeligNavn.ToLower().Contains(name.Trim().ToLower()));
+
+
+            var viewModel = new RL2021ViewModel
+            {
+                //Redlist2015Results = _assessmentApi.Redlist2015.ToPagedList(pageNumber, pageSize),
+                Redlist2021Results = query.ToPagedList(pageNumber, pageSize),
+                Name = name
+            };
+
+            return View("List2021", viewModel);
+        }
+
         [Route("2015")]
         public IActionResult Index2015(int? page, string name)
         {
@@ -87,12 +110,18 @@ namespace Assessments.Frontend.Web.Controllers
             {
                 switch (year)
                 {
+                    //case 2021:
+
+                      //  var RL2021 = await _assessmentApi.Redlist2021.ByKey(Convert.ToInt32(id), vurderingscontext).GetValueAsync();
+
+                        //return View("SpeciesAssessment2021", RL2021);
+
                     case 2015:
 
                         var rodliste2015 = await _assessmentApi.Redlist2015.ByKey(Convert.ToInt32(id), vurderingscontext).GetValueAsync();
 
                         return View("SpeciesAssessment2015", rodliste2015);
-                    
+
                     case 2006:
                         
                         var redlist2006Assessment = await _assessmentApi.Redlist2006.ByKey(id).GetValueAsync();

--- a/Assessments.Frontend.Web/Infrastructure/AssessmentApiService.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AssessmentApiService.cs
@@ -9,6 +9,8 @@ namespace Assessments.Frontend.Web.Infrastructure
         private static IOptions<ApplicationSettings> _settings;
         private static Artsdatabanken.Assessments Assessments() => new (_settings.Value.AssessmentsApi.EndpointUrl);
 
+        public readonly DataServiceQuery<RL2021> Redlist2021;
+
         public readonly DataServiceQuery<Rodliste2015> Redlist2015;
 
         public readonly DataServiceQuery<Redlist2006Assessment> Redlist2006;
@@ -16,6 +18,7 @@ namespace Assessments.Frontend.Web.Infrastructure
         public AssessmentApiService(IOptions<ApplicationSettings> settings)
         {
             _settings = settings;
+            Redlist2021 = Assessments().Redlist2021;
             Redlist2015 = Assessments().Redlist2015;
             Redlist2006 = Assessments().Redlist2006;
         }

--- a/Assessments.Frontend.Web/Models/RL2021ViewModel.cs
+++ b/Assessments.Frontend.Web/Models/RL2021ViewModel.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Artsdatabanken;
+using Microsoft.AspNetCore.Mvc;
+using X.PagedList;
+
+namespace Assessments.Frontend.Web.Models
+{
+    public class RL2021ViewModel
+    {
+        public IPagedList<RL2021> Redlist2021Results { get; set; }
+
+        // Filter
+        [Display(Name = "Navn"), FromQuery]
+        public string Name { get; set; }
+
+    }
+
+}

--- a/Assessments.Frontend.Web/Views/Home/Index.cshtml
+++ b/Assessments.Frontend.Web/Views/Home/Index.cshtml
@@ -34,8 +34,10 @@
             <p>
 
                 <a href="/test/2006">2006</a>
-                <br/>
+                <br />
                 <a href="/test/2015">2015</a>
+                <br />
+                <a href="/test/2021">2021</a>
 
             </p>
         </div>

--- a/Assessments.Frontend.Web/Views/Test/Index.cshtml
+++ b/Assessments.Frontend.Web/Views/Test/Index.cshtml
@@ -29,6 +29,7 @@
         <p>
             <a href="/test/2006">2006</a>
             <a href="/test/2015">2015</a>
+            <a href="/test/2021">2021</a>
         </p>
 
     </div>

--- a/Assessments.Frontend.Web/Views/Test/List2021.cshtml
+++ b/Assessments.Frontend.Web/Views/Test/List2021.cshtml
@@ -66,7 +66,7 @@
             {
                 <tr>
                     <td>
-                        <a asp-action="Detail" asp-route-id="@item.LatinsknavnId" asp-route-vurderingscontext="@item.VurderingsContext" asp-route-year="2021">
+                        <a asp-action="Detail" asp-route-id="@item.Id" asp-route-year="2021">
                             @item.LatinsknavnId
                         </a>
                     </td>

--- a/Assessments.Frontend.Web/Views/Test/List2021.cshtml
+++ b/Assessments.Frontend.Web/Views/Test/List2021.cshtml
@@ -37,7 +37,7 @@
     <div class="mid">
         <div class="ingress">
             <p>
-                Norsk rødliste for arter 2021 er en oversikt over arter som har risiko for å dø ut fra Norge. 
+                Norsk rødliste for arter 2021 er en oversikt over arter som har risiko for å dø ut fra Norge.
                 Rødlista er utarbeidet av Artsdatabanken i samarbeid med fageksperter.
             </p>
         </div>
@@ -47,37 +47,59 @@
         </h3>
 
         <!-- FILTER FORM -->
-        <form asp-action="2021" method="get">
-            <label asp-for="Name"></label><input asp-for="Name" />
+        <form class="list-search" asp-action="2021" method="get">
+           <input asp-for="Name" placeholder="Søk i vitenskapelig navn"/>
+           <button class="btn" type="submit">
+               <span class="material-icons">
+                   search
+               </span>
+
+                Søk
+           </button>
         </form>
 
+       <!-- List controls -->
+        <div class="controls">
+            <button id="listview" class="material-icons" type="button">list</button>
+            <button id="gridview" class="material-icons" type="button">grid_on </button>
+        </div>
+
         <!-- Data from model -->
-        <table class="table table-striped table-hover">
 
-            <thead>
-                <tr>
-                    <td>LatinsknavnId</td>
-                    <td>VurdertVitenskapeligNavn</td>
-                    <td>Kategori</td>
-                </tr>
-            </thead>
 
-            @foreach (var item in Model.Redlist2021Results)
-            {
-                <tr>
-                    <td>
-                        <a asp-action="Detail" asp-route-id="@item.Id" asp-route-year="2021">
+        <div class="listwrapper">
+            <ul class="redlist" id="redlist">
+                <li class="listheader" id="listheader">
+                    <span>LatinsknavnId</span>
+                    <span>VurdertVitenskapeligNavn</span>
+                    <span>Kategori</span>
+                </li>
+
+
+                @foreach (var item in Model.Redlist2021Results)
+                {
+                    <li class="list">
+                        <span>
+                            <a asp-action="Detail" asp-route-id="@item.Id" asp-route-year="2021">
                             @item.LatinsknavnId
-                        </a>
-                    </td>
-                    <td>@item.VurdertVitenskapeligNavn</td>
-                    <td>@item.Kategori</td>
-                </tr>
-            }
+                            </a>
+                        </span>         
+                        <span>@item.VurdertVitenskapeligNavn</span>
+                        <span>@item.Kategori</span>
+                    </li>
+                }
 
-        </table>
 
-    </div>
+            </ul>
+        </div>
+
+
+
+
+
+
+
+
 
     <!-- Pageinator buttons -->
 

--- a/Assessments.Frontend.Web/Views/Test/List2021.cshtml
+++ b/Assessments.Frontend.Web/Views/Test/List2021.cshtml
@@ -1,0 +1,90 @@
+﻿@model Assessments.Frontend.Web.Models.RL2021ViewModel
+
+@using X.PagedList.Mvc.Core;
+@using X.PagedList.Web.Common
+@using Assessments.Frontend.Web.Infrastructure
+
+@{
+    ViewBag.Title = "2021";
+}
+<div class="breadcrumbs">
+    <ul>
+        <li class="lead in-breadcrumb">
+            <a href="/">
+                Rødlista
+            </a>
+        </li>
+        <span class="breadcrumbdivider">&gt; </span>
+        <li class="in-breadcrumb currentcrumb">
+            @ViewBag.Title
+        </li>
+    </ul>
+</div>
+
+<div class="sidebarmenu"></div>
+
+<div class="content-placer">
+    <div class="page-header">
+        <h1>
+            Norsk Rødliste for arter 2021
+        </h1>
+        <h2>@ViewBag.Title</h2>
+        <span class="byline">
+            Publisert .. ikke ennå
+        </span>
+    </div>
+
+    <div class="mid">
+        <div class="ingress">
+            <p>
+                Norsk rødliste for arter 2021 er en oversikt over arter som har risiko for å dø ut fra Norge. 
+                Rødlista er utarbeidet av Artsdatabanken i samarbeid med fageksperter.
+            </p>
+        </div>
+
+        <h3>
+            @Model.Redlist2021Results.Count redlist 2021 items
+        </h3>
+
+        <!-- FILTER FORM -->
+        <form asp-action="2021" method="get">
+            <label asp-for="Name"></label><input asp-for="Name" />
+        </form>
+
+        <!-- Data from model -->
+        <table class="table table-striped table-hover">
+
+            <thead>
+                <tr>
+                    <td>LatinsknavnId</td>
+                    <td>VurdertVitenskapeligNavn</td>
+                    <td>Kategori</td>
+                </tr>
+            </thead>
+
+            @foreach (var item in Model.Redlist2021Results)
+            {
+                <tr>
+                    <td>
+                        <a asp-action="Detail" asp-route-id="@item.LatinsknavnId" asp-route-vurderingscontext="@item.VurderingsContext" asp-route-year="2021">
+                            @item.LatinsknavnId
+                        </a>
+                    </td>
+                    <td>@item.VurdertVitenskapeligNavn</td>
+                    <td>@item.Kategori</td>
+                </tr>
+            }
+
+        </table>
+
+    </div>
+
+    <!-- Pageinator buttons -->
+
+    @Html.PagedListPager(Model.Redlist2021Results, page => Url.Action("2021", Context.GetQueryParameters(new Dictionary<string, string> { { "Page", page.ToString() } })), new PagedListRenderOptions
+        {
+            PageClasses = new[] { "page-link" },
+            UlElementClasses = new[] { "pagination" },
+            LiElementClasses = new[] { "page-item" }
+        })
+</div>

--- a/Assessments.Frontend.Web/Views/Test/SpeciesAssessment2021.cshtml
+++ b/Assessments.Frontend.Web/Views/Test/SpeciesAssessment2021.cshtml
@@ -1,6 +1,6 @@
 ﻿@model Artsdatabanken.RL2021
 @{
-    ViewBag.Title = "navn";
+    ViewBag.Title = @Model.VurdertVitenskapeligNavn;
 }
 
 <div class="breadcrumbs">
@@ -16,7 +16,7 @@
         </li>
         <span class="breadcrumbdivider">&gt; </span>
         <li class="in-breadcrumb currentcrumb">
-            crumbnavn
+            @Model.VurdertVitenskapeligNavn
         </li>
     </ul>
 </div>

--- a/Assessments.Frontend.Web/Views/Test/SpeciesAssessment2021.cshtml
+++ b/Assessments.Frontend.Web/Views/Test/SpeciesAssessment2021.cshtml
@@ -1,0 +1,48 @@
+﻿@model Artsdatabanken.Rodliste2015
+@{
+    ViewBag.Title = "navn";
+}
+
+<div class="breadcrumbs">
+    <ul>
+        <li class="lead in-breadcrumb">
+            <a href="/">
+                Rødlista
+            </a>
+        </li>
+        <span class="breadcrumbdivider">&gt; </span>
+        <li class="in-breadcrumb">
+            <a href="/test/2021">2021</a>
+        </li>
+        <span class="breadcrumbdivider">&gt; </span>
+        <li class="in-breadcrumb currentcrumb">
+            crumbnavn
+        </li>
+    </ul>
+</div>
+
+<div class="content-placer">
+    <div class="page-header">
+        <h1>
+            Norsk Rødliste for arter 2021
+        </h1>
+        <h2>@ViewBag.Title</h2>
+        <span class="byline">
+            Ikke publisert ennå
+        </span>
+    </div>
+
+    <div class="mid">
+        <div class="ingress">
+            <p>
+                Norsk rødliste for arter 2021 er en oversikt over arter som har risiko for å dø ut fra Norge. 
+                Rødlista er utarbeidet av Artsdatabanken i samarbeid med fageksperter.
+            </p>
+        </div>
+
+        <div class="section">
+            <h2>Vurderingsinnhold</h2>
+            <p>Kommer her</p>
+        </div>
+    </div>
+</div>

--- a/Assessments.Frontend.Web/Views/Test/SpeciesAssessment2021.cshtml
+++ b/Assessments.Frontend.Web/Views/Test/SpeciesAssessment2021.cshtml
@@ -1,4 +1,4 @@
-﻿@model Artsdatabanken.Rodliste2015
+﻿@model Artsdatabanken.RL2021
 @{
     ViewBag.Title = "navn";
 }

--- a/Assessments.Frontend.Web/wwwroot/css/site.css
+++ b/Assessments.Frontend.Web/wwwroot/css/site.css
@@ -53,3 +53,144 @@
 td{
     padding:10px;
 }
+
+/* REDLIST VIEW */
+
+.listwrapper {
+    min-height: 20px;
+    width: 100%;
+    max-width:100%;
+    font-size: 12pt;
+    padding-top:20px;
+    padding-bottom:20px;
+}
+
+
+/* LIST VIEW */
+
+.redlist li {
+    width: 100%;
+    line-height: 1;
+    display: block;
+    font-size: 12pt;
+}
+
+
+.redlist li {
+    display: flex;
+}
+
+.redlist li span {
+    padding: 10px;
+    width:33%;
+}
+
+.redlist li span:last-child {
+   text-align:right;
+}
+
+.redlist li:nth-child(even) {
+    background:  #fafafa;
+}
+
+.listheader {
+    font-size: 15px;
+    font-weight: bold;
+    background: none;
+}
+
+/* GRID VIEW */
+.redlist  .listheader.grid {
+    display: none;
+}
+
+.redlist.grid li:nth-child(even),
+.redlist.grid li {
+    display: inline-block;
+    width: 150px;
+    height: 150px;
+    background: #fbfbfb;
+    margin-bottom: 15px;
+    margin-left: 5px;
+    vertical-align: top;
+    border: 1px solid #d4d4d4;
+    text-align:center;
+}
+
+.redlist.grid li span {
+    width: 100%;
+    display: block;
+    height: 50%;
+    text-align: center;
+}
+
+.redlist.grid li span:first-child {
+    height: 20%;
+}
+
+.redlist.grid li span:last-child {
+    height: 35px;
+    background: #e0dddd;
+    border-radius: 50%;
+    width: 35px;
+    margin: auto;
+    padding: 5px;
+    padding-top: 5px;
+    text-align: center;
+    padding-top: 10px;
+}
+
+/* SEARCH FIELD REDLIST */
+
+.list-search {
+    background: #f5f5f5;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 20px;
+    margin-bottom: 10px;
+    text-align: center;
+}
+
+.list-search input {
+    display:inline-block;
+    border: 1px solid rgb(204, 204, 204);
+    border-radius:2px;
+    box-shadow: rgba(0, 0, 0, 0.075) 0px 1px 1px 0px inset;
+    box-sizing: border-box;
+    color: rgb(85, 85, 85);
+    font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;    
+    font-size: 15px;
+    font-weight: 400;
+    height: 45px;
+    line-height: 21.4333px;
+    margin-bottom: 0px;
+    width:385px;
+    max-width:100%;
+}
+
+.btn {
+    padding: 6px 12px;
+    font-size: 15px;
+    line-height: 1.42857143;
+    display: inline-block;
+    margin-bottom: 0;
+    font-weight: 400;
+    text-align: center;
+    vertical-align: middle;
+    touch-action: manipulation;
+    cursor: pointer;
+    background: #4c4a48;
+    color: #fff;
+    border: none;
+    display: inline-block;
+    margin-left: -1px;
+    border-radius: 2px;
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+    height:45px;
+}
+
+.btn .material-icons {
+    vertical-align: bottom;
+    font-size: 16pt;
+}

--- a/Assessments.Frontend.Web/wwwroot/js/site.js
+++ b/Assessments.Frontend.Web/wwwroot/js/site.js
@@ -2,3 +2,27 @@
 // for details on configuring this project to bundle and minify static web assets.
 
 console.log("site.js loaded");
+
+document.addEventListener('click', function (e) {
+
+    // Check if the item exists
+    if (document.getElementById('listview')) {
+        if (e.target.id == "listview") {
+            console.log("set list")
+            document.getElementById('listheader').classList.remove("grid");
+            document.getElementById('redlist').classList.remove("grid");
+           
+
+            
+        }
+    }
+
+    // Check if the item exists
+    if (document.getElementById('gridview')) {
+        if (e.target.id == "gridview") {
+            console.log("set grid")
+            document.getElementById('listheader').classList.add("grid");
+            document.getElementById('redlist').classList.add("grid");
+        }
+    }
+})


### PR DESCRIPTION
- Fisket litt på stilene til søkeformen slik at den ligner forsidesøket på adb forsiden. Når vi er fornøyd med den bør det flyttes over som element man kan dytte rett inn i prosjektet grafisk profil, og bare gjenbrukes her.
- La till 2021 listevisning
- La til 2021 detaljvisning (lite innhold ennå)
- Endret listevisning fra tabell til liste, slik at den lett kan endres til grid-visning
- La til en rask javascript-knapp for å endre mellom visningsmodus. Optimalt sett burde det kanskje vært lenker som legger på en url parameter, slik at man ikke "mister" visningstypen om man søker eller filtrerer? 

Ved å bytte ut tabell med liste på denne måten er det lettere å ha kontroll på forskjellige skjermstørrelser i tillegg til at det er lett å endre visningsmodus. Jeg tenker vi lager ferdig visningen på 2021 til noe vi er fornøyd med, før vi eventuelt gjør tilsvarende for tidligere år.

![bilde](https://user-images.githubusercontent.com/17450081/120629916-9aef1480-c466-11eb-97eb-6a10414ca3bf.png)
