### PR TITLE
Add expert committee members (#72)

### DIFF
--- a/Assessments.Frontend.Web/Infrastructure/Extensions.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Extensions.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Assessments.Frontend.Web.Infrastructure
+{
+    public static class Extensions
+    {
+        public static string JoinAnd<T>(this IEnumerable<T> values, string separator, string lastSeparator = null)
+        {
+            if (values == null)
+                throw new ArgumentNullException(nameof(values));
+            
+            if (separator == null)
+                throw new ArgumentNullException(nameof(separator));
+
+            var sb = new StringBuilder();
+
+            using var enumerator = values.GetEnumerator();
+            if (enumerator.MoveNext())
+                sb.Append(enumerator.Current);
+
+            var objectIsSet = false;
+            object obj = null;
+
+            if (enumerator.MoveNext())
+            {
+                obj = enumerator.Current;
+                objectIsSet = true;
+            }
+
+            while (enumerator.MoveNext())
+            {
+                sb.Append(separator);
+                sb.Append(obj);
+                obj = enumerator.Current;
+                objectIsSet = true;
+            }
+
+            if (!objectIsSet) 
+                return sb.ToString();
+            
+            sb.Append(lastSeparator ?? separator);
+            sb.Append(obj);
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Assessments.Frontend.Web/Infrastructure/Helpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Helpers.cs
@@ -331,6 +331,8 @@ namespace Assessments.Frontend.Web.Infrastructure
             public const string Species2015 = "species-2015.json";
 
             public const string Species2006 = "species-2006.json";
+
+            public const string SpeciesExpertCommitteeMembers = "species-experts.csv";
         }
 
         public class SpeciesCategories

--- a/Assessments.Frontend.Web/Infrastructure/Services/ExpertCommitteeMemberService.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Services/ExpertCommitteeMemberService.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using CsvHelper.Configuration.Attributes;
+
+namespace Assessments.Frontend.Web.Infrastructure.Services
+{
+    public class ExpertCommitteeMemberService
+    {
+        private readonly DataRepository _dataRepository;
+
+        public ExpertCommitteeMemberService(DataRepository dataRepository)
+        {
+            _dataRepository = dataRepository;
+        }
+
+        public async Task<List<ExpertCommitteeMember>> GetExpertCommitteeMembers(string expertCommitteeName, int year)
+        {
+            var data = await _dataRepository.GetData<ExpertCommitteeMember>(Constants.Filename.SpeciesExpertCommitteeMembers);
+            
+            var expertCommitteeMembers = data.Where(x => x.ExpertCommittee == expertCommitteeName && x.Year == year).ToList();
+
+            var results = expertCommitteeMembers.Select(x =>
+            {
+                x.ExpertCommittee = x.ExpertCommittee // remove assessmentarea from names in order to match mapped model
+                    .Replace("(Svalbard)", string.Empty, StringComparison.InvariantCultureIgnoreCase)
+                    .Replace("(Norge)", string.Empty, StringComparison.InvariantCultureIgnoreCase).Trim(); 
+                return x;
+            }).ToList();
+
+            return results;
+        }
+    }
+
+    public class ExpertCommitteeMember
+    {
+        [Name("RodlisteAr")]
+        public int Year { get; set; }
+
+        public string ExpertCommittee { get; set; }
+
+        public string SpeciesGroup { get; set; }
+
+        [Name("EkspertgruppeRolle")]
+        public string Role { get; set; }
+
+        [Name("FulltNavn")]
+        public string Name { get; set; }
+
+        [Name("Etternavn")]
+        public string LastName { get; set; }
+
+        [Name("FornavnInit")]
+        public string FirstNameInitals { get; set; }
+
+        [Name("Institusjon")]
+        public string Institution { get; set; }	
+    }
+}

--- a/Assessments.Frontend.Web/Startup.cs
+++ b/Assessments.Frontend.Web/Startup.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.IO;
 using System.Reflection;
 using Assessments.Frontend.Web.Infrastructure;
+using Assessments.Frontend.Web.Infrastructure.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.OData;
@@ -41,6 +42,8 @@ namespace Assessments.Frontend.Web
             services.AddLazyCache();
             
             services.AddSingleton<DataRepository>();
+
+            services.AddTransient<ExpertCommitteeMemberService>();
 
             services.AddAutoMapper(cfg => cfg.AddMaps(Constants.AssessmentsMappingAssembly));
         }

--- a/Assessments.Frontend.Web/Views/Redlist/Assessment/SpeciesAssessment2021.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Assessment/SpeciesAssessment2021.cshtml
@@ -40,6 +40,7 @@
         <partial name="/Views/Redlist/Assessment/partials/_ImpactFactors.cshtml" />
         <partial name="/Views/Redlist/Assessment/partials/_Criteria.cshtml" />
         <partial name="/Views/Redlist/Assessment/partials/_Reference.cshtml" />
+        <partial name="/Views/Redlist/Assessment/partials/_ExpertCommitteeMembers.cshtml" model="Model" />
     </div>
 
 

--- a/Assessments.Frontend.Web/Views/Redlist/Assessment/partials/_ExpertCommitteeMembers.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Assessment/partials/_ExpertCommitteeMembers.cshtml
@@ -1,0 +1,17 @@
+﻿@using Microsoft.AspNetCore.Http.Extensions
+@using Assessments.Frontend.Web.Infrastructure.Services
+
+@model SpeciesAssessment2021
+
+@inject ExpertCommitteeMemberService _expertCommitteeMemberService
+
+@{
+    var expertCommitteeMembers = await _expertCommitteeMemberService.GetExpertCommitteeMembers(Model.ExpertCommittee, Model.AssessmentYear);
+}
+
+@if (expertCommitteeMembers.Any())
+{
+    <p>
+        Siden siteres som: @expertCommitteeMembers.Select(x => $"{x.LastName} {x.FirstNameInitals}").Distinct().ToList().JoinAnd(", ", " og "). @Model.SpeciesGroup: Vurdering av @Model.PopularName @Model.ScientificName for @(Model.AssessmentArea == "N" ? "Norge" : "Svalbard"). Norsk rødliste for arter 2021. Artsdatabanken. @Context.Request.GetEncodedUrl()
+    </p>
+}

--- a/Assessments.Frontend.Web/Views/Redlist/Assessment/partials/_ExpertCommitteeMembers.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Assessment/partials/_ExpertCommitteeMembers.cshtml
@@ -11,7 +11,10 @@
 
 @if (expertCommitteeMembers.Any())
 {
+    <h2>Sitering</h2>
     <p>
-        Siden siteres som: @expertCommitteeMembers.Select(x => $"{x.LastName} {x.FirstNameInitals}").Distinct().ToList().JoinAnd(", ", " og "). @Model.SpeciesGroup: Vurdering av @Model.PopularName @Model.ScientificName for @(Model.AssessmentArea == "N" ? "Norge" : "Svalbard"). Norsk rødliste for arter 2021. Artsdatabanken. @Context.Request.GetEncodedUrl()
+        @expertCommitteeMembers.Select(x => $"{x.LastName} {x.FirstNameInitals}").Distinct().ToList().JoinAnd(", ", " og "). 
+        @Model.SpeciesGroup: Vurdering av @Model.PopularName @Model.ScientificName for @(Model.AssessmentArea == "N" ? "Norge" : "Svalbard"). 
+        Norsk rødliste for arter 2021. Artsdatabanken. @Context.Request.GetEncodedUrl()
     </p>
 }


### PR DESCRIPTION
tjeneste som kobler ekspertgruppemedlemmer (i en csv fil - konvertert fra excel) med en vurdering

brukes til "Siden siteres som" - midlertidig lagt til nederst på vurderingssiden (uten styling):

https://github.com/Artsdatabanken/assessments-frontend/blob/89e0b6ce89141e5a86d3550400fe6e41d00f9903/Assessments.Frontend.Web/Views/Redlist/Assessment/SpeciesAssessment2021.cshtml#L43

html/styling endres i filen:
https://github.com/Artsdatabanken/assessments-frontend/blob/89e0b6ce89141e5a86d3550400fe6e41d00f9903/Assessments.Frontend.Web/Views/Redlist/Assessment/partials/_ExpertCommitteeMembers.cshtml