### PR TITLE
Add custom sorting to region names (#186)

### DIFF
--- a/Assessments.Frontend.Web/Controllers/RedlistController.cs
+++ b/Assessments.Frontend.Web/Controllers/RedlistController.cs
@@ -9,7 +9,6 @@ using Newtonsoft.Json.Linq;
 using X.PagedList;
 using System;
 using Assessments.Frontend.Web.Infrastructure.Services;
-
 // ReSharper disable InconsistentNaming
 
 namespace Assessments.Frontend.Web.Controllers
@@ -76,9 +75,7 @@ namespace Assessments.Frontend.Web.Controllers
                 query = query.Where(x => viewModel.Habitats.Any(y => x.MainHabitat.Contains(y)));
 
             // Regions
-            string[] regionNames = query.Select(x => x.RegionOccurrences.Select(x => x.Fylke)).SelectMany(x => x).Distinct().OrderBy(x => x).ToArray();
-
-            ViewBag.AllRegions = Helpers.getRegionsDict(regionNames);
+            ViewBag.AllRegions = Helpers.getRegionsDict();
             string[] chosenRegions = Helpers.findSelectedRegions(viewModel.Regions, ViewBag.AllRegions);
 
             if (chosenRegions?.Any() == true)

--- a/Assessments.Frontend.Web/Infrastructure/Helpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Helpers.cs
@@ -42,8 +42,10 @@ namespace Assessments.Frontend.Web.Infrastructure
             return selectedCategories.ToArray();
         }
 
-        public static Dictionary<string, string> getRegionsDict(string[] regionNames)
+        public static Dictionary<string, string> getRegionsDict()
         {
+            var regionNames = SortedRegions().ToArray();
+
             Dictionary<string, string> allRegions = new Dictionary<string, string>();
             for (int i = 0; i < regionNames.Length; i++)
             {
@@ -62,6 +64,11 @@ namespace Assessments.Frontend.Web.Infrastructure
             return regions.ToArray();
         }
 
+        /// <summary>
+        ///  Sortert liste med navn på regioner (etter gamle fylkesnummer)
+        /// </summary>
+        public static List<string> SortedRegions() => new() { "Østfold", "Oslo og Akershus", "Hedmark", "Oppland", "Buskerud", "Vestfold", "Telemark", "Aust-Agder", "Vest-Agder", "Rogaland", "Hordaland", "Sogn og Fjordane", "Møre og Romsdal", "Trøndelag", "Nordland", "Troms", "Finnmark", "Jan Mayen", "Nordsjøen", "Norskehavet", "Barentshavet sør", "Barentshavet nord og Polhavet", "Grønlandshavet" };
+        
         public static string[] findEuropeanPopProcentages(string[] europeanPopulation)
         {
             List<string> selectedPercenteges = new List<string>();

--- a/Assessments.Frontend.Web/Views/Redlist/List/partials/_Graphs.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/List/partials/_Graphs.cshtml
@@ -175,7 +175,7 @@
 
 
     <div class="down_graph greyscale">
-        @foreach (string key in Model.Statistics.Region.Keys)
+        @foreach (string key in Model.Statistics.Region.Keys.OrderBy(x => Helpers.SortedRegions().IndexOf(x)))
         {
             <div class="statelement">
                 <span class="statbox @key">
@@ -183,7 +183,7 @@
                 </span>
 
                 <div class="heightbar_blank">
-                    <div class="heightbar_indicator @key" style="width:@percentage(impact_max, @getNumber(@key,@Model.Statistics.Region))">
+                    <div class="heightbar_indicator @key" style="width: @percentage(impact_max, @getNumber(@key, @Model.Statistics.Region))">
                         <span class="percent">@getNumber(@key, @Model.Statistics.Region)</span>
                     </div>
                 </div>


### PR DESCRIPTION
la til egendefinert (og hardkodet) liste med navn på regioner
blir brukt i filter og på sttatistikk (antall vurderinger per region)
listen er sortert av @KristineLund (etter gamle fylkesnummer)

ulempen med listen og filteret er at vi bruker en automatisk indeks, altså endrer man rekkefølgen vil ikke lengre en url med aktivt filter for en region nødvendigvis blir riktig) - greit å være klar over. 

alternativt må vi legge tilbake "kodene" for region og heller bruke de (f.eks "aa" = Aust-Agder) 
man kan se disse i koden her: https://github.com/Artsdatabanken/assessments-frontend/blob/91aaff099b710cef72a21caedf7ef882d4fa66a4/Assessments.Mapping/Helpers/SpeciesAssessment2021ProfileHelper.cs#L199