### PR TITLE
Add species group and modify expertcommittee name (#90)

### DIFF
--- a/Assessments.Frontend.Web/Views/Redlist/Assessment/partials/_Fylkesforekomster.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Assessment/partials/_Fylkesforekomster.cshtml
@@ -12,7 +12,7 @@
     }
     else if(Model.AssessmentArea == "S")
     {
-        if (Model.ExpertCommittee == "Pattedyr (Svalbard)")
+        if (Model.SpeciesGroup == "Pattedyr") // TODO: Correct the availiable areas
         {
             distribution = ViewBag.glossary["vurdert_S_pattedyr"]["description"];
         }

--- a/Assessments.Frontend.Web/Views/Redlist/Assessment/partials/_Historikk.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Assessment/partials/_Historikk.cshtml
@@ -22,14 +22,14 @@
 <div class="page_section">
 
 
-        @if (Model.YearPreviousAssessment == 2021 || Model.YearPreviousAssessment == 0)
-        {
-            <h3>Tidligere vurderinger</h3>
-            <span>Arten er vurdert for første gang i 2021.</span>
-        }
-        else
-        {
-            @*
+    @if (Model.YearPreviousAssessment == 2021 || Model.YearPreviousAssessment == 0)
+    {
+        <h3>Tidligere vurderinger</h3>
+        <span>Arten er vurdert for første gang i 2021.</span>
+    }
+    else
+    {
+        @*
             @if (!string.IsNullOrWhiteSpace(Model.ImportInfo.Kategori2010) && !string.IsNullOrWhiteSpace(Model.ImportInfo.Kategori2015))
             {
 
@@ -101,14 +101,14 @@
                 </p>
             }
 
-            @if (Model.ExpertCommittee.ToLower() == "spretthaler" || Model.ExpertCommittee.ToLower() == "havedderkopper")
+            @if (Model.SpeciesGroup.ToLower() == "spretthaler" || Model.SpeciesGroup.ToLower() == "havedderkopper")
             {
                 <p>
                     Sist vurdert i: @Model.YearPreviousAssessment
                 </p>
             }
-            *@
-        }
+        *@
+    }
 
 
-    </div><!-- End section -->
+</div><!-- End section -->

--- a/Assessments.Frontend.Web/Views/Redlist/Assessment/partials/_SpeciesInfo.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Assessment/partials/_SpeciesInfo.cshtml
@@ -6,22 +6,16 @@
     // Expert committee field should always be present.
     // By the time we arrive here, the actual committe name has been split into correct species group,
     // and is thus now species group and not actually committtee group.
-    string ekspertgruppe = @Model.ExpertCommittee;
-
-    // As long as expert committees contain area, it needs to be stripped away to use the field.
-
-    ekspertgruppe = ekspertgruppe.Replace(" (Norge)", "");
-    ekspertgruppe = ekspertgruppe.Replace(" (Svalbard)", "");
 
 
 }
 
 <div class="sidebar_image_info">
