### PR TITLE
Build from dev

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,20 +1,16 @@
-
-name: .NET Core
-
+name: Develop branch
+# Builds all pushes to develop and publishes on the fly
 on:
   push:
-    branches: 
-      - 'main'
-      - 'master'
+    branches:
+      - 'develop'
   pull_request:
-    types: [closed]
-    branches: 
-      - 'main'
-      - 'master'
-
+    branches:
+      - 'develop'
+   
 jobs:
   build:
-    
+
     runs-on: ubuntu-latest
 
     steps:
@@ -31,10 +27,13 @@ jobs:
       run: dotnet test --no-restore --verbosity normal
     - name: Build and push Docker image api
       uses: docker/build-push-action@v1
-      if: github.event.pull_request.merged == 'true' && ${{ github.actor != 'dependabot[bot]' }}
+      if: ${{ github.actor != 'dependabot[bot]' }}
       with:
         username: ${{ secrets.ORG_DOCKER_USER }}
         password: ${{ secrets.ORG_DOCKER_PASS }}
         dockerfile: Assessments.Frontend.Web/Dockerfile
         repository: artsdatabanken/assessments-fe
-        tags: latest
+        tags: dev
+    - name: Post to slack
+      if: ${{ github.actor != 'dependabot[bot]' }}
+      run: .github/workflows/slack.sh ${{ secrets.POST_SLACK }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
       run: dotnet test --no-restore --verbosity normal
     - name: Build and push Docker image api
       uses: docker/build-push-action@v1
+      if: ${{ github.actor != 'dependabot[bot]' }}
       with:
         username: ${{ secrets.ORG_DOCKER_USER }}
         password: ${{ secrets.ORG_DOCKER_PASS }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,8 @@ name: Feature branches .NET Core
 
 on:
   push:
-    branches-ignore:
-      - master
-      - main 
+    branches:
+      - 'develop'
    
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,16 @@
 
-name: Feature branches .NET Core
+name: Test aka staging
+#Builds and publishes PRs to "stable" test
 
 on:
-  push:
-    branches:
-      - 'develop'
+  pull_request:
+    types: [closed]
+    branches: 
+      - 'test-staging'
    
 jobs:
   build:
-
+    if: github.event.pull_request.merged == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -31,12 +31,19 @@ Alle sites er beskyttet og krever VPN (man trenger ikke være koblet på for å 
 
 Nyttig lenke om man er ny til teknologien: https://docs.microsoft.com/en-us/aspnet/core/tutorials/first-mvc-app/start-mvc?view=aspnetcore-5.0&tabs=visual-studio
 
-## Deployment
-Deployment er delt i test og produksjon og skjer via github actions. Deployment til test skjer automatisk ved innsjekk av alle brancher som ikke er main/master. Ønsker du av en eller annen grunn å utelate din branch fra bygging/deployment til test, må du legge til denne i lista i fila: .github/workflows/test.yml under "branches ignore". 
+## Deployment og bygging til Linux og docker
+Git workflows representerer tre forskjellige versjoner av kjørende kode.
+- develop
+- test
+- main/master
 
-Dockerimage bygges og sendes til artdatabankens dockerhub:https://hub.docker.com/repository/docker/artsdatabanken/assessments-fe - det er foreløpig to tags; test og latest - henholdsvis test/produksjon. 
+- Develop branch er fritt vilt og alle push(og eventuelle PR) til denne bygges og publiseres på: https://assessments-fe-dev.test.artsdatabanken.no. Egnet for kortlevde tester.
+- Test(staging) er en mer stabil testversjon og vil kun bygge og publisere om en PR merges inn i branchen. Denne bygges da og publiseres på https://assessments-fe.test.artsdatabanken.no
+- Main/master bygges ved push(for å kunne adhoc rette akutte feil i produksjon) og om en PR merges inn i branchen. Denne kan publiseres ved å gå til #crocotta og bruk kommandoen "deploy assessments-fe" - den havner da hit: https://assessments-fe.artsdatabanken.no 
 
-For å dytte ut gjeldende versjon til produksjon, gå til #crocotta og bruk kommandoen deploy assessments-fe - da hentes image med tag "latest" fra dockerhub. 
+## Deployment og bygging til IIS/Windows
+- Test(beta): Jenkins mottar push hook fra Github, bygger og publiserer fra test-branch.
+- Main(prod): Bygger master/main ved å trykke "build now" i Jenkins. 
 
 ### Deplyment til iis som website eller applikasjon under en website:
 


### PR DESCRIPTION
Da har jeg tatt en liten razzia og gjort følgende:

Linux/Docker
Opprettet en ny workflow, develop, som er regnet som fritt vilt og alt av PR/push trykkes automatisk ut til: https://assessments-fe-dev.test.artsdatabanken.no. Den bører IKKE det som kjøres på beta.artsdatabanken.no. Så her er det bare å slå seg løs.

Har gjort endringer på workflow som het test.yml. Prøver her funksjonalitet jeg ikke har testa før, men om det virker så tror jeg det dekker behovet. Tanken er at denne kun bygges og publiseres ved PR som lukkes OG merges. Det skjer da automatisk og publiseres hit: https://assessments-fe.test.artsdatabanken.no

Har valgt å beholde main.yml selv om denne sannsynligvis er overflødig, siden den er driftsmessig gratis å ha kjørende. Her må man manuelt trigge publisering til server. Det kjøres da ut hit: https://assessments-fe.artsdatabanken.no. Det er kjapt å fjerne denne om vi bestemmer oss for det. 

Windows/IIS
Har foreløpig satt Jenkins til å lytte på branchen "test" og den bygger da når den mottar "push hooks fra Github". 

En tanke som slo meg er at det potensielt er uheldig?
Vi kan eventuelt ha en egen branch til dette formålet og at man f.eks merger inn fra test til en slags beta-branch? Da får man et steg hvor utvikler kan teste at koden kjører, før hen pusher denne ut til langvarig testing på beta? Spørsmålet blir forsåvidt hvor redd man er for å introdusere bugs på beta?