### PR TITLE
Improve swagger title handling and fix swagger json 

### DIFF
--- a/Assessments.Frontend.Web/Controllers/HomeController.cs
+++ b/Assessments.Frontend.Web/Controllers/HomeController.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
 using Assessments.Frontend.Web.Infrastructure;
@@ -8,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Assessments.Frontend.Web.Controllers
 {
+    [ApiExplorerSettings(IgnoreApi = true)]
     public class HomeController : BaseController<HomeController>
     {
         public IActionResult Index()

--- a/Assessments.Frontend.Web/Startup.cs
+++ b/Assessments.Frontend.Web/Startup.cs
@@ -93,9 +93,9 @@ namespace Assessments.Frontend.Web
 
                 app.UseSwaggerUI(options =>
                 {
+                    options.DocumentTitle = "Assessments api - Artsdatabanken";
                     options.RoutePrefix = "swagger";
                     options.SwaggerEndpoint("v1/swagger.json", "Assessments api");
-                    options.InjectJavascript("/js/swagger.js");
                 });
             }
 

--- a/Assessments.Frontend.Web/wwwroot/js/swagger.js
+++ b/Assessments.Frontend.Web/wwwroot/js/swagger.js
@@ -1,5 +1,0 @@
-﻿(function () {
-    window.addEventListener("load", function () {
-        document.title = "Assessments api - " + document.title;
-    });
-})();


### PR DESCRIPTION
setter inn tittel på apiet via kode, som erstatter javascript
ignorerer homecontroller i api'et (lagt til for sitemap), slik at generering av json for swagger fungerer igjen

usikker på om tittel er ok ("Assessments api - Artsdatabanken"), men swagger fungerer bare lokalt i utviklingsmiljøet (#457)
swagger skal sikkert tas i bruk på et tidspunkt, vurdere om tittel skal endres da?