### PR TITLE
add text for no result in rødlista 2021

### DIFF
--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/List/partials/_ListView.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/List/partials/_ListView.cshtml
@@ -17,7 +17,8 @@
 
         </li>
 
-
+    @if (Model.Redlist2021Results.Count > 0)
+    {
         @foreach (var item in Model.Redlist2021Results)
         {
             string speciesgroupname = @item.SpeciesGroup.ToLower();
@@ -62,4 +63,9 @@
                 </a>
             </li>
         }
+    }
+    else
+    {
+        <div class="no_results">@ViewBag.glossary["oneliners"]["noResults"]</div>
+    }
     </ul>

--- a/Assessments.Frontend.Web/wwwroot/css/search.css
+++ b/Assessments.Frontend.Web/wwwroot/css/search.css
@@ -1,6 +1,10 @@
 
 /* SEARCH FIELD REDLIST */
 
+.no_results {
+    padding: 10px 0;
+}
+
 /* Container div for anything search*/
 .list-search {
     text-align: center;

--- a/Assessments.Frontend.Web/wwwroot/json/glossary.json
+++ b/Assessments.Frontend.Web/wwwroot/json/glossary.json
@@ -56,7 +56,8 @@
     "max": "Maximum (max): ",
     "probable": "Mest trolig",
     "calculated": "Beregnet reduksjon, med føre-var forbehold:",
-    "conclusion": "Kriteriets reduksjon ≥ <terskelverdi> % tilsvarer <kategori>"
+    "conclusion": "Kriteriets reduksjon ≥ <terskelverdi> % tilsvarer <kategori>",
+    "noResults": "Kombinasjonen av søk og filter gir ingen treff i rødlista for 2021."
   },
   "inkluderingskriterier": {
     "hvorfor": {


### PR DESCRIPTION
Legger til en enkel tekst når det ikke finnes treff i rødlista. 
I issuen #87 er det også snakk om å gjøre mer enn dette, men dette er en start, og dette er noe vi absolutt må ha på plass.