-    <h2>@ekspertgruppe</h2>
+    <h2>@Model.SpeciesGroup</h2>
     @foreach (var key in speciesgroup.Keys)
     {
        
-        @if (key != null && (@ekspertgruppe == key || @ekspertgruppe.Contains(key)))
+        @if (key != null && (@Model.SpeciesGroup == key || @Model.SpeciesGroup.Contains(key)))
         {
             @if (speciesgroup[key]["tagline"] != null)
             {

--- a/Assessments.Frontend.Web/Views/Redlist/List/partials/_ListView.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/List/partials/_ListView.cshtml
@@ -32,7 +32,7 @@
                     <span class="element_category">
                         <span class="@item.Category category_tag">@item.Category</span>
                     </span>
-                    <span class="element_group">@item.ExpertCommittee</span>
+                    <span class="element_group">@item.SpeciesGroup</span>
                     <span class="element_area">
                         @item.AssessmentArea
                         @if (@item.AssessmentArea == "N")
@@ -47,9 +47,9 @@
                     </span>
 
                     <div class="element_icon">
-                        @if (speciesgroup[item.ExpertCommittee]["image"] != null)
+                        @if (speciesgroup[item.SpeciesGroup]["image"] != null)
                         {
-                            <img src="@speciesgroup[item.ExpertCommittee]["image"]" />
+                            <img src="@speciesgroup[item.SpeciesGroup]["image"]" />
                         }
                     </div>
 

--- a/Assessments.Frontend.Web/Views/Shared/_Byline.cshtml
+++ b/Assessments.Frontend.Web/Views/Shared/_Byline.cshtml
@@ -1,11 +1,11 @@
 ﻿@model SpeciesAssessment2021
 @{
-    string ekspertgruppe = char.ToLower(Model.ExpertCommittee[0]) + Model.ExpertCommittee.Substring(1);
+    string artsgruppe = char.ToLower(Model.SpeciesGroup[0]) + Model.SpeciesGroup.Substring(1);
 
     // TODO: ADD THE LINK TO EXPERT COMMITTEE (Not in existence yet)
 }
 
 <span class="byline">
-    Publisert: @(ekspertgruppe == "spretthaler" || ekspertgruppe == "spretthaler (Svalbard)" ? @Model.YearPreviousAssessment : "24.November 2021").
-    Vurdert av <a href=""> Ekspertkomité for @ekspertgruppe </a> for Artsdatabanken
+    Publisert: @(artsgruppe == "spretthaler"  ? @Model.YearPreviousAssessment : "24.November 2021").
+    Vurdert av <a href=""> Ekspertkomité for @artsgruppe </a> for Artsdatabanken
 </span>

--- a/Assessments.Mapping/Helpers/SpeciesAssessment2021ProfileHelper.cs
+++ b/Assessments.Mapping/Helpers/SpeciesAssessment2021ProfileHelper.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using Assessments.Mapping.Models.Source.Species;
+
+namespace Assessments.Mapping.Helpers
+{
+    internal static class SpeciesAssessment2021ProfileHelper
+    {
+        internal static string ResolveRegion(string fylke)
+        {
+            return fylke.ToLowerInvariant() switch
+            {
+                "aa" => "Aust-Agder",
+                "bn" => "Polhavet",
+                "bs" => "Barentshavet",
+                "bu" => "Buskerud",
+                "fi" => "Finnmark",
+                "gh" => "Grønlandshavet",
+                "he" => "Hedmark",
+                "ho" => "Hordaland",
+                "jm" => "Jan Mayen",
+                "mr" => "Møre og Romsdal",
+                "nh" => "Norskehavet",
+                "no" => "Nordland",
+                "ns" => "Nordsjøen",
+                "op" => "Oppland",
+                "osa" => "Oslo og Akershus",
+                "ro" => "Rogaland",
+                "sf" => "Sogn og Fjordane",
+                "te" => "Telemark",
+                "tr" => "Troms",
+                "tø" => "Trøndelag",
+                "va" => "Vest-Agder",
+                "ve" => "Vestfold",
+                "øs" => "Østfold",
+                _ => string.Empty
+            };
+        }
+
+        internal static string ResolveSpeciesGroupName(Rodliste2019 rl2021)
+        {
+            // https://github.com/Artsdatabanken/Rodliste2019/blob/4918668043d7d5b2e5978e29e5028bc68fd1a643/Prod.LoadingCSharp/TransformRodliste2019toDatabankRL2021.cs#L510
+
+            if (rl2021.Ekspertgruppe == "Nebbfluer, kamelhalsfluer, mudderfluer, nettvinger")
+            {
+                if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Mecoptera"))
+                    rl2021.Ekspertgruppe = "Nebbfluer";
+                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Raphidioptera"))
+                    rl2021.Ekspertgruppe = "Kamelhalsfluer";
+                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Megaloptera"))
+                    rl2021.Ekspertgruppe = "Mudderfluer";
+                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Neuroptera"))
+                    rl2021.Ekspertgruppe = "Nettvinger";
+            }
+
+            if (rl2021.Ekspertgruppe == "Døgnfluer, øyenstikkere, steinfluer, vårfluer")
+            {
+                if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Ephemeroptera"))
+                    rl2021.Ekspertgruppe = "Døgnfluer";
+                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Odonata"))
+                    rl2021.Ekspertgruppe = "Øyenstikkere";
+                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Plecoptera"))
+                    rl2021.Ekspertgruppe = "Steinfluer";
+                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Trichoptera"))
+                    rl2021.Ekspertgruppe = "Vårfluer";
+            }
+
+            if (rl2021.Ekspertgruppe == "Rettvinger, kakerlakker, saksedyr")
+            {
+                if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Orthoptera"))
+                    rl2021.Ekspertgruppe = "Rettvinger";
+                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Blattodea"))
+                    rl2021.Ekspertgruppe = "Kakerlakker";
+                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Dermaptera"))
+                    rl2021.Ekspertgruppe = "Saksedyr";
+            }
+
+            var speciesGroupName = RemoveAssessmentArea(rl2021.Ekspertgruppe).Trim();
+
+            return speciesGroupName;
+        }
+
+        internal static string RemoveAssessmentArea(string src)
+        {
+            return src
+                .Replace("(Svalbard)", string.Empty, StringComparison.InvariantCultureIgnoreCase)
+                .Replace("(Norge)", string.Empty, StringComparison.InvariantCultureIgnoreCase).Trim();
+        }
+    }
+}

--- a/Assessments.Mapping/Models/Species/SpeciesAssessment2021.cs
+++ b/Assessments.Mapping/Models/Species/SpeciesAssessment2021.cs
@@ -248,6 +248,9 @@ namespace Assessments.Mapping.Models.Species
         /// </summary>
         public string ÅrsakTilNedgraderingAvKategori { get; set; } // ÅrsakTilNedgraderingAvKategori
 
+        /// <summary>
+        /// Group the species belongs to, in most cases a taxonomic group
+        /// </summary>
         public string SpeciesGroup { get; set; }
     }
 }

--- a/Assessments.Mapping/Models/Species/SpeciesAssessment2021.cs
+++ b/Assessments.Mapping/Models/Species/SpeciesAssessment2021.cs
@@ -247,5 +247,7 @@ namespace Assessments.Mapping.Models.Species
         /// Rationale for adjusting the category based on significant effect from populations outside the region.
         /// </summary>
         public string ÅrsakTilNedgraderingAvKategori { get; set; } // ÅrsakTilNedgraderingAvKategori
+
+        public string SpeciesGroup { get; set; }
     }
 }

