### PR TITLE
fixes #511 - swapped unloading svgs for pngs to do a quickfix

### DIFF
--- a/Assessments.Frontend.Web/wwwroot/css/listview.css
+++ b/Assessments.Frontend.Web/wwwroot/css/listview.css
@@ -66,7 +66,7 @@
     width: 100%;
     height: 45px;
     padding: 5px;
-    margin-top: -30%;
+    /*margin-top: -30%;*/
 }
 
 
@@ -234,6 +234,7 @@ li a span.element_icon {
     display: block;
     margin-left: -20%;
     margin-right: -20%;
+    margin-top: -8px;
     text-align: center;
     overflow: visible;
     word-wrap: break-word;

--- a/Assessments.Frontend.Web/wwwroot/json/speciesgroup.json
+++ b/Assessments.Frontend.Web/wwwroot/json/speciesgroup.json
@@ -46,7 +46,7 @@
   },
   "Hydrozoer": {
     "url": " https://artsdatabanken.no/Rodliste/Artsgruppene/Hydrozoer",
-    "image": "https://design.artsdatabanken.no/icons/Hydrozoa.svg",
+    "image": "https://design.artsdatabanken.no/icons/Hydrozoa.png",
     "tagline": "Hydrozoa"
   },
   "Kakerlakker": {
@@ -166,7 +166,7 @@
   },
   "Stormaneter": {
     "url": " https://artsdatabanken.no/Rodliste/Artsgruppene/Stormaneter",
-    "image": "https://design.artsdatabanken.no/icons/Stormaneter.svg",
+    "image": "https://design.artsdatabanken.no/icons/Stormaneter.png",
     "tagline": "Scyphozoa"
   },
   "Svamper": {


### PR DESCRIPTION
Fremfor å bruke mye tid på å endre svg'ene til å støttes også i chrome, ble det lagret en versjon i png for de to ikonene som ikke fungerte som er lastet opp på design.artsdatabanken.no sammen med resten av ikonene. Det ser ut som svg'ene bestod av element med data: bilde fremfor faktiske paths, som er grunnen til at det ble tull med img-taggen. 

I utgangspunktet hadde vi en visjon om å embedde svg'ene for å kunne justere farger på pathsene, hilights osv, men per nå ligger de uansett i et annet prosjekt så det toget er kjørt for et halvår siden. Så da kan de like godt være png.