### PR TITLE
Endringer i into ++

### DIFF
--- a/Assessments.Frontend.Web/Infrastructure/Criteria.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Criteria.cs
@@ -46,7 +46,7 @@ namespace Assessments.Frontend.Web.Infrastructure
         {
             foreach (string el in bigstring)
             {
-                if (el.Contains(element))
+                if (el == element)
                 {
                     return "active";
                 }

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_CategoryDegrade.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_CategoryDegrade.cshtml
@@ -1,6 +1,6 @@
 ﻿@model SpeciesAssessment2021
 
-<div class="page_section">
+<div class="page_section" id="nedgradert">
 
     @if (Model.ExtinctionRiskAffected == "Ja")
     {

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_CategoryDescription.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_CategoryDescription.cshtml
@@ -6,4 +6,10 @@
 
 <div class="page_section">
     <partial name="/Views/Shared/_Categorybar.cshtml" />
+    <a href="/" class="button tinybutton tertiary">
+        Alt om kategoriskalaen 
+        <span class="material-icons">
+            keyboard_arrow_right
+        </span>
+    </a>
 </div>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Header.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Header.cshtml
@@ -3,8 +3,18 @@
     HEADER BLOCK FOR PAGE
 *@
 
-<div class="page-header">    
-    <partial name="/Views/Redlist/Species/2021/Assessment/partials/_Artsnavn.cshtml" />    
+<div class="page-header">
+    <partial name="/Views/Redlist/Species/2021/Assessment/partials/_Artsnavn.cshtml" />
+   
+    @if (@Model.AssessmentArea == "S")
+    {
+        <h2 class="svalbard-heading">
+            Svalbard 
+        </h2>
+    }
     <partial name="/Views/Redlist/Species/2021/Assessment/partials/_SpeciesGroup.cshtml" />
-    <hr/>
+    <hr />
 </div>
+
+
+

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Ingress.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Ingress.cshtml
@@ -35,7 +35,7 @@
         }
         if(Model.Category.Length > 2)
         {
-            sentence += ", og ble nedgradert på grunn av populasjoner i nærliggende regioner";
+            sentence += ", og ble <a href='#nedgradert'>nedgradert</a> på grunn av populasjoner i nærliggende regioner";
         }
         sentence = "Kategorien kommer av " + sentence + ".";
     }
@@ -61,7 +61,7 @@
                 <span>vurdert til </span>
             }
             <partial name="/Views/Shared/_Category.cshtml" /> <span class="">@Helpers.findDegrees(Model.Category, true)</span><span>
-                for Norsk rødliste for arter 2021. @sentence
+                for Norsk rødliste for arter 2021. @Html.Raw(sentence)
             </span>
 
 

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Ingress.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Ingress.cshtml
@@ -1,7 +1,45 @@
 ﻿@model SpeciesAssessment2021
 @*
     HEADER BLOCK FOR PAGE
+    TODO:
+    - NEDGRADERT : ankerlenke
+    - RL-for arter osv : lenke
+    - Troliig utdødd, egen setning
+    - Norge/Svalbard inn i ingress
+    + kriteriesetning
+    + setning om degradering
+
+
+    GOOGLE SEO må tas separat -> heading og tekst til søk
+
 *@
+
+@{
+    // Obtain which criteria are used and their titles.
+    var subcriteria = Criteria.sortCriteria(Model.CriteriaSummarized);
+    string sentence = "";
+    @if (!string.IsNullOrWhiteSpace(Model.CriteriaSummarized))
+    {
+        @foreach (var (key, value) in subcriteria)
+        {
+            if (!string.IsNullOrEmpty(value))
+            {                
+                string current = ViewBag.kriterier[key]["title"];                
+                sentence.Replace(" og ", ", ");               
+                if (sentence != "")
+                {
+                    sentence += " og ";
+                }
+                sentence += current.ToLower();
+            }
+        }
+        if(Model.Category.Length > 2)
+        {
+            sentence += ", og ble nedgradert på grunn av populasjoner i nærliggende regioner";
+        }
+        sentence = "Kategorien kommer av " + sentence + ".";
+    }
+}
 
 <div class="page_section">
     <p>
@@ -15,16 +53,19 @@
         }
         else
         {
+
+
             <span>Arten er </span>
             @if (Model.Category != "NA" && Model.Category != "NE")
             {
                 <span>vurdert til </span>
             }
-            <partial name="/Views/Shared/_Category.cshtml" /> <span class="">@Helpers.findDegrees(Model.Category, true)</span> 
-            <span>
-                for Norsk rødliste for arter 2021.
-                Rødlista for arter er en oversikt over arter som har risiko for å dø ut fra Norge.
+            <partial name="/Views/Shared/_Category.cshtml" /> <span class="">@Helpers.findDegrees(Model.Category, true)</span><span>
+                for Norsk rødliste for arter 2021. @sentence
             </span>
+
+
+
         }
     </p>
 </div>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Ingress.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Ingress.cshtml
@@ -1,19 +1,4 @@
 ﻿@model SpeciesAssessment2021
-@*
-    HEADER BLOCK FOR PAGE
-    TODO:
-    - NEDGRADERT : ankerlenke
-    - RL-for arter osv : lenke
-    - Troliig utdødd, egen setning
-    - Norge/Svalbard inn i ingress
-    + kriteriesetning
-    + setning om degradering
-
-
-    GOOGLE SEO må tas separat -> heading og tekst til søk
-
-*@
-
 @{
     // Obtain which criteria are used and their titles.
     var subcriteria = Criteria.sortCriteria(Model.CriteriaSummarized);
@@ -41,6 +26,7 @@
     }
 }
 
