### PR TITLE
Logikk for skjuling/vising av innhold.

### DIFF
--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Criteria.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Criteria.cshtml
@@ -450,282 +450,300 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
             <partial name="/Views/Shared/_Criteriabar.cshtml" />
         *@
         <ul class="outer noline">
+            <li class="tablist_listheader">
+                <span class="summary_title">Artens kriterier</span>
+                <span class="full_list_title">Alle kriterier</span>
+                <span class="full_list_description" style="display:none;">
+                    Gjeldende kriterier for arten er markert med merket
+                    <span class="impact_v">
+                        <span class="material-icons">
+                            done
+                        </span>
+                    </span>
+                </span>
+                @if (string.IsNullOrEmpty(Model.CriteriaSummarized))
+                {
+                    <span class="no_elements">Det er ikke angitt påvirkningsfaktorer.</span>
+                }
+
+            </li>
             @foreach (var (key, value) in criteria)
             {
                 string isactive = @Criteria.inString(key, @Model.CriteriaSummarized);
-            <li class="@isactive">
-                <span class="text_container clickable" onclick="expandCriteria(this, 'opened_element') ">
-                    @{ expandOrBullet(true);}
-                    <span class="title_field">
-                        @key - @value["title"]
-                        @{ iconChooser(Criteria.inString(key, Model.CriteriaSummarized)); }
+                <li class="@isactive">
+                    <span class="text_container clickable" onclick="expandCriteria(this, 'opened_element') ">
+                        @{ expandOrBullet(true);}
+                        <span class="title_field">
+                            @key - @value["title"]
+                            @{ iconChooser(Criteria.inString(key, Model.CriteriaSummarized)); }
+                        </span>
                     </span>
-                </span>
-                <p>
-                    @{ hasKey("description", @value);}
-                    @{ getModel(key);}
-                    @{ getQuantile(value, key, key);}
-                </p>
+                    <p>
+                        @{ hasKey("description", @value);}
+                        @{ getModel(key);}
+                        @{ getQuantile(value, key, key);}
+                    </p>
 
-                <!-- SUBCRITERIA (A1, ... D2) -->
-                @if (@value.ContainsKey("subcriteria"))
-                {
-                    var thesubcriteria = parseDictNested(value["subcriteria"].ToString());
-                    <ul class="second">
-                        @foreach (var (k, v) in thesubcriteria)
+                    <!-- SUBCRITERIA (A1, ... D2) -->
+                    @if (@value.ContainsKey("subcriteria"))
+                    {
+                        var thesubcriteria = parseDictNested(value["subcriteria"].ToString());
+                        <ul class="second">
+                            @foreach (var (k, v) in thesubcriteria)
+                            {
+                                var subcriteria_isactive = @Criteria.inString(k, subcriteria[key]);
+                                <li class=" @subcriteria_isactive">
+                                    <span class="text_container">
+                                        <span class="text_collection">
+                                            <span class="title_field clickable" onclick="expandCriteria(this, 'opened_element')">
+                                                @{expandOrBullet(true);}
+                                                <span class="text_text ">
+                                                    @k - @v["title"]
+                                                    @{iconChooser(subcriteria_isactive);}
+                                                </span>
+                                            </span>
+                                            <p>
+                                                @{ hasKey("description", v);}
+                                                @{ getGenerationTime(key, k);}
+                                                @{ getModel(k);}
+                                            </p>
+                                            @{ getQuantile(v, k, key);}
+
+                                            <!-- SUBCRITERIA SUBOPTIONS FOR A & C-CRITERIA && SUBOPTIONS FOR Ca2 -->
+
+                                            @if (v.ContainsKey("subsub"))
+                                            {
+                                                string[] currentlist = Criteria.obtainSubCriteriaList(subcriteria[key].Split(";"), k);
+                                                var subdict = parseDictNested(@v["subsub"].ToString());
+                                                @if (currentlist.Length > 0)
+                                                {
+                                                    @if (key == "A")
+                                                    {
+                                                        <p class="subheading"> <b>Kunnskapsgrunnlag</b></p>
+                                                    }
+
+                                                    <ul class="third activeornot">
+                                                        @foreach (var (subkey, subval) in subdict)
+                                                        {
+                                                            string modelkey = k + subkey;
+                                                            <li class="@Criteria.inList(subkey, currentlist)">
+                                                                <span class="text_container">
+                                                                    <span class="text_collection">
+                                                                        <span class="title_field">
+                                                                            @{expandOrBullet(false);}
+                                                                            <span class="text_text">
+                                                                                @subkey - <span>@subval["title"] @{ iconChooser(Criteria.inList(subkey, currentlist)); }</span>
+                                                                            </span>
+                                                                        </span>
+                                                                        @{ getQuantile(subval, modelkey, modelkey);}
+                                                                    </span>
+                                                                    <!-- SUBCRITERIA SUBOPTIONS FOR A & C-CRITERIA && SUBOPTIONS FOR Ca2 -->
+                                                                </span>
+                                                            </li>
+                                                        }
+                                                    </ul>
+
+
+                                                }
+                                            }
+
+                                        </span>
+                                    </span>
+
+                                </li>
+                            }
+                        </ul>
+                        if (key == "C")
                         {
-                            var subcriteria_isactive = @Criteria.inString(k, subcriteria[key]);
-                            <li class=" @subcriteria_isactive">
+                            <ul class="second">
+                                @{var activeC = @Criteria.inString("C", @Model.CriteriaSummarized); }
+                                <li class="@activeC">
+                                    <span class="text_container">
+                                        <span class="text_collection">
+                                            <span class="title_field" onclick="expandCriteria(this, 'opened_element')">
+                                                @{expandOrBullet(true);}
+                                                <span class="text_text clickable">
+                                                    Konklusjon for C-kriteriet
+                                                    <br />
+                                                </span>
+                                            </span>
+
+                                            @{
+                                                string c_category = Model.Category;
+                                                bool c_comparison = Model.Category.Length > 2 && !string.IsNullOrEmpty(Model.CategoryAdjustedFrom);
+                                                if (c_comparison)
+                                                {
+                                                    c_category = Model.CategoryAdjustedFrom;
+                                                }
+                                            }
+                                            <p>
+                                                @if (activeC == "active")
+                                                {
+                                                    <span class="b_summary">
+                                                        <span class="graphic_element @c_category">@c_category</span>
+                                                        <span>
+                                                            Kombinasjon av populasjonsstørrelsen og underkriteriene gir til sammen kategori
+                                                            @if (c_comparison)
+                                                            {
+                                                                @c_category
+                                                            }
+                                                            else
+                                                            {
+                                                                <partial name="/Views/Shared/_Category.cshtml" />
+                                                            }
+                                                        </span>
+                                                    </span>
+                                                }
+                                                else
+                                                {
+                                                    <span>C-kriteriet er ikke gjeldende</span>
+                                                }
+                                            </p>
+                                        </span>
+                                    </span>
+                                </li>
+                            </ul>
+                        }
+
+                    }
+
+                    @if (@value.ContainsKey("options"))
+                    {
+                        <ul class="second">
+                            <li class="@Criteria.inString("B", @Model.CriteriaSummarized)">
                                 <span class="text_container">
                                     <span class="text_collection">
                                         <span class="title_field clickable" onclick="expandCriteria(this, 'opened_element')">
                                             @{expandOrBullet(true);}
-                                            <span class="text_text ">
-                                                @k - @v["title"]
-                                                @{iconChooser(subcriteria_isactive);}
+                                            <span class="text_text">
+                                                Underkriterier
                                             </span>
                                         </span>
-                                        <p>
-                                            @{ hasKey("description", v);}
-                                            @{ getGenerationTime(key, k);}
-                                            @{ getModel(k);}
-                                        </p>
-                                        @{ getQuantile(v, k, key);}
 
-                                        <!-- SUBCRITERIA SUBOPTIONS FOR A & C-CRITERIA && SUBOPTIONS FOR Ca2 -->
-
-                                        @if (v.ContainsKey("subsub"))
+                                        <!-- SUBCRITERIA SUBOPTIONS FOR B CRITERIA -->
+                                        @if (@value.ContainsKey("subcriteria"))
                                         {
-                                            string[] currentlist = Criteria.obtainSubCriteriaList(subcriteria[key].Split(";"), k);
-                                            var subdict = parseDictNested(@v["subsub"].ToString());
-                                            @if (currentlist.Length > 0)
-                                            {
-                                                @if (key == "A")
+                                            var thesubcriteria = parseDictNested(value["options"].ToString());
+                                            <ul class="second">
+                                                @foreach (var (k, v) in thesubcriteria)
                                                 {
-                                                    <p class="subheading"> <b>Kunnskapsgrunnlag</b></p>
-                                                }
-
-                                                <ul class="third activeornot">
-                                                    @foreach (var (subkey, subval) in subdict)
-                                                    {
-                                                        string modelkey = k + subkey;
-                                                        <li class="@Criteria.inList(subkey, currentlist)">
-                                                            <span class="text_container">
-                                                                <span class="text_collection">
-                                                                    <span class="title_field">
-                                                                        @{expandOrBullet(false);}
-                                                                        <span class="text_text">
-                                                                            @subkey - <span>@subval["title"] @{ iconChooser(Criteria.inList(subkey, currentlist)); }</span>
-                                                                        </span>
+                                                    var subcriteria_isactive = @Criteria.inString(k, subcriteria[key]);
+                                                    <li class=" @subcriteria_isactive">
+                                                        <span class="text_container">
+                                                            <span class="text_collection">
+                                                                <span class="title_field clickable" onclick="expandCriteria(this, 'opened_element')">
+                                                                    @{expandOrBullet(true);}
+                                                                    <span class="text_text ">
+                                                                        @k - @v["title"]
                                                                     </span>
-                                                                    @{ getQuantile(subval, modelkey, modelkey);}
+                                                                    @{iconChooser(subcriteria_isactive);}
                                                                 </span>
-                                                                <!-- SUBCRITERIA SUBOPTIONS FOR A & C-CRITERIA && SUBOPTIONS FOR Ca2 -->
-                                                            </span>
-                                                        </li>
-                                                    }
-                                                </ul>
 
+                                                                <!-- SUBCRITERIA SUBOPTIONS FOR B -->
 
-                                            }
-                                        }
-
-                                    </span>
-                                </span>
-
-                            </li>
-                        }
-                    </ul>
-                     if (key == "C"){
-                      <ul class="second">
-                        @{var activeC = @Criteria.inString("C", @Model.CriteriaSummarized); }
-                        <li class="@activeC">
-                            <span class="text_container">
-                                <span class="text_collection">
-                                    <span class="title_field" onclick="expandCriteria(this, 'opened_element')">
-                                        @{expandOrBullet(true);}
-                                        <span class="text_text clickable">
-                                            Konklusjon for C-kriteriet
-                                            <br />
-                                        </span>
-                                    </span>
-
-                                    @{
-                                        string c_category = Model.Category;
-                                        bool c_comparison = Model.Category.Length > 2 && !string.IsNullOrEmpty(Model.CategoryAdjustedFrom);
-                                        if (c_comparison)
-                                        {
-                                            c_category = Model.CategoryAdjustedFrom;
-                                        }
-                                    }
-                                    <p>
-                                        @if (activeC == "active")
-                                        {
-                                            <span class="b_summary">
-                                                <span class="graphic_element @c_category">@c_category</span>
-                                                <span>
-                                                    Kombinasjon av populasjonsstørrelsen og underkriteriene gir til sammen kategori
-                                                    @if (c_comparison)
-                                                    {
-                                                        @c_category
-                                                    }
-                                                    else
-                                                    {
-                                                        <partial name="/Views/Shared/_Category.cshtml" />
-                                                    }
-                                                </span>
-                                            </span>
-                                        }
-                                        else
-                                        {
-                                            <span>C-kriteriet er ikke gjeldende</span>
-                                        }
-                                    </p>
-                                </span>
-                            </span>
-                        </li>
-                    </ul>
-                    }
-
-                }
-                
-                @if (@value.ContainsKey("options"))
-                {
-                    <ul class="second">
-                        <li class="@Criteria.inString("B", @Model.CriteriaSummarized)">
-                            <span class="text_container">
-                                <span class="text_collection">
-                                    <span class="title_field clickable" onclick="expandCriteria(this, 'opened_element')">
-                                        @{expandOrBullet(true);}
-                                        <span class="text_text">
-                                            Underkriterier
-                                        </span>
-                                    </span>
-
-                                    <!-- SUBCRITERIA SUBOPTIONS FOR B CRITERIA -->
-                                    @if (@value.ContainsKey("subcriteria"))
-                                    {
-                                        var thesubcriteria = parseDictNested(value["options"].ToString());
-                                        <ul class="second">
-                                            @foreach (var (k, v) in thesubcriteria)
-                                            {
-                                                var subcriteria_isactive = @Criteria.inString(k, subcriteria[key]);
-                                                <li class=" @subcriteria_isactive">
-                                                    <span class="text_container">
-                                                        <span class="text_collection">
-                                                            <span class="title_field clickable" onclick="expandCriteria(this, 'opened_element')">
-                                                                @{expandOrBullet(true);}
-                                                                <span class="text_text ">
-                                                                    @k - @v["title"]
-                                                                </span>
-                                                                @{iconChooser(subcriteria_isactive);}
-                                                            </span>
-
-                                                            <!-- SUBCRITERIA SUBOPTIONS FOR B -->
-
-                                                            @if (v.ContainsKey("sub"))
-                                                            {
-                                                                <ul class="subsub_list">
-                                                                    @{
-                                                                        var currentlist = options.Split(";");
-                                                                        var current_element = "";
-                                                                        foreach (string element in currentlist)
-                                                                        {
-                                                                            if (element.Contains(k))
+                                                                @if (v.ContainsKey("sub"))
+                                                                {
+                                                                    <ul class="subsub_list">
+                                                                        @{
+                                                                            var currentlist = options.Split(";");
+                                                                            var current_element = "";
+                                                                            foreach (string element in currentlist)
                                                                             {
-                                                                                current_element = element;
+                                                                                if (element.Contains(k))
+                                                                                {
+                                                                                    current_element = element;
+                                                                                }
                                                                             }
+                                                                            current_element = current_element.Replace(k, "");
+                                                                            current_element = Criteria.removeOuterParenthesis(current_element);
+                                                                            var clean_list = current_element.Split(",");
+                                                                            var subdict = parseDictNested(@v["sub"].ToString());
                                                                         }
-                                                                        current_element = current_element.Replace(k, "");
-                                                                        current_element = Criteria.removeOuterParenthesis(current_element);
-                                                                        var clean_list = current_element.Split(",");
-                                                                        var subdict = parseDictNested(@v["sub"].ToString());
-                                                                    }
 
-                                                                    @foreach (var (subkey, subvalue) in subdict)
-                                                                    {
-                                                                        var modelkey = key + k + subkey;
-                                                                        string clickable = "";
-                                                                        if (modelkey == "Baii")
+                                                                        @foreach (var (subkey, subvalue) in subdict)
                                                                         {
-                                                                            clickable = "clickable";
-                                                                        }
-                                                                        <li class="listitem_criteria @Criteria.inList(subkey, clean_list)">
-                                                                            <span class="text_container">
-                                                                                <span class="text_collection">
-                                                                                    <span class="text_text @clickable" onclick="expandCriteria(this, 'opened_element')">
-                                                                                        @{expandOrBullet(clickable == "clickable");}
-                                                                                        @subkey - @subvalue["title"]
+                                                                            var modelkey = key + k + subkey;
+                                                                            string clickable = "";
+                                                                            if (modelkey == "Baii")
+                                                                            {
+                                                                                clickable = "clickable";
+                                                                            }
+                                                                            <li class="listitem_criteria @Criteria.inList(subkey, clean_list)">
+                                                                                <span class="text_container">
+                                                                                    <span class="text_collection">
+                                                                                        <span class="text_text @clickable" onclick="expandCriteria(this, 'opened_element')">
+                                                                                            @{expandOrBullet(clickable == "clickable");}
+                                                                                            @subkey - @subvalue["title"]
+                                                                                        </span>
+                                                                                        @{ iconChooser(Criteria.inList(subkey, clean_list)); }
                                                                                     </span>
-                                                                                    @{ iconChooser(Criteria.inList(subkey, clean_list)); }
+
                                                                                 </span>
-
-                                                                            </span>
-                                                                            @{ getQuantile(subvalue, modelkey, modelkey);}
-                                                                        </li>
-                                                                    }
-                                                                </ul>
-                                                            }
+                                                                                @{ getQuantile(subvalue, modelkey, modelkey);}
+                                                                            </li>
+                                                                        }
+                                                                    </ul>
+                                                                }
+                                                            </span>
                                                         </span>
-                                                    </span>
-                                                </li>
-                                            }
-                                        </ul>
-                                    }
-                                </span>
-                            </span>
-                        </li>
-                    </ul>
-                    <ul class="second">
-                        @{var activeB = @Criteria.inString("B", @Model.CriteriaSummarized); }
-                        <li class="@Criteria.inString("B", @Model.CriteriaSummarized)">
-                            <span class="text_container">
-                                <span class="text_collection">
-                                    <span class="title_field" onclick="expandCriteria(this, 'opened_element')">
-                                        @{expandOrBullet(true);}
-                                        <span class="text_text clickable">
-                                            Konklusjon for B-kriteriet
-                                            <br />
-                                        </span>
+                                                    </li>
+                                                }
+                                            </ul>
+                                        }
                                     </span>
