### PR TITLE
Add new role to expertcommittee member sorting (#521)

### DIFF
--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Citation.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Citation.cshtml
@@ -7,7 +7,9 @@
 
 @{
     var expertCommitteeMembers = await _expertCommitteeMemberService.GetExpertCommitteeMembers(Model.ExpertCommittee, Model.AssessmentYear);
-    var sortedExperts = @expertCommitteeMembers.OrderBy(x => x.Role).ThenBy(x => x.LastName); 
+    var sortedExperts = expertCommitteeMembers
+        .OrderBy(x => new List<string> {"leder", "nestleder", "medlem"}.IndexOf(x.Role.ToLowerInvariant()))
+        .ThenBy(x => x.LastName);  
     var formattedExperts = sortedExperts.Select(x => $"{x.LastName} {x.FirstNameInitals}").Distinct().ToList();
     string authors = formattedExperts.JoinAnd(", ", " og ");
     }


### PR DESCRIPTION
excelfilen med ekspertkomiteemedlemmene er oppdatert med ny rollle "Nestleder" (kun gjort på gruppen for karplanter)

har derfor lagt til rollene også i sorteringen (brukes til sitering på vurderinger), slik at rekkefølgen blir leder->nestleder->medlem - og så alfabetisk på etternavn

man må slette filen species-experts.csv i Cache mappen på webprosjektet for å se endringen lokalt (siden excelfilen brukt som kilde er oppdatert) - det skjer automatisk ved bygging til prod og test

fixes #521