### PR TITLE
Artbegrep

### DIFF
--- a/Assessments.Frontend.Web/Infrastructure/Helpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Helpers.cs
@@ -255,7 +255,7 @@ namespace Assessments.Frontend.Web.Infrastructure
 
         public static string getScientificNameElement(string scientificName)
         {
-            scientificName = "<i>"+scientificName+"</i>";
+            scientificName = "<i>" + scientificName + "</i>";
             scientificName = scientificName.Replace("×", "</i>×<i>");
             scientificName = scientificName.Replace("aff.", "</i>aff.<i>");
             scientificName = scientificName.Replace("agg.", "</i>agg.<i>");
@@ -267,6 +267,25 @@ namespace Assessments.Frontend.Web.Infrastructure
             scientificName = scientificName.Replace("' ", "'<i> ");
             scientificName = scientificName.Replace("<i></i>", "");
             return scientificName;
+        }
+
+        public static string fixSpeciesLevel(string replacestring,string rang)
+        {
+            if (rang == "SubSpecies" || rang == "Variety")
+            {
+                if (rang == "SubSpecies")
+                {
+                    replacestring = replacestring.Replace("art", "underart");
+                    replacestring = replacestring.Replace("Art", "Underart");
+                }
+                else if (rang == "Variety")
+                {
+                    replacestring = replacestring.Replace("art", "varietet");
+                    replacestring = replacestring.Replace("Art", "Varietet");
+                }
+            }
+            return replacestring;
+
         }
     }
 

