### PR TITLE
Add Region Graph & Stats. Fix Criteria. Fix crash due to counting nonexisting items on narrow searches.

### DIFF
--- a/Assessments.Frontend.Web/Controllers/RedlistController.cs
+++ b/Assessments.Frontend.Web/Controllers/RedlistController.cs
@@ -202,13 +202,20 @@ namespace Assessments.Frontend.Web.Controllers
                 Console.WriteLine(habitatNames[i] + ": " + habitatStats[habitatNames[i]].ToString());
             }*/
 
+            // REGION
+            var regionNames = data.Select(x => x.RegionOccurrences.Select(x => x.Fylke)).SelectMany(x => x).Distinct().ToList();
+            var regionStats = regionNames.Select(name => new KeyValuePair<string, int>(name, data.Select(x => x.RegionOccurrences).SelectMany(x => x).Where(x => x.Fylke == name && (x.State ==0 || x.State==1)).Count()))
+                .ToDictionary(x => x.Key, x => x.Value);
+            viewModel.Statistics.Region = regionStats;
+
+            viewModel.Statistics.RegionNames = regionNames;
+
+
 
 
             // CRITERIA
-            var criteriaCategories = new List<string> { "CR", "EN", "VU", "NT " }; // trua og nær trua 
 
-            var criteriaStrings = data.Where(x => x.Category.Length >= 2 && criteriaCategories.Contains(x.Category[..2]))
-                .Select(x => x.CriteriaSummarized);
+            var criteriaStrings = data.Where(x => !string.IsNullOrEmpty(x.CriteriaSummarized)).Select(x => x.CriteriaSummarized);
 
             var criteria = new List<string> { "A", "B", "C", "D" }.Select(item => new KeyValuePair<string, int>(item, criteriaStrings.Count(x => x.Contains(item))));
 

--- a/Assessments.Frontend.Web/Models/RL2021ViewModel.cs
+++ b/Assessments.Frontend.Web/Models/RL2021ViewModel.cs
@@ -41,5 +41,9 @@ namespace Assessments.Frontend.Web.Models
         public Dictionary<string, int> Criteria { get; set; }
 
         public Dictionary<string, int> Habitat { get; set; }
+
+        public Dictionary<string, int> Region { get; set; }
+
+        public List<string> RegionNames { get; set; }
     }
 }

--- a/Assessments.Frontend.Web/Views/Redlist/List/partials/_Graphs.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/List/partials/_Graphs.cshtml
@@ -3,13 +3,16 @@
 
 @{
 
-     // Calculating max and total values for use in graph drawing
+    // Calculating max and total values for use in graph drawing
     int category_total = Model.Statistics.Categories.Sum(x => x.Value); // #of assesments with a category
-    int category_max = Model.Statistics.Categories.Values.Max();
+    int category_max = Model.Statistics.Categories.Values.DefaultIfEmpty(0).Max();
     int criteria_total = Model.Statistics.Criteria.Sum(x => x.Value); // #of assesments with a criteria
-    int criteria_max = Model.Statistics.Criteria.Values.Max();
+    int criteria_max = Model.Statistics.Criteria.Values.DefaultIfEmpty(0).Max();
     int habitat_total = Model.Statistics.Habitat.Sum(x => x.Value); // #of assesments with a criteria
-    int habitat_max = Model.Statistics.Habitat.Values.Max();
+    int habitat_max = Model.Statistics.Habitat.Values.DefaultIfEmpty(0).Max();
+
+    int region_total = Model.Statistics.Region.Sum(x => x.Value); // #of assesments with a criteria
+    int region_max = Model.Statistics.Region.Values.DefaultIfEmpty(0).Max();
 
     // OVERALL STATS - TODO. WHile waiting - use category, as it should be consistent with nr of assesments
     int total = category_total;
@@ -21,6 +24,8 @@
     Dictionary<string, object> criteria = ViewBag.kriterier.ToObject<Dictionary<string, object>>();
 
     Dictionary<string, Dictionary<string, object>> habitat = ViewBag.habitat.ToObject<Dictionary<string, Dictionary<string, object>>>();
+
+    
 
 
 
@@ -69,7 +74,7 @@
 }
 
 <div class="page_section graphs">
-    <h2>Statistikk </h2>
+    <h2>Statistikk - </h2>
 
     Totalt antall vurderinger i utvalget - dette er data vi mangler ennå.
 
@@ -144,6 +149,41 @@
 
                 <span class="downboxcontainer statbox @key">
                     <span class="downtext">@habitat[@key]["name"]</span>
