### PR TITLE
menu is now availiable on smaller sizes, although not optimal

### DIFF
--- a/Assessments.Frontend.Web/wwwroot/css/site.css
+++ b/Assessments.Frontend.Web/wwwroot/css/site.css
@@ -149,7 +149,6 @@ h1{
         color:black;
     }
 
-
     .sidebarmenu li a{
         color: black;
     }
@@ -180,15 +179,23 @@ h1{
     .history {
         display: none;
     }
+
+    .sidebarmenu {
+        margin-left: -15px;
+    }
 }
 
 
 /* MOBILE SIZE: 650px  */
 @media only screen and (max-width: 650px) {
+
 }
 
 /* Tiny mobile : 550px */
-@media only screen and (max-width: 550px) {
+@media only screen and (max-width: 527px) {
+        .sidebarmenu {
+        margin-left: -5px;
+    }
 }
 
 /* SUPER-tiny: 300px*/

--- a/Assessments.Frontend.Web/wwwroot/css/site.css
+++ b/Assessments.Frontend.Web/wwwroot/css/site.css
@@ -103,7 +103,7 @@ h1{
 
     .side {
         padding: 30px;
-        margin-top:50px;
+        margin-top: 50px;
         background: #f2f1f1;
         width: 100vw;
         margin-bottom: -14px;
@@ -115,7 +115,58 @@ h1{
         flex-direction: column-reverse;
         padding-top: 20px;
     }
+
+    .sidebarmenu {
+        display: block;
+        max-width: 100vw;
+        margin: 0;
+        margin-left: 0px;
+        padding: 0;
+        border: 0;
+        width: 100vw;
+        margin-left: -17px;
+        background: #f0f0f0;
+        padding: 10px;
+        margin-bottom: 20px;
+    }
+
+    .sidebarmenu ul {
+        display: block;
+        width: 100%;
+        max-width: 100%;
+        margin: 0;
+        padding: 0;
+        border: 0;
+    }
+
+    .sidebarmenu li {
+        display: inline-block;
+        width: auto;
+        border: 1px solid lightgrey;
+        margin: 2px;
+        padding: 5px;
+        background: whitesmoke;
+        color:black;
+    }
+
+
+    .sidebarmenu li a{
+        color: black;
+    }
+
+    .main-content, .main {
+        padding-top: 0;
+    }
+
+    .breadcrumbs {
+        max-width: 100%;
+        position: absolute;
+        top: 107px;
+        display:none;
+    }
 }
+
+
 
 /* BIG MOBILE SIZE: 766px  */
 @media only screen and (max-width: 766px) {


### PR DESCRIPTION
Previously it was just hidden on smaller sizes.
Now it is availiable on top, but not in an optimal way.
Breadcrumbs hidden on the same size due to overlapping content.