-
-                                    @{
-                                        string b_category = Model.Category;
-                                        bool b_comparison = Model.Category.Length > 2 && !string.IsNullOrEmpty(Model.CategoryAdjustedFrom);
-                                        if (b_comparison)
-                                        {
-                                            b_category = Model.CategoryAdjustedFrom;
-                                        }
-                                    }
-                                    <p>
-                                        @if (activeB == "active")
-                                        {
-                                            <span class="b_summary">
-                                                <span class="graphic_element @b_category">@b_category</span>
-                                                <span>
-                                                    Kombinasjon av B1/B2 og underkriteriene gir til sammen kategori
-                                                    @if (b_comparison)
-                                                    {
-                                                        @b_category
-                                                    }
-                                                    else
-                                                    {
-                                                        <partial name="/Views/Shared/_Category.cshtml" />
-                                                    }
-                                                </span>
-                                            </span>
-                                        }
-                                        else
-                                        {
-                                            <span>B-kriteriet er ikke gjeldende</span>
-                                        }
-                                    </p>
                                 </span>
-                            </span>
-                        </li>
-                    </ul>
-                }
-            </li>
+                            </li>
+                        </ul>
+                        <ul class="second">
+                            @{var activeB = @Criteria.inString("B", @Model.CriteriaSummarized); }
+                            <li class="@Criteria.inString("B", @Model.CriteriaSummarized)">
+                                <span class="text_container">
+                                    <span class="text_collection">
+                                        <span class="title_field" onclick="expandCriteria(this, 'opened_element')">
+                                            @{expandOrBullet(true);}
+                                            <span class="text_text clickable">
+                                                Konklusjon for B-kriteriet
+                                                <br />
+                                            </span>
+                                        </span>
+
+                                        @{
+                                            string b_category = Model.Category;
+                                            bool b_comparison = Model.Category.Length > 2 && !string.IsNullOrEmpty(Model.CategoryAdjustedFrom);
+                                            if (b_comparison)
+                                            {
+                                                b_category = Model.CategoryAdjustedFrom;
+                                            }
+                                        }
+                                        <p>
+                                            @if (activeB == "active")
+                                            {
+                                                <span class="b_summary">
+                                                    <span class="graphic_element @b_category">@b_category</span>
+                                                    <span>
+                                                        Kombinasjon av B1/B2 og underkriteriene gir til sammen kategori
+                                                        @if (b_comparison)
+                                                        {
+                                                            @b_category
+                                                        }
+                                                        else
+                                                        {
+                                                            <partial name="/Views/Shared/_Category.cshtml" />
+                                                        }
+                                                    </span>
+                                                </span>
+                                            }
+                                            else
+                                            {
+                                                <span>B-kriteriet er ikke gjeldende</span>
+                                            }
+                                        </p>
+                                    </span>
+                                </span>
+                            </li>
+                        </ul>
+                    }
+                </li>
             }
         </ul>
     </div>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Habitat.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Habitat.cshtml
