### PR TITLE
Habitat -> Downgraph. Supertiny graphs are table form.

### DIFF
--- a/Assessments.Frontend.Web/Views/Redlist/List/partials/_Graphs.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/List/partials/_Graphs.cshtml
@@ -82,7 +82,7 @@
 
     <p>En vurdering skal utelukkende ha én kategori, derfor vil antall kategorier i utvalget  tilsvare antall vurderinger i utvalget nemlig @category_total</p>
 
-    <div class="graph">
+    <div class="graph color_graph">
         @foreach (var key in category.Keys)
         {
             <div class="statelement">

--- a/Assessments.Frontend.Web/Views/Redlist/List/partials/_Graphs.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/List/partials/_Graphs.cshtml
@@ -136,24 +136,6 @@
     </p>
 
 
-    <div class="graph greyscale" style="display:none;">
-        @foreach (string key in habitat.Keys)
-        {
-            <div class="statelement" style="max-width:60px;">
-                <div class="heightbar_blank">
-                    <div class="heightbar_indicator @key" style="height:@percentage(@habitat_max, @getNumber(@key,@Model.Statistics.Habitat))">
-                        <span class="percent">@getNumber(@key, @Model.Statistics.Habitat)</span>
-                    </div>
-                </div>
-
-
-                <span class="downboxcontainer statbox @key">
-                    <span class="downtext">@habitat[@key]["name"]</span>
-                </span>
-            </div>
-        }
-    </div>
-
     <div class="down_graph greyscale">
         @foreach (string key in habitat.Keys)
         {

--- a/Assessments.Frontend.Web/Views/Redlist/List/partials/_Graphs.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/List/partials/_Graphs.cshtml
@@ -136,7 +136,7 @@
     </p>
 
 
-    <div class="graph greyscale">
+    <div class="graph greyscale" style="display:none;">
         @foreach (string key in habitat.Keys)
         {
             <div class="statelement" style="max-width:60px;">

--- a/Assessments.Frontend.Web/Views/Redlist/List/partials/_Graphs.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/List/partials/_Graphs.cshtml
@@ -154,17 +154,33 @@
         }
     </div>
 
-    <p><br /></p><p><br /></p><p><br /></p><p><br /></p><p><br /></p>
+    <div class="down_graph greyscale">
+        @foreach (string key in habitat.Keys)
+        {
+
+            <div class="statelement">
+                <span class="statbox @key">
+                    @habitat[@key]["name"]
+                </span>
+                <div class="heightbar_blank">
+                    <div class="heightbar_indicator @key" style="width:@percentage(@habitat_max, @getNumber(@key,@Model.Statistics.Habitat))">
+                        <span class="percent">@getNumber(@key, @Model.Statistics.Habitat)</span>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+
 
     <h3>Antall vurderinger per Region</h3>
 
     <p>
-        Denne grafen viser der verderingenes art forekommer eller er antatt å forekomme. De kan forekomme i mer enn en region om gangen, men informasjonen er bare 
-        registrert for arter som er rødlistet, det vil si ikke har kategoriene LC, NA eller NE. Arter som er regionalt utdødd skal heller ikke forekomme. 
+        Denne grafen viser der verderingenes art forekommer eller er antatt å forekomme. De kan forekomme i mer enn en region om gangen, men informasjonen er bare
+        registrert for arter som er rødlistet, det vil si ikke har kategoriene LC, NA eller NE. Arter som er regionalt utdødd skal heller ikke forekomme.
         <br /><b>
-    TODO: Filteret BURDE fjerne disse artsgruppene, ettersom det KAN ligge inne data der likevel. Men egentlig burde det vært skrelt vekk før vi kommer hit.
-    <br />
-</b>
+            TODO: Filteret BURDE fjerne disse artsgruppene, ettersom det KAN ligge inne data der likevel. Men egentlig burde det vært skrelt vekk før vi kommer hit.
+            <br />
+        </b>
         Den totale artsmengden er @region_total, som i og for seg ikke er et informativt tall i seg selv.
         For nåværende utvalg betyr det at vurderingene forekommer i @average(@total, @region_total) regioner per art.
 
@@ -175,7 +191,7 @@
         @foreach (string key in Model.Statistics.Region.Keys)
         {
             <div class="statelement">
-                 <span class="statbox @key">
+                <span class="statbox @key">
                     @key
                 </span>
 
@@ -186,7 +202,7 @@
                 </div>
 
 
-               
+
             </div>
         }
     </div>

--- a/Assessments.Frontend.Web/wwwroot/css/graphs.css
+++ b/Assessments.Frontend.Web/wwwroot/css/graphs.css
@@ -115,7 +115,10 @@
 
 /* downwards graph */
 .down_graph {
-    padding-right:15px;
+    padding-right: 15px;
+    max-width: 500px;
+    margin-left: 0;
+    margin-right: 15px;
 }
 .down_graph .statelement {
     width: 100%;
@@ -136,6 +139,7 @@
     margin-right: 5px;
     text-align: right;
     font-size: 10pt;
+    flex:1;
 }
 
 .down_graph .heightbar_blank,
@@ -146,7 +150,7 @@
 
 .down_graph .statelement .heightbar_blank {
     width: calc(100% - 120px);
-    max-width: 300px;
+    flex:1;
     display: flex;
     align-items: stretch
 }
@@ -164,3 +168,42 @@
 }
 
 
+@media only screen and (max-width: 330px) {
+    .down_graph .statbox {
+        flex: none;
+        max-width: 50%;
+        width: 100%;
+        word-break: break-word;
+        hyphens: auto;
+        font-size: 8pt;
+    }
+}
+
+
+@media only screen and (max-width: 250px) {
+    .down_graph {
+        padding-right: 0;
+    }
+    .down_graph .statbox {
+        max-width:80%
+    }
+
+    .down_graph .statelement {
+        border-bottom: 1px solid lightgray;
+        padding-bottom: 5px;
+    }
+
+    .down_graph .statelement .heightbar_blank {
+        width: 20%
+    }
+
+    .down_graph .statelement .percent,
+    .down_graph .statelement .heightbar_indicator {
+        width: 100%!important;/*Clean table view*/
+        margin:0;
+        background:white;
+        padding:0;
+    }
+
+
+}

--- a/Assessments.Frontend.Web/wwwroot/css/graphs.css
+++ b/Assessments.Frontend.Web/wwwroot/css/graphs.css
@@ -207,3 +207,46 @@
 
 
 }
+
+@media only screen and (max-width: 280px) {
+    .color_graph {
+        flex-direction: column;
+    }
+
+    .color_graph .statelement{
+        display:flex;
+        margin:2px;
+        border-bottom: 1px solid lightgray;
+    }
+    .color_graph .heightbar_blank {
+        height: 20px;
+        display: inline-block;
+        order:2;
+        width:50%;
+    }
+
+    .color_graph .heightbar_indicator {
+        position: relative;
+        background:none;
+        height: 100% !important; /*Clean table view*/
+    }
+
+    .color_graph .statbox {
+        order:1;
+        width:50%;
+        display:inline-block;
+        color:black;
+        background:none;
+        text-align:right;
+    }
+
+    .color_graph .percent {
+        top: auto;
+        margin: auto;
+        text-align: left;
+        font-size: 12pt;
+        padding: 2px;
+    }
+
+
+}

--- a/Assessments.Frontend.Web/wwwroot/css/graphs.css
+++ b/Assessments.Frontend.Web/wwwroot/css/graphs.css
@@ -62,9 +62,8 @@
 .statbox {
     display: block;
     padding: 10px;
+    hyphens: auto;
 }
-
-
 
 .percent {
     position: absolute;
@@ -94,8 +93,25 @@
     height: 1vw;
     width: 180px;
     text-align: initial;
+    font-size:9pt;
 }
 
+
+@media only screen and (max-width: 450px) {
+    .downboxcontainer {
+        height: 179px;
+    }
+    .downtext {
+        top: 151px;
+        left: -130px;
+        height: 1vw;
+        width: 300px;
+    }
+
+    .statbox {
+        padding: 2px;
+    }
+}
 
 /* downwards graph */
 .down_graph {
@@ -117,7 +133,7 @@
     background: none;
     display: inline-block;
     padding: 0;
-    padding-right: 5px;
+    margin-right: 5px;
     text-align: right;
     font-size: 10pt;
 }
@@ -146,4 +162,5 @@
     width: 1px;
     margin-left: 100%;
 }