--- a/Assessments.Mapping/SpeciesAssessment2021Profile.cs
+++ b/Assessments.Mapping/SpeciesAssessment2021Profile.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using Assessments.Mapping.Helpers;
 using Assessments.Mapping.Models.Source.Species;
 using Assessments.Mapping.Models.Species;
 using AutoMapper;
@@ -19,7 +19,8 @@ namespace Assessments.Mapping
             CreateMap<Rodliste2019.MinMaxProbableIntervall, SpeciesAssessment2021MinMaxProbableIntervall>();
             CreateMap<Rodliste2019.Reference, SpeciesAssessment2021Reference>();
 
-            CreateMap<Rodliste2019.Fylkesforekomst, SpeciesAssessment2021RegionOccurrence>().ForMember(dest => dest.Fylke, opt => opt.MapFrom(src => ResolveRegion(src.Fylke)));
+            CreateMap<Rodliste2019.Fylkesforekomst, SpeciesAssessment2021RegionOccurrence>()
+                .ForMember(dest => dest.Fylke, opt => opt.MapFrom(src => SpeciesAssessment2021ProfileHelper.ResolveRegion(src.Fylke)));
 
             CreateMap<Rodliste2019.TaxonHistory, SpeciesAssessment2021TaxonHistory>()
                 .ForMember(dest => dest.ExpertCommittee, opt => opt.MapFrom(src => src.Ekspertgruppe))
@@ -95,7 +96,8 @@ namespace Assessments.Mapping
                 .ForMember(dest => dest.D1PreliminaryCategory, opt => opt.MapFrom(src => src.D1FåReproduserendeIndividKode))
                 .ForMember(dest => dest.D2PreliminaryCategory, opt => opt.MapFrom(src => src.D2MegetBegrensetForekomstarealKode))
                 
-                .ForMember(dest => dest.ExpertCommittee, opt => opt.MapFrom(src => ResolveExpertCommitteeName(src)))
+                .ForMember(dest => dest.ExpertCommittee, opt => opt.MapFrom(src => SpeciesAssessment2021ProfileHelper.RemoveAssessmentArea(src.Ekspertgruppe)))
+                .ForMember(dest => dest.SpeciesGroup, opt => opt.MapFrom(src => SpeciesAssessment2021ProfileHelper.ResolveSpeciesGroupName(src)))
                 
                 .ForMember(dest => dest.EPreliminaryCategory, opt => opt.MapFrom(src => src.EKvantitativUtryddingsmodellKode))
                 
