### PR TITLE
Add google analytics and modify list title (#454)

### DIFF
--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/List/List.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/List/List.cshtml
@@ -1,5 +1,9 @@
 ﻿@model RL2021ViewModel
 
+@{
+	ViewData["Title"] = "Norsk rødliste for arter 2021";
+}
+
 <partial name="/Views/Redlist/Species/2021/List/partials/_Breadcrumb.cshtml" />
 <div class="pagecontainer">
     <partial name="/Views/Redlist/Species/Shared/_PageMenu.cshtml" />

--- a/Assessments.Frontend.Web/Views/Redlist/_Layout.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/_Layout.cshtml
@@ -1,10 +1,13 @@
-﻿<!DOCTYPE html>
+﻿@using Microsoft.Extensions.Configuration
+@inject IConfiguration _configuration
+
+<!DOCTYPE html>
 <html lang="en">
 
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@ViewData["Title"] - Assessments Frontend</title>
+    <title>@ViewData["Title"] - Artsdatabanken</title>
     <link rel="stylesheet" href="https://design.artsdatabanken.no/style/style-reset.css" asp-append-version="true" />
     <link rel="stylesheet" href="https://design.artsdatabanken.no/style/layout.css" asp-append-version="true" />
     <link rel="stylesheet" href="https://design.artsdatabanken.no/style/header-footer.css" asp-append-version="true" />
@@ -24,6 +27,29 @@
     <script src="https://design.artsdatabanken.no/script/footer.js"></script>
 
     <meta name="description" content="Norsk rødliste for arter 2021 er en oversikt over arter som har risiko for å dø ut fra Norge. Rødlista er utarbeidet av Artsdatabanken i samarbeid med fageksperter. " />
+
+    <environment names="Production,Staging">
+	    <!-- Google Analytics -->
+	    <script>
+	        (function(i, s, o, g, r, a, m) {
+		        i['GoogleAnalyticsObject'] = r;
+		        i[r] = i[r] ||
+			        function() {
+				        (i[r].q = i[r].q || []).push(arguments);
+			        }, i[r].l = 1 * new Date();
+		        a = s.createElement(o),
+			        m = s.getElementsByTagName(o)[0];
+		        a.async = 1;
+		        a.src = g;
+		        m.parentNode.insertBefore(a, m);
+	        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
+
+	        ga('create', '@(_configuration["Google:AnalyticsId"])', 'auto');
+	        ga('send', 'pageview');
+        </script>
+	    <!-- End Google Analytics -->
+    </environment>
+
 </head>
 
 <body>

--- a/Assessments.Frontend.Web/appsettings.Development.json
+++ b/Assessments.Frontend.Web/appsettings.Development.json
@@ -7,9 +7,12 @@
       "Assessments.*": "Debug"
     }
   },
-  "Mapping": {
-    "Redlist": {
-      "TransformSpeciesAssessments": false
-    }
-  }
+    "Mapping": {
+        "Redlist": {
+            "TransformSpeciesAssessments": false
+        }
+    },
+    "Google": {
+        "AnalyticsId": "UA-74815937-3"
+    } 
 }

--- a/Assessments.Frontend.Web/appsettings.json
+++ b/Assessments.Frontend.Web/appsettings.json
@@ -1,15 +1,18 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning",
+            "Microsoft.Hosting.Lifetime": "Information"
+        }
+    },
+    "AllowedHosts": "*",
+    "Mapping": {
+        "Redlist": {
+            "TransformSpeciesAssessments": true
+        }
+    },
+    "Google": {
+        "AnalyticsId": "UA-74815937-4"
     }
-  },
-  "AllowedHosts": "*",
-  "Mapping": {
-    "Redlist": {
-      "TransformSpeciesAssessments": true
-    }
-  }
 }


### PR DESCRIPTION
la til google analytics sporingskode (production og staging), koblet mot eksisterende kontoer
gjeldende konto hentes fra appsettings

_usikker om det fungerer i staging miljø, vi har kanskje ikke satt opp riktig konfigurasjon for dette_

..også litt usikker på om dette fungerer ordentlig når sidene ligger på et subdomene (litt vanskelig å teste før vi bygger det ut på beta) 

la også til en (bedre) tittel på listesiden