@@ -8,57 +8,64 @@
 *@
 
 @{
-//model IEnumerable<string>
-Dictionary<string, Dictionary<string, string>> habitat = ViewBag.habitat.ToObject<Dictionary<string, Dictionary<string, string>>>();
+    //model IEnumerable<string>
+    Dictionary<string, Dictionary<string, string>> habitat = ViewBag.habitat.ToObject<Dictionary<string, Dictionary<string, string>>>();
 
 
     void habitatFunction(string imageurl, string title, string description, string mapping, string active)
     {
-    <div class="habitat_element @active">
-        <div class="habitat_icon">
-            @if (imageurl != null)
+        <div class="habitat_element @active">
+            <div class="habitat_icon">
+                @if (imageurl != null)
+                {
+                    <img src=@imageurl alt="Foto som viser @title" />
+                }
+            </div>
+            @if (title != null)
             {
-                <img src=@imageurl alt="Foto som viser @title"/>
+                <b>@title</b>
+            }
+            @if (description != null)
+            {
+                <p class="expand_hide">
+                    @description
+
+                </p>
+            }
+            @if (mapping != null)
+            {
+
+                <p class="expand_hide">
+                    @Html.Raw(mapping)
+                </p>
+
+                <button class="tertiary tinybutton" onclick="expandHabitat(this, 'expanded')">
+                    <span class="more">
+                        Se mer
+                        <span class="material-icons">arrow_drop_down</span>
+                    </span>
+                    <span class="less">
+                        Se mindre
+                        <span class="material-icons">arrow_drop_up</span>
+                    </span>
+                </button>
             }
         </div>
-        @if (title != null)
-        {
-            <b>@title</b>
-        }
-        @if (description != null)
-        {
-            <p class="expand_hide">
-                @description
-
-            </p>
-        }
-        @if (mapping != null)
-        {
-
-            <p class="expand_hide">
-                @Html.Raw(mapping)
-            </p>
-
-            <button class="tertiary tinybutton" onclick="expandHabitat(this, 'expanded')">
-                <span class="more">
-                    Se mer 
-                    <span class="material-icons">arrow_drop_down</span>
-                </span>
-                <span class="less">
-                    Se mindre
-                    <span class="material-icons">arrow_drop_up</span>
-                </span>
-            </button>
-        }
-    </div>    
     }
 }
 