--- a/Assessments.Frontend.Web/Infrastructure/Helpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Helpers.cs
@@ -273,15 +273,44 @@ namespace Assessments.Frontend.Web.Infrastructure
         {
             if (rang == "SubSpecies" || rang == "Variety")
             {
+                if (replacestring.StartsWith("art", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    // starter med art - uten mellomrom først
+                    if (replacestring[0] == 'A')
+                    {
+                        if (rang == "SubSpecies")
+                        {
+                            replacestring = "Underart" + replacestring.Substring(3); // fra tegn 4 og ut....
+                        }
+                        else if (rang == "Variety")
+                        {
+                            replacestring = "Varietet" + replacestring.Substring(3);
+                        }
+                    }
+                    else
+                    {
+                        //liten a - i tilfelle det ikke er en setning 
+                        if (rang == "SubSpecies")
+                        {
+                            replacestring = "underart" + replacestring.Substring(3);
+                        }
+                        else if (rang == "Variety")
+                        {
+                            replacestring = "varietet" + replacestring.Substring(3);
+                        }
+                    }
+                }
+
+                // art med mellomrom foran (unngå f.eks. kart)
                 if (rang == "SubSpecies")
                 {
-                    replacestring = replacestring.Replace("art", "underart");
-                    replacestring = replacestring.Replace("Art", "Underart");
+                    replacestring = replacestring.Replace(" art", "underart");
+                    replacestring = replacestring.Replace(" Art", "Underart");
                 }
                 else if (rang == "Variety")
                 {
-                    replacestring = replacestring.Replace("art", "varietet");
-                    replacestring = replacestring.Replace("Art", "Varietet");
+                    replacestring = replacestring.Replace(" art", "varietet");
+                    replacestring = replacestring.Replace(" Art", "Varietet");
                 }
             }
             return replacestring;

--- a/Assessments.Frontend.Web/Infrastructure/Helpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Helpers.cs
@@ -269,49 +269,25 @@ namespace Assessments.Frontend.Web.Infrastructure
             return scientificName;
         }
 
-        public static string fixSpeciesLevel(string replacestring,string rang)
+        public static string fixSpeciesLevel(string replacestring, string rang)
         {
             if (rang == "SubSpecies" || rang == "Variety")
             {
-                if (replacestring.StartsWith("art", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    // starter med art - uten mellomrom først
-                    if (replacestring[0] == 'A')
-                    {
-                        if (rang == "SubSpecies")
-                        {
-                            replacestring = "Underart" + replacestring.Substring(3); // fra tegn 4 og ut....
-                        }
-                        else if (rang == "Variety")
-                        {
-                            replacestring = "Varietet" + replacestring.Substring(3);
-                        }
-                    }
-                    else
-                    {
-                        //liten a - i tilfelle det ikke er en setning 
-                        if (rang == "SubSpecies")
-                        {
-                            replacestring = "underart" + replacestring.Substring(3);
-                        }
-                        else if (rang == "Variety")
-                        {
-                            replacestring = "varietet" + replacestring.Substring(3);
-                        }
-                    }
-                }
-
-                // art med mellomrom foran (unngå f.eks. kart)
                 if (rang == "SubSpecies")
                 {
-                    replacestring = replacestring.Replace(" art", "underart");
-                    replacestring = replacestring.Replace(" Art", "Underart");
+                    replacestring = replacestring.Replace("{art}", "underart");
+                    replacestring = replacestring.Replace("{Art}", "Underart");
                 }
                 else if (rang == "Variety")
                 {
-                    replacestring = replacestring.Replace(" art", "varietet");
-                    replacestring = replacestring.Replace(" Art", "Varietet");
+                    replacestring = replacestring.Replace("{art}", "varietet");
+                    replacestring = replacestring.Replace("{Art}", "Varietet");
                 }
+            }
+            else
+            {
+                replacestring = replacestring.Replace("{art}", "art");
+                replacestring = replacestring.Replace("{Art}", "Art");
             }
             return replacestring;
 

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_CategoryChange.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_CategoryChange.cshtml
@@ -34,7 +34,7 @@
         {
             <h3>Årsak til endring av kategori</h3>
             <p>
-                Kategorien for denne @Helpers.fixSpeciesLevel("arten", Model.TaxonRank) har endret seg fra @previous_category til @current_category siden Rødlista @which_redlist.
+                Kategorien for denne @Helpers.fixSpeciesLevel("{art}en", Model.TaxonRank) har endret seg fra @previous_category til @current_category siden Rødlista @which_redlist.
                 Endringen kommer på grunnlag av <span style="text-transform:lowercase">@Model.ReasonCategoryChange.Description()</span>.
             </p>
 

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_CategoryChange.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_CategoryChange.cshtml
@@ -26,23 +26,15 @@
 
         //UTEN GRADER MATCH
 
-
-
-
-
         @if (which_redlist != "2021" && previous_category != current_category)
         {
             <h3>Årsak til endring av kategori</h3>
             <p>
                 Kategorien for denne @Helpers.fixSpeciesLevel("{art}en", Model.TaxonRank) har endret seg fra @previous_category til @current_category siden Rødlista @which_redlist.
-                Endringen kommer på grunnlag av <span style="text-transform:lowercase">@Model.ReasonCategoryChange.Description()</span>.
+                Endringen kommer på grunnlag av <span style="text-transform:lowercase">
+                @Helpers.fixSpeciesLevel(@Model.ReasonCategoryChange.Description(), Model.TaxonRank)</span>.
             </p>
 
         }
     }
-
-
-
-
-
 </div>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_CategoryChange.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_CategoryChange.cshtml
@@ -34,7 +34,7 @@
         {
             <h3>Årsak til endring av kategori</h3>
             <p>
-                Kategorien for denne arten har endret seg fra @previous_category til @current_category siden Rødlista @which_redlist.
+                Kategorien for denne @Helpers.fixSpeciesLevel("arten", Model.TaxonRank) har endret seg fra @previous_category til @current_category siden Rødlista @which_redlist.
                 Endringen kommer på grunnlag av <span style="text-transform:lowercase">@Model.ReasonCategoryChange.Description()</span>.
             </p>
 

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Criteria.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Criteria.cshtml
@@ -113,8 +113,10 @@
     {
         @if (field.ContainsKey(key))
         {
+            var text = field[key].ToString();
+
             <p class="@key">
-                @Html.Raw(field[key])
+                @Html.Raw(Helpers.fixSpeciesLevel(text, Model.TaxonRank))
             </p>
         }
 
@@ -457,10 +459,10 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
         *@
         <ul class="outer noline">
             <li class="tablist_listheader">
-                <span class="summary_title">@Helpers.fixSpeciesLevel("Artens", Model.TaxonRank) kriterier</span>
+                <span class="summary_title">@Helpers.fixSpeciesLevel("{Art}ens", Model.TaxonRank) kriterier</span>
                 <span class="full_list_title">Alle kriterier</span>
                 <span class="full_list_description" style="display:none;">
-                    Gjeldende kriterier for @Helpers.fixSpeciesLevel("arten", Model.TaxonRank) er markert med merket
+                    Gjeldende kriterier for @Helpers.fixSpeciesLevel("{art}en", Model.TaxonRank) er markert med merket
                     <span class="impact_v">
                         <span class="material-icons">
                             done
@@ -476,11 +478,12 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
             @foreach (var (key, value) in criteria)
             {
                 string isactive = @Criteria.inString(key, @Model.CriteriaSummarized);
+                string valtitle = @Helpers.fixSpeciesLevel(value["title"].ToString(), Model.TaxonRank);
                 <li class="@isactive">
                     <span class="text_container clickable" onclick="expandCriteria(this, 'opened_element') ">
                         @{ expandOrBullet(true);}
-                        <span class="title_field">
-                            @key - @value["title"]
+                        <span class="title_field">                           
+                            @key - @valtitle
                             @{ iconChooser(Criteria.inString(key, Model.CriteriaSummarized)); }
                         </span>
                     </span>
@@ -497,6 +500,8 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
                         <ul class="second">
                             @foreach (var (k, v) in thesubcriteria)
                             {
+
+                                string vtitle = @Helpers.fixSpeciesLevel(v["title"].ToString(), Model.TaxonRank);
                                 var subcriteria_isactive = @Criteria.inString(k, subcriteria[key]);
                                 <li class=" @subcriteria_isactive">
                                     <span class="text_container">
@@ -504,7 +509,7 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
                                             <span class="title_field clickable" onclick="expandCriteria(this, 'opened_element')">
                                                 @{expandOrBullet(true);}
                                                 <span class="text_text ">
-                                                    @k - @v["title"]
+                                                    @k - @vtitle
                                                     @{iconChooser(subcriteria_isactive);}
                                                 </span>
                                             </span>
@@ -531,6 +536,8 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
                                                     <ul class="third activeornot">
                                                         @foreach (var (subkey, subval) in subdict)
                                                         {
+
+                                                            string subvaltitle = @Helpers.fixSpeciesLevel(subval["title"].ToString(), Model.TaxonRank);
                                                             string modelkey = k + subkey;
                                                             <li class="@Criteria.inList(subkey, currentlist)">
                                                                 <span class="text_container">
@@ -538,7 +545,7 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
                                                                         <span class="title_field">
                                                                             @{expandOrBullet(false);}
                                                                             <span class="text_text">
-                                                                                @subkey - <span>@subval["title"] @{ iconChooser(Criteria.inList(subkey, currentlist)); }</span>
+                                                                                @subkey - <span>@subvaltitle @{ iconChooser(Criteria.inList(subkey, currentlist)); }</span>
                                                                             </span>
                                                                         </span>
                                                                         @{ getQuantile(subval, modelkey, modelkey);}

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Criteria.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Criteria.cshtml
@@ -423,12 +423,18 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
 {
 <div class="page_section criteria" id="criteria">
     <div class="criteria_description">
-        <h3>@ViewBag.glossary["criteria"]["tagline"]</h3>
+        @{ 
+            string heading = ViewBag.glossary["criteria"]["tagline"];
+            heading = @Helpers.fixSpeciesLevel(heading, Model.TaxonRank);
+            string description = ViewBag.glossary["criteria"]["description"];
+            description = @Helpers.fixSpeciesLevel(description, Model.TaxonRank);
+        }
+        <h3>@heading</h3>
         <p>
-            @Html.Raw(ViewBag.glossary["criteria"]["description"])
+            @Html.Raw(description)
             <br />
             <a href="https://www.artsdatabanken.no/Pages/314252/Metode#316484" class="link-styled">Gå til metode</a>
-          </p>
+        </p>
        
         <h4>@ViewBag.glossary["criteria"]["subheading"]</h4>
         <p>@Model.CriteriaSummarized
@@ -451,10 +457,10 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
         *@
         <ul class="outer noline">
             <li class="tablist_listheader">
-                <span class="summary_title">Artens kriterier</span>
+                <span class="summary_title">@Helpers.fixSpeciesLevel("Artens", Model.TaxonRank) kriterier</span>
                 <span class="full_list_title">Alle kriterier</span>
                 <span class="full_list_description" style="display:none;">
-                    Gjeldende kriterier for arten er markert med merket
+                    Gjeldende kriterier for @Helpers.fixSpeciesLevel("arten", Model.TaxonRank) er markert med merket
                     <span class="impact_v">
                         <span class="material-icons">
                             done

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Criteria.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Criteria.cshtml
@@ -640,6 +640,7 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
                                             <ul class="second">
                                                 @foreach (var (k, v) in thesubcriteria)
                                                 {
+                                                    string vtitle = @v["title"].ToString();
                                                     var subcriteria_isactive = @Criteria.inString(k, subcriteria[key]);
                                                     <li class=" @subcriteria_isactive">
                                                         <span class="text_container">
@@ -647,7 +648,7 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
                                                                 <span class="title_field clickable" onclick="expandCriteria(this, 'opened_element')">
                                                                     @{expandOrBullet(true);}
                                                                     <span class="text_text ">
-                                                                        @k - @v["title"]
+                                                                        @k - @Helpers.fixSpeciesLevel(vtitle, Model.TaxonRank)
                                                                     </span>
                                                                     @{iconChooser(subcriteria_isactive);}
                                                                 </span>
@@ -675,6 +676,7 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
 
                                                                         @foreach (var (subkey, subvalue) in subdict)
                                                                         {
+                                                                            string vsubtitle = subvalue["title"].ToString();
                                                                             var modelkey = key + k + subkey;
                                                                             string clickable = "";
                                                                             if (modelkey == "Baii")
@@ -686,7 +688,7 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
                                                                                     <span class="text_collection">
                                                                                         <span class="text_text @clickable" onclick="expandCriteria(this, 'opened_element')">
                                                                                             @{expandOrBullet(clickable == "clickable");}
-                                                                                            @subkey - @subvalue["title"]
+                                                                                            @subkey - @Helpers.fixSpeciesLevel(vsubtitle, Model.TaxonRank)
                                                                                         </span>
                                                                                         @{ iconChooser(Criteria.inList(subkey, clean_list)); }
                                                                                     </span>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_GenerationLength.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_GenerationLength.cshtml
@@ -6,7 +6,7 @@
 {
     <h3>Generasjonstid</h3>
     <p>
-        <span> @Helpers.fixSpeciesLevel("Artens", Model.TaxonRank) generasjonstid er satt til @Model.GenerationLength år.</span><br/>
+        <span> @Helpers.fixSpeciesLevel("{Art}ens", Model.TaxonRank) generasjonstid er satt til @Model.GenerationLength år.</span><br/>
         @ViewBag.glossary["generasjonstid"]["description"]
     </p>
 

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_GenerationLength.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_GenerationLength.cshtml
@@ -6,7 +6,7 @@
 {
     <h3>Generasjonstid</h3>
     <p>
-        <span> Artens generasjonstid er satt til @Model.GenerationLength år.</span><br/>
+        <span> @Helpers.fixSpeciesLevel("Artens", Model.TaxonRank) generasjonstid er satt til @Model.GenerationLength år.</span><br/>
         @ViewBag.glossary["generasjonstid"]["description"]
     </p>
 

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Habitat.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Habitat.cshtml
@@ -63,7 +63,11 @@
 
     <div class="habitat page_section ">        
         <h2>@ViewBag.glossary["habitat"]["tagline"]</h2>
-        <p>@Html.Raw(@ViewBag.glossary["habitat"]["description"])</p>
+        <p>
+            @{string habitatdescription = ViewBag.glossary["habitat"]["description"];}
+            @Html.Raw(Helpers.fixSpeciesLevel(habitatdescription, Model.TaxonRank))
+        </p>
+
 
         <button class="changetab active" onclick="expandHabitat(this, 'see_all', 'remove')">
             Hovedhabitat
@@ -76,7 +80,7 @@
         <div class="habitat_container tabbed_element_container">
 
             <div class="tablist_listheader">
-                <span class="summary_title">Artens hovedhabitat</span>
+                <span class="summary_title">@Helpers.fixSpeciesLevel("Artens", Model.TaxonRank) hovedhabitat</span>
                 <span class="full_list_title">Alle habitat</span>
                 @if (Model.MainHabitat.Count == 0)
                 {

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Habitat.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Habitat.cshtml
@@ -80,7 +80,7 @@
         <div class="habitat_container tabbed_element_container">
 
             <div class="tablist_listheader">
-                <span class="summary_title">@Helpers.fixSpeciesLevel("Artens", Model.TaxonRank) hovedhabitat</span>
+                <span class="summary_title">@Helpers.fixSpeciesLevel("{Art}ens", Model.TaxonRank) hovedhabitat</span>
                 <span class="full_list_title">Alle habitat</span>
                 @if (Model.MainHabitat.Count == 0)
                 {

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_ImpactFactors.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_ImpactFactors.cshtml
@@ -78,6 +78,7 @@
     void listHeaders(string key, Dictionary<string, object> value, string addborder)
     {
         string has_table = "";
+        string vtitle = @value["title"].ToString();
         foreach (var factor in Model.ImpactFactors)
         {
             @if (factor.Id == (key))
@@ -86,12 +87,11 @@
             }
         }
         <span class="text_container @has_table" onclick="expandImpact(this, 'opened_element')">
-
             <span class="text_collection">
                 <span class="title_field  @isClickableClass(value)">
-                    @{ toggleChooser(value);}
-                    <span class="text_text">
-                        @value["title"]
+                    @{toggleChooser(value);}
+                    <span class="text_text">                       
+                        @Helpers.fixSpeciesLevel(vtitle, Model.TaxonRank)
                         @{iconChooser(activeOrNot(key));}
                     </span>
                 </span>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_ImpactFactors.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_ImpactFactors.cshtml
@@ -138,7 +138,7 @@
         <div class="page_section impact" id="impactfactors">
             <h2>Påvirkningsfaktorer </h2>
             <p>
-                Nedenfor listes det opp forskjellige påvirkningsfaktorer som kan gi utslag for rødlisting av arten.
+                Nedenfor listes det opp forskjellige påvirkningsfaktorer som kan gi utslag for rødlisting av @Helpers.fixSpeciesLevel("arten", Model.TaxonRank).
             </p>
 
             <button id="summary" class="changetab active" onclick="impactlist('summary',this)">Oppsummering</button>
@@ -146,7 +146,7 @@
             <br />
             <ul class="outer tabbed_element_container">
                 <li class="tablist_listheader">
-                    <span class="summary_title">Artens påvirkningsfaktorer</span>
+                    <span class="summary_title">@Helpers.fixSpeciesLevel("Artens", Model.TaxonRank) påvirkningsfaktorer</span>
                     <span class="full_list_title">Alle påvirkningsfaktorer</span>
                     @if (Model.ImpactFactors.Count == 0)
                     {

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_ImpactFactors.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_ImpactFactors.cshtml
@@ -138,7 +138,7 @@
         <div class="page_section impact" id="impactfactors">
             <h2>Påvirkningsfaktorer </h2>
             <p>
-                Nedenfor listes det opp forskjellige påvirkningsfaktorer som kan gi utslag for rødlisting av @Helpers.fixSpeciesLevel("arten", Model.TaxonRank).
+                Nedenfor listes det opp forskjellige påvirkningsfaktorer som kan gi utslag for rødlisting av @Helpers.fixSpeciesLevel("{art}en", Model.TaxonRank).
             </p>
 
             <button id="summary" class="changetab active" onclick="impactlist('summary',this)">Oppsummering</button>
@@ -146,7 +146,7 @@
             <br />
             <ul class="outer tabbed_element_container">
                 <li class="tablist_listheader">
-                    <span class="summary_title">@Helpers.fixSpeciesLevel("Artens", Model.TaxonRank) påvirkningsfaktorer</span>
+                    <span class="summary_title">@Helpers.fixSpeciesLevel("{Art}ens", Model.TaxonRank) påvirkningsfaktorer</span>
                     <span class="full_list_title">Alle påvirkningsfaktorer</span>
                     @if (Model.ImpactFactors.Count == 0)
                     {

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_InclusionCriteria.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_InclusionCriteria.cshtml
@@ -56,8 +56,8 @@
 
 
 <div class="page_section inclusion_section">
-    <h3>@heading</h3>
-    <p>@Html.Raw(reason)</p>
+    <h3>@Helpers.fixSpeciesLevel(heading, Model.TaxonRank)</h3>
+    <p>@Html.Raw(Helpers.fixSpeciesLevel(reason, Model.TaxonRank))</p>
    
     <a class="link-styled" href="https://www.artsdatabanken.no/Pages/316561/Nasjonale_tilpasninger">
         Hvilke arter vurderes?

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Ingress.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Ingress.cshtml
@@ -41,7 +41,7 @@
         }
         else
         {
-            <span>@Helpers.fixSpeciesLevel("Arten", Model.TaxonRank) er </span>
+            <span>@Helpers.fixSpeciesLevel("{Art}en", Model.TaxonRank) er </span>
             @if (Model.Category != "NA" && Model.Category != "NE")
             {
                 <span>vurdert til </span>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Ingress.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Ingress.cshtml
@@ -1,4 +1,5 @@
 ﻿@model SpeciesAssessment2021
+@using static Assessments.Frontend.Web.Infrastructure.Helpers
 @{
     // Obtain which criteria are used and their titles.
     var subcriteria = Criteria.sortCriteria(Model.CriteriaSummarized);
@@ -21,7 +22,7 @@
                 sentence += current.ToLower();
             }
         }
-        if(Model.Category.Length > 2)
+        if (Model.Category.Length > 2)
         {
             sentence += ", og ble <a href='#nedgradert'>nedgradert</a> på grunn av populasjoner i nærliggende regioner";
         }
@@ -41,20 +42,20 @@
         }
         else
         {
-            <span>Arten er </span>
+            <span>@Helpers.fixSpeciesLevel("Arten", Model.TaxonRank) er </span>
             @if (Model.Category != "NA" && Model.Category != "NE")
             {
                 <span>vurdert til </span>
             }
             <partial name="/Views/Shared/_Category.cshtml" /> <span class="">@Helpers.findDegrees(Model.Category, true)</span><span>
-                
+
                 @if (@Model.Category == "CR" && @Model.PresumedExtinct == true)
                 {
-                <span>for Norsk rødliste for arter 2021, og er trolig utdødd.</span>
+                    <span>for Norsk rødliste for arter 2021, og er trolig utdødd.</span>
                 }
                 else
                 {
-                  <span>for Norsk rødliste for arter 2021.</span>
+                    <span>for Norsk rødliste for arter 2021.</span>
                 }
                 @Html.Raw(sentence)
             </span>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Ingress.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Ingress.cshtml
@@ -1,5 +1,4 @@
 ﻿@model SpeciesAssessment2021
-@using static Assessments.Frontend.Web.Infrastructure.Helpers
 @{
     // Obtain which criteria are used and their titles.
     var subcriteria = Criteria.sortCriteria(Model.CriteriaSummarized);

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Map.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Map.cshtml
@@ -1,7 +1,6 @@
 ﻿@model SpeciesAssessment2021
 @*
-    Norwegian name and scientific name with and without autor.
-    Codeblock from Innsynsløsninga 2021 by SN. Modified by HEM for launch.
+   Map of Norway with svalbard
 *@
 
 @functions{

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_MapSvalbard.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_MapSvalbard.cshtml
@@ -1,7 +1,6 @@
 ﻿@model SpeciesAssessment2021
 @*
-    Norwegian name and scientific name with and without autor.
-    Codeblock from Innsynsløsninga 2021 by SN. Modified by HEM for launch.
+    Map of Svalbard 
 *@
 
 @functions{

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_NoCriteria.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_NoCriteria.cshtml
@@ -3,10 +3,10 @@
 @if (Model.Category.Contains("LC"))
 {
     <h3>
-        Hvorfor er ikke denne @Helpers.fixSpeciesLevel("arten", Model.TaxonRank) rødlistet?
+        Hvorfor er ikke denne @Helpers.fixSpeciesLevel("{art}en", Model.TaxonRank) rødlistet?
     </h3>
     <p>
-        Denne @Helpers.fixSpeciesLevel("arten", Model.TaxonRank) oppfyller ikke kriteriene for rødlisting.
+        Denne @Helpers.fixSpeciesLevel("{art}en", Model.TaxonRank) oppfyller ikke kriteriene for rødlisting.
         Den vurderes derfor til kategorien <i>livskraftig</i> LC.
     </p>
     <a class="link-styled" href="https://www.artsdatabanken.no/rodlisteforarter2021/Metode#193097">

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_NoCriteria.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_NoCriteria.cshtml
@@ -3,7 +3,7 @@
 @if (Model.Category.Contains("LC"))
 {
     <h3>
-        Hvorfor er ikke denne arten rødlistet?
+        Hvorfor er ikke denne @Helpers.fixSpeciesLevel("arten", Model.TaxonRank) rødlistet?
     </h3>
     <p>
         Denne @Helpers.fixSpeciesLevel("arten", Model.TaxonRank) oppfyller ikke kriteriene for rødlisting.

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_NoCriteria.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_NoCriteria.cshtml
@@ -6,7 +6,7 @@
         Hvorfor er ikke denne arten rødlistet?
     </h3>
     <p>
-        Denne arten oppfyller ikke kriteriene for rødlisting.
+        Denne @Helpers.fixSpeciesLevel("arten", Model.TaxonRank) oppfyller ikke kriteriene for rødlisting.
         Den vurderes derfor til kategorien <i>livskraftig</i> LC.
     </p>
     <a class="link-styled" href="https://www.artsdatabanken.no/rodlisteforarter2021/Metode#193097">

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_PopulationProportions.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_PopulationProportions.cshtml
@@ -16,7 +16,8 @@
             <h3>@ViewBag.glossary["populationsize"]["title"]</h3>
 
             <p>
-                @ViewBag.glossary["populationsize"]["description"]
+                @{string description = ViewBag.glossary["populationsize"]["description"];}
+                @Html.Raw(Helpers.fixSpeciesLevel(description, Model.TaxonRank))
             </p>
 
             <h4>@ViewBag.glossary["populationsize"]["subtitle"]</h4>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_RegionStatistics.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_RegionStatistics.cshtml
@@ -40,7 +40,8 @@
 { // No content would imply it exists nowhere or is recorded nowhere
 <div class="geographic_facts">
     <h3> @ViewBag.glossary["region"]["tagline"]</h3>
-    <p> @Html.Raw(@ViewBag.glossary["region"]["description"])</p>
+    @{string description = ViewBag.glossary["region"]["description"];}
+    @Html.Raw(Helpers.fixSpeciesLevel(description, Model.TaxonRank))
 
     <h3>Geografisk distribusjon</h3>
 

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Regions.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Regions.cshtml
@@ -7,7 +7,7 @@
     {
         distributionName = "vurdert_N";
     }
-    else if(Model.AssessmentArea == "S")
+    else if (Model.AssessmentArea == "S")
     {
         if (Model.SpeciesGroup == "Pattedyr")
         {
@@ -21,9 +21,10 @@
 }
 
 <div class="page_section @distributionName">
-    <h2>Vurderingsområde og artens utbredelse</h2>
+    <h2>Vurderingsområde og @Helpers.fixSpeciesLevel("artens", Model.TaxonRank) utbredelse</h2>
     <p>
-        @ViewBag.glossary[distributionName]["description"]
+        @{string description = ViewBag.glossary[distributionName]["description"];}        
+        @Helpers.fixSpeciesLevel(description, Model.TaxonRank)
     </p>
 
     <partial name="/Views/Redlist/Species/2021/Assessment/partials/_RegionStatistics.cshtml" />

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Regions.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Regions.cshtml
@@ -21,7 +21,7 @@
 }
 
 <div class="page_section @distributionName">
-    <h2>Vurderingsområde og @Helpers.fixSpeciesLevel("artens", Model.TaxonRank) utbredelse</h2>
+    <h2>Vurderingsområde og @Helpers.fixSpeciesLevel("{art}ens", Model.TaxonRank) utbredelse</h2>
     <p>
         @{string description = ViewBag.glossary[distributionName]["description"];}        
         @Helpers.fixSpeciesLevel(description, Model.TaxonRank)

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_SidebarContent.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_SidebarContent.cshtml
@@ -15,7 +15,7 @@
     <img src="https://design.artsdatabanken.no/list-icons/taxon-icon.png" alt="Logobilde for artssiden"/>
     <br />
     <a href="@taxon_url" class="link-styled">
-        Til artssiden
+        Til @Helpers.fixSpeciesLevel("artssiden", Model.TaxonRank)
     </a>
 
     <hr />

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_SidebarContent.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_SidebarContent.cshtml
@@ -15,7 +15,7 @@
     <img src="https://design.artsdatabanken.no/list-icons/taxon-icon.png" alt="Logobilde for artssiden"/>
     <br />
     <a href="@taxon_url" class="link-styled">
-        Til @Helpers.fixSpeciesLevel("artssiden", Model.TaxonRank)
+        Til @Helpers.fixSpeciesLevel("{art}ssiden", Model.TaxonRank)
     </a>
 
     <hr />

--- a/Assessments.Frontend.Web/wwwroot/json/categories.json
+++ b/Assessments.Frontend.Web/wwwroot/json/categories.json
@@ -1,7 +1,7 @@
 ﻿{
   "RE": {
     "tagline": "Regionalt utdødd",
-    "description": "– det er svært liten tvil om at arten er dødd ut/har emigrert fra vurderingsområdet.",
+    "description": "– det er svært liten tvil om at {art}en er dødd ut/har emigrert fra vurderingsområdet.",
     "presentationstring": "regionalt utdødd "
   },
   "CR": {

--- a/Assessments.Frontend.Web/wwwroot/json/enums.json
+++ b/Assessments.Frontend.Web/wwwroot/json/enums.json
@@ -21,7 +21,7 @@
     },
     "NewSpecies":
     {
-      "title": "Arten nyoppdaget eller nybeskrevet for landet"
+      "title": "{Art}en nyoppdaget eller nybeskrevet for landet"
     },
     "TaxonomicChange":
     {
@@ -33,15 +33,15 @@
     },
     "NotEvaluated2010":
     {
-      "title": "Ikke vurdert: NA/NE art 2010"
+      "title": "Ikke vurdert: NA/NE {art} 2010"
     },
     "NotEvaluated2015":
     {
-      "title": "Ikke vurdert: NA/NE art 2015"
+      "title": "Ikke vurdert: NA/NE {art} 2015"
     },
     "NotEvaluated2021":
     {
-      "title": "Ikke vurdert: NA/NE art 2021"
+      "title": "Ikke vurdert: NA/NE {art} 2021"
     }
   }
 }

--- a/Assessments.Frontend.Web/wwwroot/json/glossary.json
+++ b/Assessments.Frontend.Web/wwwroot/json/glossary.json
@@ -5,15 +5,15 @@
   },
   "habitat": {
     "tagline": "Habitat",
-    "description": "Artens <a href=\"https://www.artsdatabanken.no/Pages/314252/Metode#316492\">habitat</a> er dens viktigste leveområder. I vurderingene er det laget noen predefinerte habitat basert på inndeling etter <a href=\"https://artsdatabanken.no/NiN/Natursystem/Typeinndeling\">Natur i Norge (NiN)</a> systemet."
+    "description": "{Art}ens <a href=\"https://www.artsdatabanken.no/Pages/314252/Metode#316492\">habitat</a> er dens viktigste leveområder. I vurderingene er det laget noen predefinerte habitat basert på inndeling etter <a href=\"https://artsdatabanken.no/NiN/Natursystem/Typeinndeling\">Natur i Norge (NiN)</a> systemet."
   },
   "region": {
     "tagline": "Regioner og havområder ",
-    "description": " En art er forekommende i et (historisk) fylke eller havområde hvis vesentlige deler av livssyklusen foregår der. <i>Kjent</i> forekomst betyr kjent eller sannsynlig nåværende forekomst. <i>Antatt</i> forekomst brukes om mulig forekomst (basert på eldre observasjoner eller biogeografiske antagelser). <i>Antatt utdødd</i> forekomst brukes når arten muligens har dødd ut lokalt, mens <i>utdødd</i> forekomst betyr at det er overveiende sannsynlighet for at arten har dødd ut i området. Marine arter regnes som forekommende i kystfylker om de opptrer innenfor norsk territorialfarvann ved fylket. Kartet viser den historiske fylkesinndelingen per 1. januar 2018."
+    "description": " En {art} er forekommende i et (historisk) fylke eller havområde hvis vesentlige deler av livssyklusen foregår der. <i>Kjent</i> forekomst betyr kjent eller sannsynlig nåværende forekomst. <i>Antatt</i> forekomst brukes om mulig forekomst (basert på eldre observasjoner eller biogeografiske antagelser). <i>Antatt utdødd</i> forekomst brukes når {art}en muligens har dødd ut lokalt, mens <i>utdødd</i> forekomst betyr at det er overveiende sannsynlighet for at {art}en har dødd ut i området. Marine {art}er regnes som forekommende i kystfylker om de opptrer innenfor norsk territorialfarvann ved fylket. Kartet viser den historiske fylkesinndelingen per 1. januar 2018."
   },
   "criteria": {
-    "tagline": "Hvilke kriterier gjør at denne arten er rødlistet?",
-    "description": "Arten vurderes mot et sett kriterier, og de(t) som gir høyest kategori blir gjeldende. ",
+    "tagline": "Hvilke kriterier gjør at denne {art}en er rødlistet?",
+    "description": "{Art}en vurderes mot et sett kriterier, og de(t) som gir høyest kategori blir gjeldende. ",
     "subheading": "Gjeldende kriterier"
   },
   "generasjonstid": {
@@ -22,7 +22,7 @@
   },
   "TroligUtdodd": {
     "tagline": "Trolig utdødd",
-    "description": "– merkelapp på arter vurdert som <i>kritisk truet</i> CR når det mistenkes, men ikke kan fastslås med sikkerhet, at arten er utdødd."
+    "description": "– merkelapp på {art}er vurdert som <i>kritisk truet</i> CR når det mistenkes, men ikke kan fastslås med sikkerhet, at {art}en er utdødd."
   },
   "vurdert_N": {
     "tagline": "Vurdert for Norge",
@@ -38,7 +38,7 @@
   },
   "populationsize": {
     "title": "Populasjonsandel",
-    "description": "En art er ikke nødvendigvis begrenset til norske områder. Men populasjonen i norske områder utgjør noen ganger en betydelig andel av den totale populasjonen.",
+    "description": "En {art} er ikke nødvendigvis begrenset til norske områder. Men populasjonen i norske områder utgjør noen ganger en betydelig andel av den totale populasjonen.",
     "subtitle": "Nåværende populasjonsstørrelse i vurderingsområdet utgjør:",
     "AndelNåværendeBestand": "av maksimum populasjonsstørrelse etter år 1900 i samme område",
     "MaxAndelAvEuropeiskBestand": "av europeisk populasjonsstørrelse",
@@ -49,9 +49,8 @@
     "description": "Kategori med grader er kategori etter nedgradering/oppgradering av den opprinnelige kategorien (satt etter kriteriene) for vurderingsområdet. Denne justeringen blir gjort når utdøingsrisiko i vurderingsområdet er sterkt påvirket av bestander i naboregioner."
   },
   "oneliners": {
-    "litentvil": "Det er svært liten tvil om at arten er utdødd fra",   
-    "Påvirkningsfaktorer": "Påvirkningsfaktorer er i hovedsak menneskeskapte faktorer som antas å påvirke arten negativt. Klassifiseringssystemet for påvirkningsfaktorer er hierarkisk. Valg av påvirkningsfaktor på et overordnet nivå, eks. \"Påvirkning på habitat\" betyr ikke at alle underliggende nivå nødvendigvis er oppfylt, men at det kan være usikkert hvilke påvirkningsfaktorer på de lavere nivåene som gjør seg gjeldende for arten. For hver påvirkningsfaktor er tidsrom, omfang og alvorlighetsgrad angitt. Omfang og alvorlighetsgrad er relativt til den totale populasjonsstørrelsen eller forekomstarealet.",
-    "habitat_description_2015": "<p>I Rødlista 2015 benyttes Naturtyper i Norge (NiN 1.0) som klassifiseringssystem for å beskrive artenes leveområder (Halvorsen mfl. 2009). Dette klassifiseringssystemet har 4 naturtypenivå: i) landskap, ii) landskapsdel, iii) natursystem, og iv) livsmedium. Mer detaljert informasjon finnes i <a href=\"http://artsdatabanken.no/Files/16095\">veilederen til rødlistevurdering</a>(pdf) og <a href=\"http://www.artsdatabanken.no/NaturiNorge\">Naturtypebasen</a>. Ved registrering av artenes leveområde (hovedhabitat), inkluderes bare de leveområdene som er viktigst for arten. Det innebærer at habitatet skal være relevant for mer enn 20 % av bestanden.</p>",
+    "litentvil": "Det er svært liten tvil om at {art}en er utdødd fra",
+    "Påvirkningsfaktorer": "Påvirkningsfaktorer er i hovedsak menneskeskapte faktorer som antas å påvirke {art}en negativt. Klassifiseringssystemet for påvirkningsfaktorer er hierarkisk. Valg av påvirkningsfaktor på et overordnet nivå, eks. \"Påvirkning på habitat\" betyr ikke at alle underliggende nivå nødvendigvis er oppfylt, men at det kan være usikkert hvilke påvirkningsfaktorer på de lavere nivåene som gjør seg gjeldende for {art}en. For hver påvirkningsfaktor er tidsrom, omfang og alvorlighetsgrad angitt. Omfang og alvorlighetsgrad er relativt til den totale populasjonsstørrelsen eller forekomstarealet.",
     "min": "Minimum (min): ",
     "max": "Maximum (max): ",
     "probable": "Mest trolig",
@@ -61,13 +60,13 @@
   },
   "inkluderingskriterier": {
     "hvorfor": {
-      "title": "Hvorfor er denne arten vurdert?",
-      "description": "Denne arten er rødlistevurdert fordi den ",
+      "title": "Hvorfor er denne {art}en vurdert?",
+      "description": "Denne {art}en er rødlistevurdert fordi den ",
       "else": " enten har etablert bestand i vurderingsområdet, er en regelmessig gjest eller er etablert før 1800."
     },
     "EtablertFør1800": {
-      "title": "er en fremmedart som ble etablert før 1800",
-      "description": "Det vil si at den er en fremmedart, men er antatt eller dokumentert etablert med fast reproduserende populasjon per år 1800. "
+      "title": "er en fremmed{art} som ble etablert før 1800",
+      "description": "Det vil si at den er en fremmed{art}, men er antatt eller dokumentert etablert med fast reproduserende populasjon per år 1800. "
     },
     "EtablertBestandINorge": {
       "title": "har en etablert populasjon i vurderingsområdet",
@@ -78,65 +77,65 @@
       "description": "Det vil si at den ikke er fast reproduserende, men mer enn 2 % av global populasjon oppholder seg regelmessig innenfor vurderingsområdet i deler av sin års-/livssyklus."
     },
     "hvorforikke": {
-      "title": "Hvorfor er ikke arten ",
+      "title": "Hvorfor er ikke {art}en ",
       "NA": "egnet?",
       "NE": "vurdert?"
     },
     "IkkeReproduserendeGjestNA": {
       "title": "Ikke reproduserende gjest",
-      "description": "Arten er ikke etablert med fast reproduserende populasjon og mindre enn 2 % av global populasjon oppholder seg regelmessig innenfor vurderingsområdet (gjest)."
+      "description": "{Art}en er ikke etablert med fast reproduserende populasjon og mindre enn 2 % av global populasjon oppholder seg regelmessig innenfor vurderingsområdet (gjest)."
     },
     "FremmedArtNA": {
-      "title": "Fremmedart",
-      "description": "Arten er fremmed, og ble enten etablert innenfor vurderingsområdet etter år 1800 eller antas å kunne etablere seg innen 50 år (<a href=\"http://www.artsdatabanken.no/Pages/241513/Fleire_artar_bankar_paa\">dørstokkart</a>). "
+      "title": "Fremmed{art}",
+      "description": "{Art}en er fremmed, og ble enten etablert innenfor vurderingsområdet etter år 1800 eller antas å kunne etablere seg innen 50 år (<a href=\"http://www.artsdatabanken.no/Pages/241513/Fleire_artar_bankar_paa\">dørstokk{art}</a>). "
     },
     "ObservertReproduserendeIkkeEtablertNA": {
       "title": "Ikke etablert reproduserende",
-      "description": "Arten er observert reproduserende innenfor vurderingsområdet, men antas å ikke være etablert med fast reproduserende populasjon."
+      "description": "{Art}en er observert reproduserende innenfor vurderingsområdet, men antas å ikke være etablert med fast reproduserende populasjon."
     },
     "ObservertReproduktivIkkeEtablertNA": {
       "title": "Ikke etablert reproduserende ",
-      "description": "Arten er observert i reproduktivt stadium innenfor vurderingsområdet, men antas å ikke være etablert med fast reproduserende populasjon."
+      "description": "{Art}en er observert i reproduktivt stadium innenfor vurderingsområdet, men antas å ikke være etablert med fast reproduserende populasjon."
     },
     "UregelmessigGjestIkkeReproduserendeNA": {
       "title": "Uregelmessig gjest",
-      "description": "Arten opptrer uregelmessig innenfor vurderingsområdet, da som en følge av naturlig forflyttning."
+      "description": "{Art}en opptrer uregelmessig innenfor vurderingsområdet, da som en følge av naturlig forflyttning."
     },
     "IkkeDokumentertForekomstNA": {
       "title": "Ikke dokumentert forekomst",
-      "description": "Arten har ikke dokumentert forekomst innenfor vurderingsområdet."
+      "description": "{Art}en har ikke dokumentert forekomst innenfor vurderingsområdet."
     },
     "HybridartUtenReproduksjonNA": {
-      "title": "Hybridart uten reproduksjon",
-      "description": "Hybridart uten reproduksjon."
+      "title": "Hybrid{art} uten reproduksjon",
+      "description": "Hybrid{art} uten reproduksjon."
     },
     "HybridartUvisstOmReproduserendeNA": {
-      "title": "Hybridart - uvisst om er reproduserende",
-      "description": "Hybridart, men uvisst om den er reproduserende. "
+      "title": "Hybrid{art} - uvisst om er reproduserende",
+      "description": "Hybrid{art}, men uvisst om den er reproduserende. "
     },
     "ForekommerBareIHybridkombinasjonNA": {
       "title": "Forekommer bare i hybridkombinasjon",
-      "description": "Arten forekommer bare i hybridkombinasjon i vurderingsområdet."
+      "description": "{Art}en forekommer bare i hybridkombinasjon i vurderingsområdet."
     },
     "MangelfullKunnskapNE": {
       "title": "Mangelfull kunnskap",
-      "description": "Arten er ikke forsøkt rødlistevurdert på grunn av svært mangelfull kunnskap."
+      "description": "{Art}en er ikke forsøkt rødlistevurdert på grunn av svært mangelfull kunnskap."
     },
     "UavklartSystematikkNE": {
       "title": "Uavklart systematikk",
-      "description": "Arten er ikke forsøkt rødlistevurdert fordi arten eller artsgruppen den tilhører har uavklart systematikk."
+      "description": "{Art}en er ikke forsøkt rødlistevurdert fordi {art}en eller artsgruppen den tilhører har uavklart systematikk."
     },
     "UklartOmReproduserendeBestandNE": {
       "title": "Uklart om reproduserende bestand",
-      "description": "Arten er ikke forsøkt rødlistevurdert fordi det er uavklart om arten er etablert med en fast reproduserende populasjon i vurderingsområdet."
+      "description": "{Art}en er ikke forsøkt rødlistevurdert fordi det er uavklart om {art}en er etablert med en fast reproduserende populasjon i vurderingsområdet."
     },
     "ArtsgruppeIkkeRisikovurdertNE": {
-      "title": "Artsgruppe ikke risikovurdert",
-      "description": "Arten er ikke forsøkt rødlistevurdert fordi den tilhører en artsgruppe som ikke vurderes til Rødlista 2021."
+      "title": "{Art}sgruppe ikke risikovurdert",
+      "description": "{Art}en er ikke forsøkt rødlistevurdert fordi den tilhører en artsgruppe som ikke vurderes til Rødlista 2021."
     },
     "AnnetNE": {
       "title": "Annet",
-      "description": "Arten er ikke forsøkt rødlistevurdert."
+      "description": "{Art}en er ikke forsøkt rødlistevurdert."
     }
   },
   "statistics": {

--- a/Assessments.Frontend.Web/wwwroot/json/glossary.json
+++ b/Assessments.Frontend.Web/wwwroot/json/glossary.json
@@ -106,12 +106,12 @@
       "description": "{Art}en har ikke dokumentert forekomst innenfor vurderingsområdet."
     },
     "HybridartUtenReproduksjonNA": {
-      "title": "Hybrid{art} uten reproduksjon",
-      "description": "Hybrid{art} uten reproduksjon."
+      "title": "Hybridart uten reproduksjon",
+      "description": "Hybridart uten reproduksjon."
     },
     "HybridartUvisstOmReproduserendeNA": {
-      "title": "Hybrid{art} - uvisst om er reproduserende",
-      "description": "Hybrid{art}, men uvisst om den er reproduserende. "
+      "title": "Hybridart - uvisst om er reproduserende",
+      "description": "Hybridart, men uvisst om den er reproduserende. "
     },
     "ForekommerBareIHybridkombinasjonNA": {
       "title": "Forekommer bare i hybridkombinasjon",

--- a/Assessments.Frontend.Web/wwwroot/json/impactfactors.json
+++ b/Assessments.Frontend.Web/wwwroot/json/impactfactors.json
@@ -385,7 +385,7 @@
         "title": "Sanking/høsting"
       },
       "3.7.": {
-        "title": "Indirekte via høsting av artens næring"
+        "title": "Indirekte via høsting av {art}ens næring"
       },
       "3.6.": {
         "title": "Andre"

--- a/Assessments.Frontend.Web/wwwroot/json/kriterier.json
+++ b/Assessments.Frontend.Web/wwwroot/json/kriterier.json
@@ -11,14 +11,14 @@
             "title": "Direkte observasjoner"
           },
           "b": {
-            "title": "Egnet bestandsindeks for arten"
+            "title": "Egnet bestandsindeks for {art}en"
           },
           "c": {
             "title": "Redusert forekomstareal, utbredelsesområde og/eller forringet habitatkvalitet"
           },
           "d": {
-            "title": "faktisk eller potensiell høsting/utnytting av arten",
-            "optionaltext": "Reell eller potensiell utnytting av arten"
+            "title": "faktisk eller potensiell høsting/utnytting av {art}en",
+            "optionaltext": "Reell eller potensiell utnytting av {art}en"
           },
           "e": {
             "title": "Negativ påvirkning fra innførte arter, hybridisering, patogener, forurensning, konkurrerende arter eller parasitter"
@@ -44,14 +44,14 @@
             "title": "Direkte observasjoner"
           },
           "b": {
-            "title": "Egnet bestandsindeks for arten"
+            "title": "Egnet bestandsindeks for {art}en"
           },
           "c": {
             "title": "Redusert forekomstareal, utbredelsesområde og/eller forringet habitatkvalitet"
           },
           "d": {
-            "title": "faktisk eller potensiell høsting/utnytting av arten",
-            "optionaltext": "Reell eller potensiell utnytting av arten"
+            "title": "faktisk eller potensiell høsting/utnytting av {art}en",
+            "optionaltext": "Reell eller potensiell utnytting av {art}en"
           },
           "e": {
             "title": "Negativ påvirkning fra innførte arter, hybridisering, patogener, forurensning, konkurrerende arter eller parasitter"
@@ -74,14 +74,14 @@
         "description": "Fremtidig reduksjon over et tidsrom på 3 generasjoner, men minimum 10 år.",
         "subsub": {
           "b": {
-            "title": "Egnet bestandsindeks for arten"
+            "title": "Egnet bestandsindeks for {art}en"
           },
           "c": {
             "title": "Redusert forekomstareal, utbredelsesområde og/eller forringet habitatkvalitet"
           },
           "d": {
-            "title": "faktisk eller potensiell høsting/utnytting av arten",
-            "optionaltext": "Reell eller potensiell utnytting av arten"
+            "title": "faktisk eller potensiell høsting/utnytting av {art}en",
+            "optionaltext": "Reell eller potensiell utnytting av {art}en"
           },
           "e": {
             "title": "Negativ påvirkning fra innførte arter, hybridisering, patogener, forurensning, konkurrerende arter eller parasitter"
@@ -107,14 +107,14 @@
             "title": "Direkte observasjoner"
           },
           "b": {
-            "title": "Egnet bestandsindeks for arten"
+            "title": "Egnet bestandsindeks for {art}en"
           },
           "c": {
             "title": "Redusert forekomstareal, utbredelsesområde og/eller forringet habitatkvalitet"
           },
           "d": {
-            "title": "faktisk eller potensiell høsting/utnytting av arten",
-            "optionaltext": "Reell eller potensiell utnytting av arten"
+            "title": "faktisk eller potensiell høsting/utnytting av {art}en",
+            "optionaltext": "Reell eller potensiell utnytting av {art}en"
           },
           "e": {
             "title": "Negativ påvirkning fra innførte arter, hybridisering, patogener, forurensning, konkurrerende arter eller parasitter"
@@ -172,7 +172,7 @@
             "title": "forekomstareal"
           },
           "iii": {
-            "title": "areal eller kvalitet på artens habitat"
+            "title": "areal eller kvalitet på {art}ens habitat"
           },
           "iv": {
             "title": "antall lokaliteter eller delpopulasjoner"
@@ -203,7 +203,7 @@
     "subcriteria": {
       "B1": {
         "title": "Utbredelsesområde",
-        "description": "Utbredelsesområde er et mål for en arts geografiske utbredelse, og tilsvarer arealet av en minimum konveks polygon der de rette linjene i polygonen omfatter alle kjente og antatte nåværende forekomster. ",
+        "description": "Utbredelsesområde er et mål for en {art}s geografiske utbredelse, og tilsvarer arealet av en minimum konveks polygon der de rette linjene i polygonen omfatter alle kjente og antatte nåværende forekomster. ",
         "content": {
           "unit": "km&#178;",
           "comparator": "<",
@@ -217,7 +217,7 @@
       },
       "B2": {
         "title": "Forekomstareal",
-        "description": "Forekomstareal er et mål for det spesifikke arealet arten lever i, standardisert som summen av alle 2 km x 2 km (4 km&#178;) ruter som inneholder kjent eller antatt forekomst av arten. ",
+        "description": "Forekomstareal er et mål for det spesifikke arealet {art}en lever i, standardisert som summen av alle 2 km x 2 km (4 km&#178;) ruter som inneholder kjent eller antatt forekomst av {art}en. ",
         "content": {
           "unit": "km&#178;",
           "comparator": "<",


### PR DESCRIPTION
fixes #44


- Bytter ut "art" med varietet eller underart der det skal. 
- Laget liten funksjon i helpers som tar inn en streng og kjører replace på {art} og {Art} i nevnte streng. Oppdatterte json med disse taggene der vi ønsker å bytte ut tekstene.
- Tror jeg har fått med alle steder det må oppdateres, hvis ikke, si i fra.
- Må testes grundig, da det er enormt mange underelement som kun vises i spesifikke tilfeller, men mange tekster vises også veldig ofte, som overskrifter på tema og ingress.