+
 

--- a/Assessments.Frontend.Web/wwwroot/css/graphs.css
+++ b/Assessments.Frontend.Web/wwwroot/css/graphs.css
@@ -75,44 +75,6 @@
     width: 100%;
 }
 
-.downboxcontainer {
-    font-size: 10pt;
-    height: 179px;
-    display: block;
-    position: relative;
-    background: none;
-}
-
-.downtext {
-    transform: rotate(90deg);
-    display: block;
-    position: absolute;
-    top: 93px;
-    left: -62px;
-    z-index: 2;
-    height: 1vw;
-    width: 180px;
-    text-align: initial;
-    font-size:9pt;
-}
-
-
-@media only screen and (max-width: 450px) {
-    .downboxcontainer {
-        height: 179px;
-    }
-    .downtext {
-        top: 151px;
-        left: -130px;
-        height: 1vw;
-        width: 300px;
-    }
-
-    .statbox {
-        padding: 2px;
-    }
-}
-
 /* downwards graph */
 .down_graph {
     padding-right: 15px;


### PR DESCRIPTION
Habitat now has three main graph types, normal greyscale, normal colour and down.

- removed all down-text and code related to rotating text

Normal colour:
- added css-jump which made the graphs more narrow on smaller screens
- added table view size for super-tiny screens, but this one is triggered at very small size, as the one above allows quite small views

Down:
- Contained with a max width for the entire graph to avoid too large bars
- added tiny extra jump where the text optimizes size a bit
- added table view size for super-tiny screens