-<div class="habitat page_section ">
-    @if (@Model.MainHabitat.Count() != 0)
+
+@if (!Model.Category.Contains("LC") &&
+     !Model.Category.Contains("NA") &&
+     !Model.Category.Contains("NE") &&
+     !Model.Category.Contains("RE") || @Model.MainHabitat.Count() != 0)
     {
+
+    <div class="habitat page_section ">        
         <h2>@ViewBag.glossary["habitat"]["tagline"]</h2>
         <p>@Html.Raw(@ViewBag.glossary["habitat"]["description"])</p>
+
+        <p>@Model.MainHabitat.Count</p>
 
         <button class="changetab active" onclick="expandHabitat(this, 'see_all', 'remove')">
             Hovedhabitat
@@ -69,6 +76,16 @@ Dictionary<string, Dictionary<string, string>> habitat = ViewBag.habitat.ToObjec
         </button>
 
         <div class="habitat_container tabbed_element_container">
+
+            <div class="tablist_listheader">
+                <span class="summary_title">Artens hovedhabitat</span>
+                <span class="full_list_title">Alle habitat</span>
+                @if (Model.MainHabitat.Count == 0)
+                {
+                    <span class="no_elements">Det er ikke angitt hovedhabitat.</span>
+                }
+
+            </div>
             @foreach (var key in habitat.Keys)
             {
                 var imageurl = @habitat[key]["image"];
@@ -78,9 +95,8 @@ Dictionary<string, Dictionary<string, string>> habitat = ViewBag.habitat.ToObjec
                 var active = @Model.MainHabitat.Contains(key) ? "active" : "inactive";
                 habitatFunction(imageurl, title, description, mapping, active);
             }
-        </div>
-    }
-
+        </div>    
+    </div>
     <script>
         // See more text by altering css of the clicked element's top parent node
         var seemorebuttons = document.getElementsByClassName('seemore');
