### PR TITLE
Keep querystrings when paging

### DIFF
--- a/Assessments.Frontend.Web/Infrastructure/Helpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Helpers.cs
@@ -1,37 +1,9 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
-using Microsoft.AspNetCore.Http;
 
 namespace Assessments.Frontend.Web.Infrastructure
 {
     public static class Helpers
     {
-        public static QueryParameters GetQueryParameters(this HttpContext context, Dictionary<string, string> parameters)
-        {
-            var dictionary = context.Request.Query.ToDictionary(d => d.Key, d => d.Value.ToString());
-
-            foreach (var (key, value) in parameters)
-            {
-                if (dictionary.ContainsKey(key))
-                    dictionary.Remove(key);
-
-                dictionary.Add(key, value);
-            }
-
-            return new QueryParameters(dictionary);
-        }
-
-        public class QueryParameters : Dictionary<string, string>
-        {
-            public QueryParameters(IDictionary<string, string> dictionary) : base(dictionary) { }
-
-            public QueryParameters WithRoute(string routeParam, string routeValue)
-            {
-                this[routeParam] = routeValue;
-
-                return this;
-            }
-        }
         public static string[] findSelectedCategories( bool redlisted, bool endangered,
             string[] categoriesSelected) 
         {

--- a/Assessments.Frontend.Web/Views/Redlist/List/List2021.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/List/List2021.cshtml
@@ -24,12 +24,23 @@
             </div>
         </div>
 
-        <!-- Pageinator buttons -->
-        @Html.PagedListPager(Model.Redlist2021Results, page => Url.Action("Index2021", Context.GetQueryParameters(new Dictionary<string, string> { { "Page", page.ToString() } })), new PagedListRenderOptions
-        {
-            PageClasses = new[] { "page-link" },
-            UlElementClasses = new[] { "pagination" },
-            LiElementClasses = new[] { "page-item" }
-        })
+        <!-- Paginator buttons -->
+        @Html.PagedListPager(Model.Redlist2021Results, page => Url.Action("Index2021", new
+       {
+           Page = page,
+           Area = Context.Request.Query["CateAreagory"],
+           Category = Context.Request.Query["Category"],
+           Criterias = Context.Request.Query["Criterias"],
+           EuroPop = Context.Request.Query["EuroPop"],
+           Regions = Context.Request.Query["Regions"],
+           Habitats = Context.Request.Query["Habitats"],
+           SpeciesGroups = Context.Request.Query["SpeciesGroups"],
+           PresumedExtinct = Context.Request.Query["PresumedExtinct"]
+       }), new PagedListRenderOptions
+       {
+           PageClasses = new[] { "page-link" },
+           UlElementClasses = new[] { "pagination" },
+           LiElementClasses = new[] { "page-item" }
+       })
     </div>
 </div>


### PR DESCRIPTION
beholder parametre på riktig måte når man går mellom sidene i listen (paginering)
nye filter/parametre må legges til manuelt nå (hadde kode som gjorde det automatisk, men ikke fungerte optimalt tidligere)