+                </span>
+            </div>
+        }
+    </div>
+
+    <p><br /></p><p><br /></p><p><br /></p><p><br /></p><p><br /></p>
+
+    <h3>Antall vurderinger per Region</h3>
+
+    <p>
+        Denne grafen viser der verderingenes art forekommer eller er antatt å forekomme. De kan forekomme i mer enn en region om gangen, men informasjonen er bare 
+        registrert for arter som er rødlistet, det vil si ikke har kategoriene LC, NA eller NE. Arter som er regionalt utdødd skal heller ikke forekomme. 
+        <br /><b>
+    TODO: Filteret BURDE fjerne disse artsgruppene, ettersom det KAN ligge inne data der likevel. Men egentlig burde det vært skrelt vekk før vi kommer hit.
+    <br />
+</b>
+        Den totale artsmengden er @region_total, som i og for seg ikke er et informativt tall i seg selv.
+        For nåværende utvalg betyr det at vurderingene forekommer i @average(@total, @region_total) regioner per art.
+
+    </p>
+
+
+    <div class="graph">
+        @foreach (string key in Model.Statistics.Region.Keys)
+        {
+            <div class="statelement" style="max-width:60px;">
+                <div class="heightbar_blank">
+                    <div class="heightbar_indicator @key" style="height:@percentage(@region_max, @getNumber(@key,@Model.Statistics.Region))">
+                        <span class="percent">@getNumber(@key, @Model.Statistics.Region)</span>
+                    </div>
+                </div>
+
+
+                <span class="downboxcontainer statbox @key">
+                    <span class="downtext">@key</span>
                 </span>
             </div>
         }

--- a/Assessments.Frontend.Web/Views/Redlist/List/partials/_Graphs.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/List/partials/_Graphs.cshtml
@@ -1,10 +1,9 @@
 @model RL2021ViewModel
 
+
 @{
 
-
-
-    // Calculating max and total values for use in graph drawing
+     // Calculating max and total values for use in graph drawing
     int category_total = Model.Statistics.Categories.Sum(x => x.Value); // #of assesments with a category
     int category_max = Model.Statistics.Categories.Values.Max();
     int criteria_total = Model.Statistics.Criteria.Sum(x => x.Value); // #of assesments with a criteria
@@ -51,7 +50,7 @@
         string calculated = (verdi / utvalg).ToString("0.00");
 
         calculated = calculated.Replace(",", ".");
-        return calculated ;
+        return calculated;
     }
 }
 
@@ -70,7 +69,7 @@
 }
 
 <div class="page_section graphs">
-    <h2>Statistikk</h2>
+    <h2>Statistikk </h2>
 
     Totalt antall vurderinger i utvalget - dette er data vi mangler ennå.
 

--- a/Assessments.Frontend.Web/Views/Shared/_Category.cshtml
+++ b/Assessments.Frontend.Web/Views/Shared/_Category.cshtml
@@ -10,8 +10,11 @@
     {
         // Takes in category as presented in the model
         // Returns name of category (whyever for?)
-        return category.Substring(0,2);
-
+        if (category.Length > 0)
+        {
+            return category.Substring(0, 2);
+        }
+        return "";
     }
 }
 
@@ -21,14 +24,16 @@
         // Takes in category as presented in the model
         // uses categoryMatcher to remove degrees etc.
         // Returns name of category (whatever for?)
-        if(category != "" && category != null)
+
+        if(category != "" || category != null)
+        {
+            return "manglende vurdering ";
+        }else
         {
             var actual_category = @categoryMatcher(category);
             var final_string = @ViewBag.categories[actual_category]["presentationstring"];
             return final_string;
         }
-        return category+ "mangler";
-
     }
 }
 

--- a/Assessments.Frontend.Web/wwwroot/json/categories.json
+++ b/Assessments.Frontend.Web/wwwroot/json/categories.json
@@ -46,5 +46,4 @@
     "presentationstring": "ikke vurdert "
   }
 
-
 }


### PR DESCRIPTION
Add Region Graph & Stats.  
-> added inline text about the graph, as we want better filtering first.

Fixed Criteria. 
-> Bug was the filter. The filter removed more than 1000 relevant matches. 

Fixed crash due to counting nonexisting items on narrow searches.
-> when the dictionary is empty it did not count to zero, but instead set null for max comparisons. Now it does.

Fixed crash for elements without category
-> category matcher now supports null and empty string