+
 <div class="page_section">
     <p>
         @if (Model.AssessmentYear == 2010)
@@ -53,19 +39,23 @@
         }
         else
         {
-
-
             <span>Arten er </span>
             @if (Model.Category != "NA" && Model.Category != "NE")
             {
                 <span>vurdert til </span>
             }
             <partial name="/Views/Shared/_Category.cshtml" /> <span class="">@Helpers.findDegrees(Model.Category, true)</span><span>
-                for Norsk rødliste for arter 2021. @Html.Raw(sentence)
+                
+                @if (@Model.Category == "CR" && @Model.PresumedExtinct == true)
+                {
+                <span>for Norsk rødliste for arter 2021, og er trolig utdødd.</span>
+                }
+                else
+                {
+                  <span>for Norsk rødliste for arter 2021.</span>
+                }
+                @Html.Raw(sentence)
             </span>
-
-
-
         }
     </p>
 </div>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/Shared/_PageMenu.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/Shared/_PageMenu.cshtml
@@ -13,10 +13,15 @@
 
 <div class="sidebarmenu">
     <button class="button tertiary" onclick="expandParent(this, 'expand')">Om Rødlista </button>
-    <h3>Om Rødlista </h3>
+    
     <ul>
 
         @*lenker fra cms/drupal via api*@
+        <li>
+            <a class="menuheaderlink" asp-controller="Redlist" asp-action="Index2021">
+                <h3>Rødlista 2021</h3>
+            </a>
+        </li>
         @foreach (var (key, value) in menuItems)
         {
             <li>

--- a/Assessments.Frontend.Web/Views/Redlist/_Layout.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/_Layout.cshtml
@@ -20,6 +20,8 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <script src="https://design.artsdatabanken.no/script/header.js"></script>
     <script src="https://design.artsdatabanken.no/script/footer.js"></script>
+
+    <meta name="description" content="Norsk rødliste for arter 2021 er en oversikt over arter som har risiko for å dø ut fra Norge. Rødlista er utarbeidet av Artsdatabanken i samarbeid med fageksperter. " />
 </head>
 
 <body>

--- a/Assessments.Frontend.Web/Views/Redlist/_Layout.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/_Layout.cshtml
@@ -16,6 +16,7 @@
     <link rel="stylesheet" href="~/css/filter.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/css/search.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/css/toggleSwitch.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/css/rl2021.css" asp-append-version="true" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <script src="https://design.artsdatabanken.no/script/header.js"></script>
     <script src="https://design.artsdatabanken.no/script/footer.js"></script>

--- a/Assessments.Frontend.Web/Views/Shared/_Category.cshtml
+++ b/Assessments.Frontend.Web/Views/Shared/_Category.cshtml
@@ -25,8 +25,4 @@
 
 <span>
     <i>@categoryDescription(@Model.Category)</i> @Model.Category
-    @if (@Model.Category == "CR" && @Model.PresumedExtinct == true)
-    {
-        <span>og er trolig utdødd</span>
-    }
 </span>

--- a/Assessments.Frontend.Web/wwwroot/css/categorybar.css
+++ b/Assessments.Frontend.Web/wwwroot/css/categorybar.css
@@ -29,7 +29,7 @@
     margin: 0px;
     vertical-align: top;
     padding-top: 14px;
-    padding-bottom: 20px;
+    padding-bottom: 5px;
     margin-bottom: 20px;
     height: auto;
     position: relative;

--- a/Assessments.Frontend.Web/wwwroot/css/rl2021.css
+++ b/Assessments.Frontend.Web/wwwroot/css/rl2021.css
@@ -1,0 +1,21 @@
+h1, h2, h3 {
+    color: #0f0f0f;
+    font-weight: normal;
+}
+
+.page-header h1 {
+    line-height: 1.3;
+    font-size: 33px;
+}
+
+.svalbard-heading {
+    color: #185c7d;
+}
+
+.sidebarmenu{
+    padding-top:0;
+}
+
+.main-content {
+    /*padding-top: 7px;*/
+}

--- a/Assessments.Frontend.Web/wwwroot/css/site.css
+++ b/Assessments.Frontend.Web/wwwroot/css/site.css
@@ -194,7 +194,7 @@ option {
     }
 
     .content-placer {
-        padding-top: 20px;
+        padding-top: 33px;
         width: calc(75% - 4px);
         display: flex;
     }

--- a/Assessments.Frontend.Web/wwwroot/css/site.css
+++ b/Assessments.Frontend.Web/wwwroot/css/site.css
@@ -610,3 +610,13 @@ option {
 .sidebarmenu .material-icons {
    float:right;
 }
+
+
+.sidebarmenu li .menuheaderlink {
+    border: none;
+    padding:inherit;
+}
+
+.sidebarmenu li h3 {
+    color: #098293;
+}


### PR DESCRIPTION
- Headerstyling har endret seg. Skal senere fikses i drupal også.
- Meny har fått klikkbar overskrift.
- Lenke i kategoriskalaen (som ikke går noe sted ennå...)
- fikset typo for bkriteriet ( fixes #369 )
- Svalbard har fått bli underoverskrift - men kun for svalbardarter. Vi har ikk Norge på Norge-arter. 

(God eksempelart på ingress for nedgradert: 31847)

**Endringer i ingress:**
- fjernet oneliner om rødlista
- for arter med criteriasummarized, la til overskriftene på relevante brukte kriterier
- for nedgraderte, la til setning om det 
- nedgradert har fått ankerlenke 
- trolig utdødd har blitt omplassert