### PR TITLE
See the which assessment is active when tabbing

### DIFF
--- a/Assessments.Frontend.Web/wwwroot/css/listview.css
+++ b/Assessments.Frontend.Web/wwwroot/css/listview.css
@@ -152,6 +152,12 @@ td {
     padding-bottom:5px;
 }
 
+.list a:hover,
+.list a:focus,
+.list a:active {
+    background-color: #e9e9e9;
+}
+
 
 
 
@@ -167,13 +173,6 @@ td {
         grid-template-columns: 2fr 45px;
         text-align:right;
     }
-
-    .element_speciesgroup span,
-    .element_species span {
-        
-        background:white;
-    }
-
 }
 
 


### PR DESCRIPTION
add a background-color to list elements when hovered, active and in focus, to be able to see them when tabbing