@@ -94,14 +110,14 @@ Dictionary<string, Dictionary<string, string>> habitat = ViewBag.habitat.ToObjec
                 element.parentElement.classList.add(className);
                 element.previousElementSibling.classList.remove("active");
                 element.classList.add("active");
-            } else {               
+            } else {
                 if (element.parentElement.classList.contains(className)) {
                     element.parentElement.classList.remove(className);
                 } else {
                     element.parentElement.classList.add(className);
-                }                
+                }
             }
-            
+
         }
     </script>
-</div>
+}

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Habitat.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Habitat.cshtml
@@ -65,8 +65,6 @@
         <h2>@ViewBag.glossary["habitat"]["tagline"]</h2>
         <p>@Html.Raw(@ViewBag.glossary["habitat"]["description"])</p>
 
-        <p>@Model.MainHabitat.Count</p>
-
         <button class="changetab active" onclick="expandHabitat(this, 'see_all', 'remove')">
             Hovedhabitat
         </button>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_ImpactFactors.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_ImpactFactors.cshtml
@@ -2,8 +2,7 @@
 
 @functions{
 
-    // Snatched and shortened from 2018 nature red list,
-    // Not yet ready for use.
+    // Reference for impact factors
     // https://github.com/Artsdatabanken/RodlisteNaturtyper2018visning/blob/2019update/Views/Home/Partials/impact-factors.cshtml
 
     string ImpactIcon(string id, string subtitle)
@@ -131,7 +130,10 @@
 }
 
 