@@ -149,82 +151,6 @@ namespace Assessments.Mapping
 
                 .ForMember(dest => dest.ReasonCategoryChange, opt => opt.MapFrom(src => src.ÅrsakTilEndringAvKategori))
                 .ForMember(dest => dest.ÅrsakTilNedgraderingAvKategori, opt => opt.MapFrom(src => src.ÅrsakTilNedgraderingAvKategori));
-        }
-
-        private static string ResolveRegion(string fylke)
-        {
-            return fylke.ToLowerInvariant() switch
-            {
-                "aa" => "Aust-Agder",
-                "bn" => "Polhavet",
-                "bs" => "Barentshavet",
-                "bu" => "Buskerud",
-                "fi" => "Finnmark",
-                "gh" => "Grønlandshavet",
-                "he" => "Hedmark",
-                "ho" => "Hordaland",
-                "jm" => "Jan Mayen",
-                "mr" => "Møre og Romsdal",
-                "nh" => "Norskehavet",
-                "no" => "Nordland",
-                "ns" => "Nordsjøen",
-                "op" => "Oppland",
-                "osa" => "Oslo og Akershus",
-                "ro" => "Rogaland",
-                "sf" => "Sogn og Fjordane",
-                "te" => "Telemark",
-                "tr" => "Troms",
-                "tø" => "Trøndelag",
-                "va" => "Vest-Agder",
-                "ve" => "Vestfold",
-                "øs" => "Østfold",
-                _ => string.Empty
-            };
-        }
-
-        private static string ResolveExpertCommitteeName(Rodliste2019 rl2021)
-        {
-            // basert på https://github.com/Artsdatabanken/Rodliste2019/blob/4918668043d7d5b2e5978e29e5028bc68fd1a643/Prod.LoadingCSharp/TransformRodliste2019toDatabankRL2021.cs#L510
-            
-            if (rl2021.Ekspertgruppe == "Nebbfluer, kamelhalsfluer, mudderfluer, nettvinger")
-            {
-                if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Mecoptera"))
-                    rl2021.Ekspertgruppe = "Nebbfluer";
-                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Raphidioptera"))
-                    rl2021.Ekspertgruppe = "Kamelhalsfluer";
-                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Megaloptera"))
-                    rl2021.Ekspertgruppe = "Mudderfluer";
-                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Neuroptera"))
-                    rl2021.Ekspertgruppe = "Nettvinger";
-            }
-
-            if (rl2021.Ekspertgruppe == "Døgnfluer, øyenstikkere, steinfluer, vårfluer")
-            {
-                if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Ephemeroptera"))
-                    rl2021.Ekspertgruppe = "Døgnfluer";
-                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Odonata"))
-                    rl2021.Ekspertgruppe = "Øyenstikkere";
-                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Plecoptera"))
-                    rl2021.Ekspertgruppe = "Steinfluer";
-                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Trichoptera"))
-                    rl2021.Ekspertgruppe = "Vårfluer";
-            }
-
-            if (rl2021.Ekspertgruppe == "Rettvinger, kakerlakker, saksedyr")
-            {
-                if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Orthoptera"))
-                    rl2021.Ekspertgruppe = "Rettvinger";
-                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Blattodea"))
-                    rl2021.Ekspertgruppe = "Kakerlakker";
-                else if (rl2021.VurdertVitenskapeligNavnHierarki.Contains("/Dermaptera"))
-                    rl2021.Ekspertgruppe = "Saksedyr";
-            }
-
-            return rl2021.Ekspertgruppe
-
-                // ta bort vurderingsområde fra navn
-                .Replace("(Svalbard)", string.Empty, StringComparison.InvariantCultureIgnoreCase)
-                .Replace("(Norge)", string.Empty, StringComparison.InvariantCultureIgnoreCase).Trim();
         }
     }
 


### PR DESCRIPTION
har endret logikk for "ExpertCommittee" - det er nå det samme originale navnet som er lagret i databasen for rødlista, men uten vurderingsområde (norge/svalbard)

la til "SpeciesGroup" - som heller ikke har vurderingsområde, men har logikk for splitting av navn (hentet fra rødlisteprosjektet og som tidligere ble brukt på "ExpertCommittee" feltet)


oppgaven ble beskrevet og diskutert i to ulike issues, beholder og holder tråden i denne https://github.com/Artsdatabanken/assessments-frontend/issues/90