-@{ if (!Model.Category.Contains("LC") && !Model.Category.Contains("NA") && !Model.Category.Contains("NE") && !Model.Category.Contains("RE"))
+@{ if (!Model.Category.Contains("LC") && 
+        !Model.Category.Contains("NA") && 
+        !Model.Category.Contains("NE") && 
+        !Model.Category.Contains("RE"))
     {
         <div class="page_section impact" id="impactfactors">
             <h2>Påvirkningsfaktorer </h2>
@@ -143,8 +145,13 @@
             <button id="full_list" class="changetab" onclick="impactlist('full_list',this)">Full liste</button>
             <br />
             <ul class="outer tabbed_element_container">
+                <li class="tablist_listheader">
+                    <span class="summary_title">Artens påvirkningsfaktorer</span>
+                    <span class="full_list_title">Alle påvirkningsfaktorer</span>
+                    <span class="no_elements">Ingen elementer valgt</span>
+                </li>
                 @foreach (var (key, value) in impactfactors_json)
-                {
+                {                
                 <li class="@activeOrNot(key)">
                     @{listHeaders(key, value, "addborder");}
                     @if (value.ContainsKey("subelement"))

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_ImpactFactors.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_ImpactFactors.cshtml
@@ -148,7 +148,11 @@
                 <li class="tablist_listheader">
                     <span class="summary_title">Artens påvirkningsfaktorer</span>
                     <span class="full_list_title">Alle påvirkningsfaktorer</span>
-                    <span class="no_elements">Ingen elementer valgt</span>
+                    @if (Model.ImpactFactors.Count == 0)
+                    {
+                        <span class="no_elements">Det er ikke angitt påvirkningsfaktorer.</span>
+                    }
+
                 </li>
                 @foreach (var (key, value) in impactfactors_json)
                 {                

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_PopulationProportions.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_PopulationProportions.cshtml
@@ -3,13 +3,14 @@
 @* // Section containing numbers for proportions of different population sizes. *@
 
 
+
 <div class="page_section populationsize">
 
     @if (Model.Category != "NE" && Model.Category != "NA")
     {
         @if (Helpers.isNotEmpty(Model.ProportionOfMaxPopulation) ||
-          Helpers.isNotEmpty(Model.PercentageEuropeanPopulation) ||
-          Helpers.isNotEmpty(Model.PercentageGlobalPopulation))
+        Helpers.isNotEmpty(Model.PercentageEuropeanPopulation) ||
+        Helpers.isNotEmpty(Model.PercentageGlobalPopulation))
         {
 
             <h3>@ViewBag.glossary["populationsize"]["title"]</h3>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_RegionStatistics.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_RegionStatistics.cshtml
@@ -10,10 +10,15 @@
     // This used to be a big table which was difficult to read on mobile platforms.
     // This may not be an optimal solution, but it is more universal than a checkbox that sometimes is included and sometimes not.
 
-    var has_element = "";
+    var has_element = string.Empty;
+    bool has_only_none = true;
     foreach (var element in Model.RegionOccurrences)
     {
         has_element += element.State;
+        if(element.State != 2)
+        {
+            has_only_none = false;
+        }
     }
 
     void area(string class2, string title)
@@ -28,74 +33,77 @@
     }
 }
 
-@if (has_element != "")
+@if (!Model.Category.Contains("LC") &&
+     !Model.Category.Contains("NA") &&
+     !Model.Category.Contains("NE") ||
+      !string.IsNullOrEmpty(has_element) && !has_only_none)
 { // No content would imply it exists nowhere or is recorded nowhere
-    <div class="geographic_facts">
-        <h3> @ViewBag.glossary["region"]["tagline"]</h3>
-        <p> @Html.Raw(@ViewBag.glossary["region"]["description"])</p>
+<div class="geographic_facts">
+    <h3> @ViewBag.glossary["region"]["tagline"]</h3>
+    <p> @Html.Raw(@ViewBag.glossary["region"]["description"])</p>
 
-        <h3>Geografisk distribusjon</h3>
+    <h3>Geografisk distribusjon</h3>
 
-        <div class="region_distributions @Model.AssessmentArea">
-            @if (Model.AssessmentArea == "N")
-            {
-                <ul class="regionlist">
-                    <li class="region_list_header">
-                        <b>Region</b>
-                        <span class="indicator"></span>
-                        <b>Forekomst</b>
+    <div class="region_distributions @Model.AssessmentArea">
+        @if (Model.AssessmentArea == "N")
+        {
+            <ul class="regionlist">
+                <li class="region_list_header">
+                    <b>Region</b>
+                    <span class="indicator"></span>
+                    <b>Forekomst</b>
+                </li>
+                @foreach (var region in Model.RegionOccurrences.OrderBy(x => Helpers.SortedRegions().IndexOf(x.Fylke)).Reverse())
+                {
+                    <li class="region">
+                        <p>@region.Fylke</p>
+                        <span class="area">
+                            @if (region.State == 0)
+                            {
+                                area("known", "Kjent");
+                            }
+                            else if (region.State == 1)
+                            {
+                                area("presumed", "Antatt");
+                            }
+                            else if (region.State == 2)
+                            {
+                                area("none", "Ingen");
+                            }
+                            else if (region.State == 3)
+                            {
+                                area("presumed_extinct", "Antatt Utdødd");
+                            }
+                            else if (region.State == 4)
+                            {
+                                area("extinct", "Utdødd");
+                            }
+                        </span>
                     </li>
-                    @foreach (var region in Model.RegionOccurrences.OrderBy(x => Helpers.SortedRegions().IndexOf(x.Fylke)).Reverse())
-                    {
-                        <li class="region">
-                            <p>@region.Fylke</p>
-                            <span class="area">
-                                @if (region.State == 0)
-                                {
-                                    area("known", "Kjent");
-                                }
-                                else if (region.State == 1)
-                                {
-                                    area("presumed", "Antatt");
-                                }
-                                else if (region.State == 2)
-                                {
-                                    area("none", "Ingen");
-                                }
-                                else if (region.State == 3)
-                                {
-                                    area("presumed_extinct", "Antatt Utdødd");
-                                }
-                                else if (region.State == 4)
-                                {
-                                    area("extinct", "Utdødd");
-                                }
-                            </span>
-                        </li>
-                    }
-                </ul>
-            }
-            else
-            {
-        <ul class="regionlist legend">
-            
-            <li class="region">
-                @{area("known", "Kjent");}
-            </li>
-            <li class="region">
-                @{area("presumed", "Antatt");}
-            </li>
-            <li class="region">
-                @{area("none", "Ingen");}
-            </li>
-            <li class="region">
-                @{area("presumed_extinct", "Antatt Utdødd");}
-            </li>
-            <li class="region">
-                @{area("extinct", "Utdødd");}
-            </li>
+                }
+            </ul>
+        }
+        else
+        {
+            <ul class="regionlist legend">
 
-        </ul>
+                <li class="region">
+                    @{area("known", "Kjent");}
+                </li>
+                <li class="region">
+                    @{area("presumed", "Antatt");}
+                </li>
+                <li class="region">
+                    @{area("none", "Ingen");}
+                </li>
+                <li class="region">
+                    @{area("presumed_extinct", "Antatt Utdødd");}
+                </li>
+                <li class="region">
+                    @{area("extinct", "Utdødd");}
+                </li>
+
+            </ul>
         }
         <div class="map @Model.AssessmentArea">
             @if (Model.AssessmentArea == "S")

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Regions.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Regions.cshtml
@@ -25,5 +25,6 @@
     <p>
         @ViewBag.glossary[distributionName]["description"]
     </p>
+
     <partial name="/Views/Redlist/Species/2021/Assessment/partials/_RegionStatistics.cshtml" />
 </div><!-- End section -->

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_SpeciesDetails.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_SpeciesDetails.cshtml
@@ -1,9 +1,34 @@
 ﻿@model SpeciesAssessment2021
 
+@{
+    bool hasDetails()
+    {
+        bool hasPopulationSize = false;
+        bool hasGenerationLength = false;
+
+        if (Helpers.isNotEmpty(Model.ProportionOfMaxPopulation) ||
+        Helpers.isNotEmpty(Model.PercentageEuropeanPopulation) ||
+        Helpers.isNotEmpty(Model.PercentageGlobalPopulation))
+        {
+            hasPopulationSize = true;
+        }
+        if (Helpers.isNotEmpty(Model.GenerationLength))
+        {
+            hasGenerationLength = true;
+        }
+
+        if (hasPopulationSize || hasGenerationLength)
+        { // If both are true, it will always be true regardless of check
+            return true;
+        }
+        return false;
+    }
+}
+
+@if (hasDetails()) {
 <div class="page_section">
     <h2> Detaljer</h2>
-    
     <partial name="/Views/Redlist/Species/2021/Assessment/partials/_PopulationProportions.cshtml" />
     <partial name="/Views/Redlist/Species/2021/Assessment/partials/_GenerationLength.cshtml" />
-    
 </div>
+}

--- a/Assessments.Frontend.Web/wwwroot/css/assessment.css
+++ b/Assessments.Frontend.Web/wwwroot/css/assessment.css
@@ -699,27 +699,31 @@ span.area i {
     background: pink;
 }
 
+.tablist_listheader{
+    display:block;
+    min-width:100%;
+}
+
 .full_list_title,
 .summary_title {
     font-family: 'Roboto Condensed', sans-serif;
     font-size: 14pt;
     padding-bottom: 10px;
+
 }
 
+.no_elements,
+.full_list_title,
+.full_list .summary_title,
+.full_list .no_elements,
+.see_all .summary_title,
+.see_all .no_elements {
+    display: none;
+}
+
+.see_all .full_list_title,
+.summary_title,
 .full_list .full_list_title,
-.summary .summary_title {
+.no_elements {
     display: block;
-}
-
-.summary .full_list_title ,
-.full_list .summary_title {
-    display:none;
-}
-
-.no_elements{
-    display:none;
-}
-
-.summary .no_elements{
-    display:block;
 }

--- a/Assessments.Frontend.Web/wwwroot/css/assessment.css
+++ b/Assessments.Frontend.Web/wwwroot/css/assessment.css
@@ -712,6 +712,11 @@ span.area i {
 
 }
 
+.full_list_description{
+    padding-bottom:10px;
+}
+
+.full_list_description,
 .no_elements,
 .full_list_title,
 .full_list .summary_title,
@@ -721,6 +726,7 @@ span.area i {
     display: none;
 }
 
+.full_list .full_list_description,
 .see_all .full_list_title,
 .summary_title,
 .full_list .full_list_title,

--- a/Assessments.Frontend.Web/wwwroot/css/assessment.css
+++ b/Assessments.Frontend.Web/wwwroot/css/assessment.css
@@ -698,3 +698,28 @@ span.area i {
     color: hotpink;
     background: pink;
 }
+
+.full_list_title,
+.summary_title {
+    font-family: 'Roboto Condensed', sans-serif;
+    font-size: 14pt;
+    padding-bottom: 10px;
+}
+
+.full_list .full_list_title,
+.summary .summary_title {
+    display: block;
+}
+
+.summary .full_list_title ,
+.full_list .summary_title {
+    display:none;
+}
+
+.no_elements{
+    display:none;
+}
+
+.summary .no_elements{
+    display:block;
+}

--- a/Assessments.Frontend.Web/wwwroot/css/search.css
+++ b/Assessments.Frontend.Web/wwwroot/css/search.css
@@ -2,8 +2,7 @@
 /* SEARCH FIELD REDLIST */
 
 .no_results {
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding:10px;
 }
 
 /* Container div for anything search*/


### PR DESCRIPTION
- testart for noen som kategorimessig KAN ha habitat og påvirkningsfaktor men ikke har det oppgitt: 37916
- skjuler geografi for NA, NE, LC -> med mindre noen har oppgitt en region som ikke er "ingen". altså at noen har oppgitt en eller anna form for distribusjon. Forsøket her er egentlig å skjule alle uten distribusjon, men også alle på NA/NE fordi de potensielt kan være gamle rester.
- Habitatboksen skjules på NA,NE,LC,RE - med mindre den  er oppgitt der. da vises den. Forhåpentligvis.
- påvirkningsfaktorer bør virke likt som habitat.
- kriterier skal vel i teorien aldri vises med mindre kriteriene er brukt. Er det optimalt? Uvisst. Men det er nå så.
- Disse tre har nå fått interne overskrifter, som sikkert ikke er optimale,
- Disse endrer seg mellom summary og full visning.
- Detaljer skal nå bare vises når det er innhold i den.

fixes #50 
fixes #419