### PR TITLE
Førjulsoppdateringer.

### DIFF
--- a/Assessments.Frontend.Web/Controllers/RedlistController.cs
+++ b/Assessments.Frontend.Web/Controllers/RedlistController.cs
@@ -250,12 +250,47 @@ namespace Assessments.Frontend.Web.Controllers
             if (assessment == null)
                 return NotFound();
 
+            ViewBag.revisionid = null;
+
             ViewBag.kriterier = await GetResource("wwwroot/json/kriterier.json");
             
             ViewBag.glossary = await GetResource("wwwroot/json/glossary.json"); 
             
             ViewBag.categories = await GetResource("wwwroot/json/categories.json");
             
+            ViewBag.habitat = await GetResource("wwwroot/json/habitat.json");
+
+            ViewBag.speciesgroup = await GetResource("wwwroot/json/speciesgroup.json");
+
+            ViewBag.impactfactors = await GetResource("wwwroot/json/impactfactors.json");
+
+            return View("Species/2021/Assessment/SpeciesAssessment2021", assessment);
+        }
+        [Route("2021/{id:required}/{revisionid:required}")]
+        public async Task<IActionResult> Detail(int id, int revisionid)
+        {
+            var data = await DataRepository.GetSpeciesAssessments();
+
+            var assessment = data.FirstOrDefault(x => x.Id == id);
+            
+            if (assessment == null)
+                return NotFound();
+
+            if (assessment.Revisions == null || assessment.Revisions.All(x => x.Revision != revisionid))
+            {
+                return NotFound();
+            }
+
+            ViewBag.revisionid = revisionid;
+
+            assessment = assessment.Revisions.Single(x => x.Revision == revisionid);
+
+            ViewBag.kriterier = await GetResource("wwwroot/json/kriterier.json");
+
+            ViewBag.glossary = await GetResource("wwwroot/json/glossary.json");
+
+            ViewBag.categories = await GetResource("wwwroot/json/categories.json");
+
             ViewBag.habitat = await GetResource("wwwroot/json/habitat.json");
 
             ViewBag.speciesgroup = await GetResource("wwwroot/json/speciesgroup.json");

--- a/Assessments.Frontend.Web/Infrastructure/Helpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Helpers.cs
@@ -255,7 +255,7 @@ namespace Assessments.Frontend.Web.Infrastructure
 
         public static string getScientificNameElement(string scientificName)
         {
-            scientificName = "<i>"+scientificName+"</i>";
+            scientificName = "<i>" + scientificName + "</i>";
             scientificName = scientificName.Replace("×", "</i>×<i>");
             scientificName = scientificName.Replace("aff.", "</i>aff.<i>");
             scientificName = scientificName.Replace("agg.", "</i>agg.<i>");
@@ -267,6 +267,46 @@ namespace Assessments.Frontend.Web.Infrastructure
             scientificName = scientificName.Replace("' ", "'<i> ");
             scientificName = scientificName.Replace("<i></i>", "");
             return scientificName;
+        }
+
+
+        public static string getPublishedDate(int assesmentyear, int yearPreviousAssessment)
+        {
+            string firspublished = "24.11.2021";
+            firspublished = assesmentyear == 2010 ? yearPreviousAssessment.ToString() : firspublished;
+            return firspublished;
+        }
+
+        public static string getRevisionDate(DateTime RevisionDate, string firspublished)
+        {
+            if (RevisionDate.Date.ToShortDateString() != firspublished)
+            {
+                return RevisionDate.Date.ToShortDateString();
+            }
+            return string.Empty;
+        }
+
+        public static string fixSpeciesLevel(string replacestring, string rang)
+        {
+            if (rang == "SubSpecies" || rang == "Variety")
+            {
+                if (rang == "SubSpecies")
+                {
+                    replacestring = replacestring.Replace("{art}", "underart");
+                    replacestring = replacestring.Replace("{Art}", "Underart");
+                }
+                else if (rang == "Variety")
+                {
+                    replacestring = replacestring.Replace("{art}", "varietet");
+                    replacestring = replacestring.Replace("{Art}", "Varietet");
+                }
+            }
+            else
+            {
+                replacestring = replacestring.Replace("{art}", "art");
+                replacestring = replacestring.Replace("{Art}", "Art");
+            }
+            return replacestring;
         }
     }
 

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/SpeciesAssessment2021.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/SpeciesAssessment2021.cshtml
@@ -19,10 +19,12 @@
 }
 
 <partial name="/Views/Redlist/Species/2021/Assessment/partials/_Breadcrumb.cshtml" />
+
 <div class="pagecontainer">
     <partial name="/Views/Redlist/Species/Shared/_PageMenu.cshtml" />
 
     <div class="content-placer bigmid">
+        <partial name="/Views/Redlist/Species/2021/Assessment/partials/_Archived.cshtml" />
         <div class="mid-content with_sidebar">
             <partial name="/Views/Redlist/Species/2021/Assessment/partials/_Header.cshtml" />
             <div class="mobile_padding">
@@ -36,6 +38,7 @@
                 <partial name="/Views/Redlist/Species/2021/Assessment/partials/_SpeciesDetails.cshtml" />
                 <partial name="/Views/Redlist/Species/2021/Assessment/partials/_Reference.cshtml" />
                 <partial name="/Views/Redlist/Species/2021/Assessment/partials/_Citation.cshtml" model="Model" />
+                <partial name="/Views/Redlist/Species/2021/Assessment/partials/_Revision.cshtml" model="Model" />
             </div>
         </div>
         <div class="side mobile_padding">

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Archived.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Archived.cshtml
@@ -1,0 +1,17 @@
+﻿@if (@ViewBag.revisionid > 0)
+{
+<div class="archive">
+    <span class="material-icons">
+        warning_amber
+    </span>
+    Denne vurderingen er utdatert. 
+    @if (@ViewBag.revisionid > 0)
+    {
+
+        <a asp-action="Detail" asp-route-id="@Model.Id" asp-route-revisionid="">
+            Gå til gjeldende vurdering
+        </a>
+    }
+
+</div>
+}

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Breadcrumb.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Breadcrumb.cshtml
@@ -6,11 +6,11 @@
 <div class="breadcrumbs">
     <ol>
         @{/*
-            <li class="lead in-breadcrumb">
-                <a asp-controller="Redlist" asp-action="rodlisteforarter">Rødlista for arter</a>
-                <span class="breadcrumbdivider">&gt; </span>
-            </li>
-          */
+                    <li class="lead in-breadcrumb">
+                        <a asp-controller="Redlist" asp-action="rodlisteforarter">Rødlista for arter</a>
+                        <span class="breadcrumbdivider">&gt; </span>
+                    </li>
+                  */
         }
 
         <li class="in-breadcrumb">
@@ -30,15 +30,30 @@
         @if (@Model.AssessmentArea == "S")
         {
             <li class="in-breadcrumb">
-                <a asp-controller="Redlist" asp-action="Index2021" asp-route-Area="S">
-                    Svalbard
-                </a>
+                 <a asp-action="Detail" asp-route-id="@Model.Id" asp-route-revisionid="1">Originalversjon </a>
                 <span class="breadcrumbdivider">&gt; </span>
             </li>
         }
 
-        <li class="in-breadcrumb currentcrumb" disabled="true">
-            @Model.ScientificName
-        </li>
+        @if (@ViewBag.revisionid > 0)
+        {
+            <li class="in-breadcrumb">
+                <a asp-action="Detail" asp-route-id="@Model.Id" asp-route-revisionid="">
+                    @Model.ScientificName
+                </a>
+                <span class="breadcrumbdivider">&gt; </span>
+            </li>
+
+            <li class="in-breadcrumb currentcrumb" disabled="true">
+               Versjon @ViewBag.revisionid
+            </li>
+        }
+        else
+        {
+            <li class="in-breadcrumb currentcrumb" disabled="true">
+                @Model.ScientificName
+            </li>
+        }
+
     </ol>
 </div>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_CategoryChange.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_CategoryChange.cshtml
@@ -26,23 +26,15 @@
 
         //UTEN GRADER MATCH
 
-
-
-
-
         @if (which_redlist != "2021" && previous_category != current_category)
         {
             <h3>Årsak til endring av kategori</h3>
             <p>
-                Kategorien for denne arten har endret seg fra @previous_category til @current_category siden Rødlista @which_redlist.
-                Endringen kommer på grunnlag av <span style="text-transform:lowercase">@Model.ReasonCategoryChange.Description()</span>.
+                Kategorien for denne @Helpers.fixSpeciesLevel("{art}en", Model.TaxonRank) har endret seg fra @previous_category til @current_category siden Rødlista @which_redlist.
+                Endringen kommer på grunnlag av <span style="text-transform:lowercase">
+                @Helpers.fixSpeciesLevel(@Model.ReasonCategoryChange.Description(), Model.TaxonRank)</span>.
             </p>
 
         }
     }
-
-
-
-
-
 </div>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Citation.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Citation.cshtml
@@ -6,21 +6,41 @@
 @inject ExpertCommitteeMemberService _expertCommitteeMemberService
 
 @{
+    // Authors
     var expertCommitteeMembers = await _expertCommitteeMemberService.GetExpertCommitteeMembers(Model.ExpertCommittee, Model.AssessmentYear);
     var sortedExperts = expertCommitteeMembers
-        .OrderBy(x => new List<string> {"leder", "nestleder", "medlem"}.IndexOf(x.Role.ToLowerInvariant()))
-        .ThenBy(x => x.LastName);  
+        .OrderBy(x => new List<string> { "leder", "nestleder", "medlem" }.IndexOf(x.Role.ToLowerInvariant()))
+        .ThenBy(x => x.LastName);
+
     var formattedExperts = sortedExperts.Select(x => $"{x.LastName} {x.FirstNameInitals}").Distinct().ToList();
     string authors = formattedExperts.JoinAnd(", ", " og ");
-    }
 
-    @if (expertCommitteeMembers.Any())
+    // Date
+    string firspublished = Helpers.getPublishedDate(Model.AssessmentYear, Model.YearPreviousAssessment);
+    string revisiondate = Helpers.getRevisionDate(Model.RevisionDate, firspublished);
+    string date = firspublished;
+    if (!string.IsNullOrWhiteSpace(Model.RevisionReason))
     {
-        <h2>Sitering</h2>
-
-        <p class="citation">
-            @authors (2021, 24. november).
-            @Model.SpeciesGroup: Vurdering av @Model.PopularName @Model.ScientificName for @(Model.AssessmentArea == "N" ? "Norge" : "Svalbard").
-            Norsk rødliste for arter 2021. Artsdatabanken. @Context.Request.GetEncodedUrl()
-        </p>
+        date = revisiondate;
     }
+    date = "(" + date + ").";
+    firspublished = "(" + firspublished + ").";
+
+    // Publication
+            string species = Model.PopularName + " " + Model.ScientificName;
+    string area = (Model.AssessmentArea == "N" ? "Norge" : "Svalbard");
+    string articlename = Model.SpeciesGroup + ": Vurdering av " + species + " for " + area + ".";
+    string publication = "Norsk rødliste for arter 2021. Artsdatabanken. ";
+}
+
+@if (expertCommitteeMembers.Any())
+{
+    <h2>Sitering</h2>
+    <p class="citation">
+        @authors
+        @date
+        @articlename
+        @publication
+        @Context.Request.GetEncodedUrl()
+    </p>
+}

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Criteria.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Criteria.cshtml
@@ -113,8 +113,10 @@
     {
         @if (field.ContainsKey(key))
         {
+            var text = field[key].ToString();
+
             <p class="@key">
-                @Html.Raw(field[key])
+                @Html.Raw(Helpers.fixSpeciesLevel(text, Model.TaxonRank))
             </p>
         }
 
@@ -423,12 +425,18 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
 {
 <div class="page_section criteria" id="criteria">
     <div class="criteria_description">
-        <h3>@ViewBag.glossary["criteria"]["tagline"]</h3>
+        @{ 
+            string heading = ViewBag.glossary["criteria"]["tagline"];
+            heading = @Helpers.fixSpeciesLevel(heading, Model.TaxonRank);
+            string description = ViewBag.glossary["criteria"]["description"];
+            description = @Helpers.fixSpeciesLevel(description, Model.TaxonRank);
+        }
+        <h3>@heading</h3>
         <p>
-            @Html.Raw(ViewBag.glossary["criteria"]["description"])
+            @Html.Raw(description)
             <br />
             <a href="https://www.artsdatabanken.no/Pages/314252/Metode#316484" class="link-styled">Gå til metode</a>
-          </p>
+        </p>
        
         <h4>@ViewBag.glossary["criteria"]["subheading"]</h4>
         <p>@Model.CriteriaSummarized
@@ -451,10 +459,10 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
         *@
         <ul class="outer noline">
             <li class="tablist_listheader">
-                <span class="summary_title">Artens kriterier</span>
+                <span class="summary_title">@Helpers.fixSpeciesLevel("{Art}ens", Model.TaxonRank) kriterier</span>
                 <span class="full_list_title">Alle kriterier</span>
                 <span class="full_list_description" style="display:none;">
-                    Gjeldende kriterier for arten er markert med merket
+                    Gjeldende kriterier for @Helpers.fixSpeciesLevel("{art}en", Model.TaxonRank) er markert med merket
                     <span class="impact_v">
                         <span class="material-icons">
                             done
@@ -470,11 +478,12 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
             @foreach (var (key, value) in criteria)
             {
                 string isactive = @Criteria.inString(key, @Model.CriteriaSummarized);
+                string valtitle = @Helpers.fixSpeciesLevel(value["title"].ToString(), Model.TaxonRank);
                 <li class="@isactive">
                     <span class="text_container clickable" onclick="expandCriteria(this, 'opened_element') ">
                         @{ expandOrBullet(true);}
-                        <span class="title_field">
-                            @key - @value["title"]
+                        <span class="title_field">                           
+                            @key - @valtitle
                             @{ iconChooser(Criteria.inString(key, Model.CriteriaSummarized)); }
                         </span>
                     </span>
@@ -491,6 +500,8 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
                         <ul class="second">
                             @foreach (var (k, v) in thesubcriteria)
                             {
+
+                                string vtitle = @Helpers.fixSpeciesLevel(v["title"].ToString(), Model.TaxonRank);
                                 var subcriteria_isactive = @Criteria.inString(k, subcriteria[key]);
                                 <li class=" @subcriteria_isactive">
                                     <span class="text_container">
@@ -498,7 +509,7 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
                                             <span class="title_field clickable" onclick="expandCriteria(this, 'opened_element')">
                                                 @{expandOrBullet(true);}
                                                 <span class="text_text ">
-                                                    @k - @v["title"]
+                                                    @k - @vtitle
                                                     @{iconChooser(subcriteria_isactive);}
                                                 </span>
                                             </span>
@@ -525,6 +536,8 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
                                                     <ul class="third activeornot">
                                                         @foreach (var (subkey, subval) in subdict)
                                                         {
+
+                                                            string subvaltitle = @Helpers.fixSpeciesLevel(subval["title"].ToString(), Model.TaxonRank);
                                                             string modelkey = k + subkey;
                                                             <li class="@Criteria.inList(subkey, currentlist)">
                                                                 <span class="text_container">
@@ -532,7 +545,7 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
                                                                         <span class="title_field">
                                                                             @{expandOrBullet(false);}
                                                                             <span class="text_text">
-                                                                                @subkey - <span>@subval["title"] @{ iconChooser(Criteria.inList(subkey, currentlist)); }</span>
+                                                                                @subkey - <span>@subvaltitle @{ iconChooser(Criteria.inList(subkey, currentlist)); }</span>
                                                                             </span>
                                                                         </span>
                                                                         @{ getQuantile(subval, modelkey, modelkey);}
@@ -627,6 +640,7 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
                                             <ul class="second">
                                                 @foreach (var (k, v) in thesubcriteria)
                                                 {
+                                                    string vtitle = @v["title"].ToString();
                                                     var subcriteria_isactive = @Criteria.inString(k, subcriteria[key]);
                                                     <li class=" @subcriteria_isactive">
                                                         <span class="text_container">
@@ -634,7 +648,7 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
                                                                 <span class="title_field clickable" onclick="expandCriteria(this, 'opened_element')">
                                                                     @{expandOrBullet(true);}
                                                                     <span class="text_text ">
-                                                                        @k - @v["title"]
+                                                                        @k - @Helpers.fixSpeciesLevel(vtitle, Model.TaxonRank)
                                                                     </span>
                                                                     @{iconChooser(subcriteria_isactive);}
                                                                 </span>
@@ -662,6 +676,7 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
 
                                                                         @foreach (var (subkey, subvalue) in subdict)
                                                                         {
+                                                                            string vsubtitle = subvalue["title"].ToString();
                                                                             var modelkey = key + k + subkey;
                                                                             string clickable = "";
                                                                             if (modelkey == "Baii")
@@ -673,7 +688,7 @@ Model.Category.Contains("VU") || Model.Category.Contains("NT")))
                                                                                     <span class="text_collection">
                                                                                         <span class="text_text @clickable" onclick="expandCriteria(this, 'opened_element')">
                                                                                             @{expandOrBullet(clickable == "clickable");}
-                                                                                            @subkey - @subvalue["title"]
+                                                                                            @subkey - @Helpers.fixSpeciesLevel(vsubtitle, Model.TaxonRank)
                                                                                         </span>
                                                                                         @{ iconChooser(Criteria.inList(subkey, clean_list)); }
                                                                                     </span>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_GenerationLength.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_GenerationLength.cshtml
@@ -6,7 +6,7 @@
 {
     <h3>Generasjonstid</h3>
     <p>
-        <span> Artens generasjonstid er satt til @Model.GenerationLength år.</span><br/>
+        <span> @Helpers.fixSpeciesLevel("{Art}ens", Model.TaxonRank) generasjonstid er satt til @Model.GenerationLength år.</span><br/>
         @ViewBag.glossary["generasjonstid"]["description"]
     </p>
 

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Habitat.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Habitat.cshtml
@@ -63,7 +63,11 @@
 
     <div class="habitat page_section ">        
         <h2>@ViewBag.glossary["habitat"]["tagline"]</h2>
-        <p>@Html.Raw(@ViewBag.glossary["habitat"]["description"])</p>
+        <p>
+            @{string habitatdescription = ViewBag.glossary["habitat"]["description"];}
+            @Html.Raw(Helpers.fixSpeciesLevel(habitatdescription, Model.TaxonRank))
+        </p>
+
 
         <button class="changetab active" onclick="expandHabitat(this, 'see_all', 'remove')">
             Hovedhabitat
@@ -76,7 +80,7 @@
         <div class="habitat_container tabbed_element_container">
 
             <div class="tablist_listheader">
-                <span class="summary_title">Artens hovedhabitat</span>
+                <span class="summary_title">@Helpers.fixSpeciesLevel("{Art}ens", Model.TaxonRank) hovedhabitat</span>
                 <span class="full_list_title">Alle habitat</span>
                 @if (Model.MainHabitat.Count == 0)
                 {

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Header.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Header.cshtml
@@ -5,11 +5,10 @@
 
 <div class="page-header">
     <partial name="/Views/Redlist/Species/2021/Assessment/partials/_Artsnavn.cshtml" />
-   
     @if (@Model.AssessmentArea == "S")
     {
         <h2 class="svalbard-heading">
-            Svalbard 
+            Svalbard
         </h2>
     }
     <partial name="/Views/Redlist/Species/2021/Assessment/partials/_SpeciesGroup.cshtml" />

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_ImpactFactors.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_ImpactFactors.cshtml
@@ -78,6 +78,7 @@
     void listHeaders(string key, Dictionary<string, object> value, string addborder)
     {
         string has_table = "";
+        string vtitle = @value["title"].ToString();
         foreach (var factor in Model.ImpactFactors)
         {
             @if (factor.Id == (key))
@@ -86,12 +87,11 @@
             }
         }
         <span class="text_container @has_table" onclick="expandImpact(this, 'opened_element')">
-
             <span class="text_collection">
                 <span class="title_field  @isClickableClass(value)">
-                    @{ toggleChooser(value);}
-                    <span class="text_text">
-                        @value["title"]
+                    @{toggleChooser(value);}
+                    <span class="text_text">                       
+                        @Helpers.fixSpeciesLevel(vtitle, Model.TaxonRank)
                         @{iconChooser(activeOrNot(key));}
                     </span>
                 </span>
@@ -138,7 +138,7 @@
         <div class="page_section impact" id="impactfactors">
             <h2>Påvirkningsfaktorer </h2>
             <p>
-                Nedenfor listes det opp forskjellige påvirkningsfaktorer som kan gi utslag for rødlisting av arten.
+                Nedenfor listes det opp forskjellige påvirkningsfaktorer som kan gi utslag for rødlisting av @Helpers.fixSpeciesLevel("{art}en", Model.TaxonRank).
             </p>
 
             <button id="summary" class="changetab active" onclick="impactlist('summary',this)">Oppsummering</button>
@@ -146,7 +146,7 @@
             <br />
             <ul class="outer tabbed_element_container">
                 <li class="tablist_listheader">
-                    <span class="summary_title">Artens påvirkningsfaktorer</span>
+                    <span class="summary_title">@Helpers.fixSpeciesLevel("{Art}ens", Model.TaxonRank) påvirkningsfaktorer</span>
                     <span class="full_list_title">Alle påvirkningsfaktorer</span>
                     @if (Model.ImpactFactors.Count == 0)
                     {

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_InclusionCriteria.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_InclusionCriteria.cshtml
@@ -56,8 +56,8 @@
 
 
 <div class="page_section inclusion_section">
-    <h3>@heading</h3>
-    <p>@Html.Raw(reason)</p>
+    <h3>@Helpers.fixSpeciesLevel(heading, Model.TaxonRank)</h3>
+    <p>@Html.Raw(Helpers.fixSpeciesLevel(reason, Model.TaxonRank))</p>
    
     <a class="link-styled" href="https://www.artsdatabanken.no/Pages/316561/Nasjonale_tilpasninger">
         Hvilke arter vurderes?

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Ingress.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Ingress.cshtml
@@ -21,7 +21,7 @@
                 sentence += current.ToLower();
             }
         }
-        if(Model.Category.Length > 2)
+        if (Model.Category.Length > 2)
         {
             sentence += ", og ble <a href='#nedgradert'>nedgradert</a> på grunn av populasjoner i nærliggende regioner";
         }
@@ -41,23 +41,24 @@
         }
         else
         {
-            <span>Arten er </span>
+            <span>@Helpers.fixSpeciesLevel("{Art}en", Model.TaxonRank) er </span>
             @if (Model.Category != "NA" && Model.Category != "NE")
             {
                 <span>vurdert til </span>
             }
             <partial name="/Views/Shared/_Category.cshtml" /> <span class="">@Helpers.findDegrees(Model.Category, true)</span><span>
-                
+
                 @if (@Model.Category == "CR" && @Model.PresumedExtinct == true)
                 {
-                <span>for Norsk rødliste for arter 2021, og er trolig utdødd.</span>
+                    <span>for Norsk rødliste for arter 2021, og er trolig utdødd.</span>
                 }
                 else
                 {
-                  <span>for Norsk rødliste for arter 2021.</span>
+                    <span>for Norsk rødliste for arter 2021.</span>
                 }
                 @Html.Raw(sentence)
             </span>
         }
     </p>
+    <partial name="/Views/Redlist/Species/2021/Assessment/partials/_RevisionReason.cshtml" />
 </div>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Map.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Map.cshtml
@@ -1,7 +1,6 @@
 ﻿@model SpeciesAssessment2021
 @*
-    Norwegian name and scientific name with and without autor.
-    Codeblock from Innsynsløsninga 2021 by SN. Modified by HEM for launch.
+   Map of Norway with svalbard
 *@
 
 @functions{

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_MapSvalbard.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_MapSvalbard.cshtml
@@ -1,7 +1,6 @@
 ﻿@model SpeciesAssessment2021
 @*
-    Norwegian name and scientific name with and without autor.
-    Codeblock from Innsynsløsninga 2021 by SN. Modified by HEM for launch.
+    Map of Svalbard 
 *@
 
 @functions{

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_NoCriteria.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_NoCriteria.cshtml
@@ -3,10 +3,10 @@
 @if (Model.Category.Contains("LC"))
 {
     <h3>
-        Hvorfor er ikke denne arten rødlistet?
+        Hvorfor er ikke denne @Helpers.fixSpeciesLevel("{art}en", Model.TaxonRank) rødlistet?
     </h3>
     <p>
-        Denne arten oppfyller ikke kriteriene for rødlisting.
+        Denne @Helpers.fixSpeciesLevel("{art}en", Model.TaxonRank) oppfyller ikke kriteriene for rødlisting.
         Den vurderes derfor til kategorien <i>livskraftig</i> LC.
     </p>
     <a class="link-styled" href="https://www.artsdatabanken.no/rodlisteforarter2021/Metode#193097">

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_PopulationProportions.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_PopulationProportions.cshtml
@@ -16,7 +16,8 @@
             <h3>@ViewBag.glossary["populationsize"]["title"]</h3>
 
             <p>
-                @ViewBag.glossary["populationsize"]["description"]
+                @{string description = ViewBag.glossary["populationsize"]["description"];}
+                @Html.Raw(Helpers.fixSpeciesLevel(description, Model.TaxonRank))
             </p>
 
             <h4>@ViewBag.glossary["populationsize"]["subtitle"]</h4>

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_PublishedDate - Copy.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_PublishedDate - Copy.cshtml
@@ -1,0 +1,21 @@
+﻿@model SpeciesAssessment2021
+@{
+    // @steinho, hvordan finner jeg riktig pub. dato?
+
+    // Find correct startdate (Exceptions include 2010 spretthaler)
+    string firspublished = "24.11.2021";
+    firspublished = Model.AssessmentYear == 2010 ? Model.YearPreviousAssessment.ToString() : firspublished;
+    string printstring = "Publisert: " + firspublished;
+
+    // Add the revisiondate when it exists
+    string revisiondate = string.Empty;
+    @if (Model.RevisionDate.Date.ToShortDateString() != firspublished)
+    {
+        revisiondate = Model.RevisionDate.Date.ToShortDateString();
+        printstring += ", sist endret: " + revisiondate;
+    }
+}
+
+
+<span class="date datestring">@printstring</span>
+

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_PublishedDate.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_PublishedDate.cshtml
@@ -1,0 +1,18 @@
+﻿@model SpeciesAssessment2021
+@{
+    // @steinho, hvordan finner jeg riktig pub. dato?
+
+    // Find correct startdate (Exceptions include 2010 spretthaler)
+    string firspublished = Helpers.getPublishedDate(Model.AssessmentYear, Model.YearPreviousAssessment);
+    string printstring = "Publisert: " + firspublished;
+
+    // Add the revisiondate when it exists
+    string revisiondate = Helpers.getRevisionDate(Model.RevisionDate, firspublished);
+
+    @if (!string.IsNullOrEmpty(revisiondate))
+    {        
+        printstring += ", sist endret: " + revisiondate;
+    }
+}
+<span class="date datestring">@printstring</span>
+

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_RegionStatistics.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_RegionStatistics.cshtml
@@ -40,7 +40,8 @@
 { // No content would imply it exists nowhere or is recorded nowhere
 <div class="geographic_facts">
     <h3> @ViewBag.glossary["region"]["tagline"]</h3>
-    <p> @Html.Raw(@ViewBag.glossary["region"]["description"])</p>
+    @{string description = ViewBag.glossary["region"]["description"];}
+    @Html.Raw(Helpers.fixSpeciesLevel(description, Model.TaxonRank))
 
     <h3>Geografisk distribusjon</h3>
 

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Regions.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Regions.cshtml
@@ -7,7 +7,7 @@
     {
         distributionName = "vurdert_N";
     }
-    else if(Model.AssessmentArea == "S")
+    else if (Model.AssessmentArea == "S")
     {
         if (Model.SpeciesGroup == "Pattedyr")
         {
@@ -21,9 +21,10 @@
 }
 
 <div class="page_section @distributionName">
-    <h2>Vurderingsområde og artens utbredelse</h2>
+    <h2>Vurderingsområde og @Helpers.fixSpeciesLevel("{art}ens", Model.TaxonRank) utbredelse</h2>
     <p>
-        @ViewBag.glossary[distributionName]["description"]
+        @{string description = ViewBag.glossary[distributionName]["description"];}        
+        @Helpers.fixSpeciesLevel(description, Model.TaxonRank)
     </p>
 
     <partial name="/Views/Redlist/Species/2021/Assessment/partials/_RegionStatistics.cshtml" />

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Revision.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_Revision.cshtml
@@ -1,0 +1,25 @@
+﻿@model SpeciesAssessment2021
+@using Microsoft.AspNetCore.Http.Extensions
+@if (Model.Revisions != null && Model.Revisions.Any())
+{
+
+    <h3>Tidligere versjoner</h3>
+    <p>
+        Utdaterte versjoner med en tidligere publiseringsdato kan sees på følgende lenker:
+    </p>
+    foreach (var revision in Model.Revisions)
+    {
+        <span class="material-icons" style="float:left; padding:10px;">
+            history
+        </span>
+        <p class="citation">
+            @revision.RevisionDate.ToShortDateString(),
+            versjon @revision.Revision <br />
+            <a href="@Context.Request.GetEncodedUrl()/@revision.Revision">@Context.Request.GetEncodedUrl()/@revision.Revision</a>
+        </p>
+    }
+}
+else if (ViewBag.revisionid != null)
+{
+    <partial name="/Views/Redlist/Species/2021/Assessment/partials/_Archived.cshtml" />
+}

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_RevisionReason.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_RevisionReason.cshtml
@@ -1,0 +1,17 @@
+﻿@model SpeciesAssessment2021
+@if (!string.IsNullOrWhiteSpace(Model.RevisionReason))
+{
+<div>
+    <span class="material-icons" style="float:left;display:inline-block; padding:10px;">
+        <span class="material-icons">
+            new_releases
+        </span>
+    </span>
+    <i style="display:none;">NB - Vurderingen er justert etter publisering: </i>
+    <b>Justeringer etter publisering</b>
+    <p>
+        @Model.RevisionReason
+        <a asp-action="Detail" asp-route-id="@Model.Id" asp-route-revisionid="1">Gå til første utgave</a>
+    </p>        
+</div>      
+}

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_SidebarContent.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_SidebarContent.cshtml
@@ -15,7 +15,7 @@
     <img src="https://design.artsdatabanken.no/list-icons/taxon-icon.png" alt="Logobilde for artssiden"/>
     <br />
     <a href="@taxon_url" class="link-styled">
-        Til artssiden
+        Til @Helpers.fixSpeciesLevel("{art}ssiden", Model.TaxonRank)
     </a>
 
     <hr />

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_SpeciesGroup.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/partials/_SpeciesGroup.cshtml
@@ -7,6 +7,13 @@
     // By the time we arrive here, the actual committe name has been split into correct species group,
     // and is thus now species group and not actually committtee group.
 
+    // @steinho, hvordan finner jeg riktig pub. dato?
+    string firspublished = "24.11.2021";
+    string dateline = "Publisert: " + (Model.AssessmentYear == 2010 ? Model.YearPreviousAssessment : firspublished);
+    @if (Model.RevisionDate.Date.ToShortDateString() != firspublished && !string.IsNullOrEmpty(Model.RevisionReason))
+    {
+        dateline += ", sist endret: " + Model.RevisionDate.Date.ToShortDateString();
+    }
 
 }
 
@@ -21,14 +28,14 @@
 
                     @if (speciesgroup[key]["image"] != null)
                     {
-                        <img src="@speciesgroup[key]["image"]" alt="@key"/>
+                        <img src="@speciesgroup[key]["image"]" alt="@key" />
                     }
                 </div>
             }
         }
     </div>
-    <p >
+    <p>
         Vurdert av <a href="https://www.artsdatabanken.no/rodlisteforarter2021/ekspertkomiteene" class="lowercase">ekspertkomité for @Model.ExpertCommittee </a> <br />
-        <span class="date">Publisert: @(Model.AssessmentYear == 2010  ? @Model.YearPreviousAssessment : "24. november 2021")</span>
+        <partial name="/Views/Redlist/Species/2021/Assessment/partials/_PublishedDate.cshtml" />
     </p>
 </div>

--- a/Assessments.Frontend.Web/wwwroot/css/listview.css
+++ b/Assessments.Frontend.Web/wwwroot/css/listview.css
@@ -66,7 +66,7 @@
     width: 100%;
     height: 45px;
     padding: 5px;
-    margin-top: -30%;
+    /*margin-top: -30%;*/
 }
 
 
@@ -234,6 +234,7 @@ li a span.element_icon {
     display: block;
     margin-left: -20%;
     margin-right: -20%;
+    margin-top: -8px;
     text-align: center;
     overflow: visible;
     word-wrap: break-word;

--- a/Assessments.Frontend.Web/wwwroot/css/site.css
+++ b/Assessments.Frontend.Web/wwwroot/css/site.css
@@ -162,6 +162,7 @@ option {
         height: 100%;
         width: 25%;
         min-width: 200px;
+        flex: 0.25;
     }
 
     .side button{
@@ -172,6 +173,7 @@ option {
         width: 75%;
         padding:20px;
         padding-top:0;
+        flex:1;
     }
 
     .pagecontainer{
@@ -182,6 +184,7 @@ option {
         padding-top: 33px;
         width: calc(75% - 4px);
         display: flex;
+        flex-wrap: wrap;
     }
 
 
@@ -860,4 +863,23 @@ option {
 
 .show_inline_block {
     display: inline-block;
+}
+
+.archive {
+    padding: 15px;
+    background: #ffaf31;
+    text-align: center;
+    color: black;
+    width: 100%;
+    font-size: initial;
+    margin-bottom: 20px;
+}
+
+.darktheme .archive a,
+.archive a {
+    color: #850808;
+}
+
+.archive .material-icons{
+    vertical-align:bottom;
 }

--- a/Assessments.Frontend.Web/wwwroot/js/filter.js
+++ b/Assessments.Frontend.Web/wwwroot/js/filter.js
@@ -3,6 +3,8 @@
 
 // DOM elements
 const filters = document.getElementById("filters");
+
+if (filters) {
 const isCheckInputs = document.getElementsByClassName("collapse_checkbox");
 const insectFilters = document.getElementsByClassName("insect_input");
 const insectInput = document.getElementById("Insekter");
@@ -36,7 +38,7 @@ function handleFirstTime() {
     })
 }
 
-function scrollToPreviousPosition(){
+function scrollToPreviousPosition() {
     if (!scrollTo) return;
     const position = scrollTo.value;
     window.scrollTo(0, position);
@@ -77,14 +79,14 @@ function startup() {
         document.getElementById("open_filter").classList.remove("no_js");
     }
     if (filters) { // Double-check in case first check gets removed ^^
-        filters.classList.remove("no_js");    
+        filters.classList.remove("no_js");
         // Add js-tag for elements only relevant to js-users. 
         filters.classList.add("only_js");
     }
-    closeFilters();    
+    closeFilters();
     addOnclick();
     window.addEventListener('resize', addOnclick);
-    if (!hasVisited()) {         
+    if (!hasVisited()) {
         setVisited();
         handleFirstTime();
     }
@@ -115,7 +117,7 @@ function submitClickedElement(element) {
 
 /* Old code not changed  much */
 
-function setCollapsibleIcon(name){
+function setCollapsibleIcon(name) {
     if (name == "initial_check") {
         return;
     }
@@ -147,20 +149,20 @@ function setCollapsibleIcon(name){
 
 // Handle toggle events for misc. scenario
 
-function shouldToggleMarkAll(elementsClass){
+function shouldToggleMarkAll(elementsClass) {
     const allElements = document.getElementsByClassName(elementsClass);
     return Array.prototype.every.call(allElements, (element) => {
         return element.checked === true;
     })
 }
 
-function shouldToggleMarkRedOrEnd(list){
+function shouldToggleMarkRedOrEnd(list) {
     return Array.prototype.every.call(list, (item) => {
         return document.getElementById("input_" + item).checked === true;
     })
 }
 
-function toggleMarkAll(){
+function toggleMarkAll() {
     if (shouldToggleMarkAll("insect_input")) {
         insectInput.checked = true;
     }
@@ -191,11 +193,11 @@ function toggleRedlistedCategories() {
     toggleAllOfType(redlisted, "redlisted_check", "endangered_check");
 }
 
-function toggleEndangeredCategories() {  
+function toggleEndangeredCategories() {
     toggleAllOfType(endangered, "endangered_check", "redlisted_check");
 }
 
-function toggleInsects(){
+function toggleInsects() {
     Array.prototype.forEach.call(insectFilters, insect => {
         if (insectInput.checked) {
             insect.checked = true;
@@ -205,13 +207,13 @@ function toggleInsects(){
     });
 }
 
-function toggleSingleFilter(element, parentId){
+function toggleSingleFilter(element, parentId) {
     if (!element.checked) {
         document.getElementById(parentId).checked = false;
     }
 }
 
-function updateToggleAll(el){
+function updateToggleAll(el) {
     if (el && el.classList[0] === "insect_input") {
         toggleSingleFilter(el, "Insekter");
     } else if (el && endangered.some(category => el.id.indexOf(category) != -1)) {
@@ -236,7 +238,7 @@ function onClickAction(el, addOrRemove) {
             toggleMarkAll();
         } else {
             el.onclick = null;
-        }        
+        }
     }
     if (addOrRemove == "add") {
         scrollTo.value = "scroll_" + window.scrollY;
@@ -246,7 +248,7 @@ function onClickAction(el, addOrRemove) {
             //activate if toggle all of the filters are possible? 
             toggleSingleFilter(el);
         }*/
-    }    
+    }
 }
 
 function addOnclick() {
@@ -271,6 +273,5 @@ function removeSubmitOnclick() {
 }
 
 /* RUN THE STARTUP */
-if (filters) {
-    startup();
+startup();
 }

--- a/Assessments.Frontend.Web/wwwroot/js/search.js
+++ b/Assessments.Frontend.Web/wwwroot/js/search.js
@@ -259,37 +259,43 @@ window.onclick = (e) => {
 // Go from searchfield to suggestion on arrowdown
 
 var autocompletelist = document.getElementById("autocomplete_list_ul");
-searchField.addEventListener('keydown', function (event) {
-    if (autocompletelist.innerHTML.trim() != "") {
-        if (event.key == "ArrowDown") {
-            event.preventDefault();
-            autocompletelist.firstChild.focus();
+if (searchField) {
+    searchField.addEventListener('keydown', function (event) {
+        if (autocompletelist.innerHTML.trim() != "") {
+            if (event.key == "ArrowDown") {
+                event.preventDefault();
+                autocompletelist.firstChild.focus();
+            }
         }
-    }
-});
+    });
 
-searchField.addEventListener('focus', function (event) {
-    if (autocompletelist.innerHTML.trim() != "") {
-        showList();
-    }
-});
+    searchField.addEventListener('focus', function (event) {
+        if (autocompletelist.innerHTML.trim() != "") {
+            showList();
+        }
+    });
+}
+
 
 // Navigate list with arrowkeys, leave list on first-child upkey
-autocompletelist.addEventListener('keydown', function (event) {
-    event.preventDefault();
-    if (event.key == "ArrowUp") {
-        if (event.target == autocompletelist.firstChild) {
-            searchField.focus();
-        } else {
-            event.target.previousElementSibling.focus();
+if (autocompletelist) {
+    autocompletelist.addEventListener('keydown', function (event) {
+        event.preventDefault();
+        if (event.key == "ArrowUp") {
+            if (event.target == autocompletelist.firstChild) {
+                searchField.focus();
+            } else {
+                event.target.previousElementSibling.focus();
+            }
+        } else if (event.key == "ArrowDown") {
+            if (event.target != autocompletelist.lastChild) {
+                event.target.nextElementSibling.focus();
+            }
+        } else if (event.key == "Escape") {
+            hideList();
         }
-    } else if (event.key == "ArrowDown") {
-        if (event.target != autocompletelist.lastChild) {
-            event.target.nextElementSibling.focus();
-        }
-    } else if (event.key == "Escape") {
-        hideList();
-    }
-});
+    });
+
+}
 
 

--- a/Assessments.Frontend.Web/wwwroot/json/categories.json
+++ b/Assessments.Frontend.Web/wwwroot/json/categories.json
@@ -1,7 +1,7 @@
 ﻿{
   "RE": {
     "tagline": "Regionalt utdødd",
-    "description": "– det er svært liten tvil om at arten er dødd ut/har emigrert fra vurderingsområdet.",
+    "description": "– det er svært liten tvil om at {art}en er dødd ut/har emigrert fra vurderingsområdet.",
     "presentationstring": "regionalt utdødd "
   },
   "CR": {

--- a/Assessments.Frontend.Web/wwwroot/json/enums.json
+++ b/Assessments.Frontend.Web/wwwroot/json/enums.json
@@ -21,7 +21,7 @@
     },
     "NewSpecies":
     {
-      "title": "Arten nyoppdaget eller nybeskrevet for landet"
+      "title": "{Art}en nyoppdaget eller nybeskrevet for landet"
     },
     "TaxonomicChange":
     {
@@ -33,15 +33,15 @@
     },
     "NotEvaluated2010":
     {
-      "title": "Ikke vurdert: NA/NE art 2010"
+      "title": "Ikke vurdert: NA/NE {art} 2010"
     },
     "NotEvaluated2015":
     {
-      "title": "Ikke vurdert: NA/NE art 2015"
+      "title": "Ikke vurdert: NA/NE {art} 2015"
     },
     "NotEvaluated2021":
     {
-      "title": "Ikke vurdert: NA/NE art 2021"
+      "title": "Ikke vurdert: NA/NE {art} 2021"
     }
   }
 }

--- a/Assessments.Frontend.Web/wwwroot/json/glossary.json
+++ b/Assessments.Frontend.Web/wwwroot/json/glossary.json
@@ -5,15 +5,15 @@
   },
   "habitat": {
     "tagline": "Habitat",
-    "description": "Artens <a href=\"https://www.artsdatabanken.no/Pages/314252/Metode#316492\">habitat</a> er dens viktigste leveområder. I vurderingene er det laget noen predefinerte habitat basert på inndeling etter <a href=\"https://artsdatabanken.no/NiN/Natursystem/Typeinndeling\">Natur i Norge (NiN)</a> systemet."
+    "description": "{Art}ens <a href=\"https://www.artsdatabanken.no/Pages/314252/Metode#316492\">habitat</a> er dens viktigste leveområder. I vurderingene er det laget noen predefinerte habitat basert på inndeling etter <a href=\"https://artsdatabanken.no/NiN/Natursystem/Typeinndeling\">Natur i Norge (NiN)</a> systemet."
   },
   "region": {
     "tagline": "Regioner og havområder ",
-    "description": " En art er forekommende i et (historisk) fylke eller havområde hvis vesentlige deler av livssyklusen foregår der. <i>Kjent</i> forekomst betyr kjent eller sannsynlig nåværende forekomst. <i>Antatt</i> forekomst brukes om mulig forekomst (basert på eldre observasjoner eller biogeografiske antagelser). <i>Antatt utdødd</i> forekomst brukes når arten muligens har dødd ut lokalt, mens <i>utdødd</i> forekomst betyr at det er overveiende sannsynlighet for at arten har dødd ut i området. Marine arter regnes som forekommende i kystfylker om de opptrer innenfor norsk territorialfarvann ved fylket. Kartet viser den historiske fylkesinndelingen per 1. januar 2018."
+    "description": " En {art} er forekommende i et (historisk) fylke eller havområde hvis vesentlige deler av livssyklusen foregår der. <i>Kjent</i> forekomst betyr kjent eller sannsynlig nåværende forekomst. <i>Antatt</i> forekomst brukes om mulig forekomst (basert på eldre observasjoner eller biogeografiske antagelser). <i>Antatt utdødd</i> forekomst brukes når {art}en muligens har dødd ut lokalt, mens <i>utdødd</i> forekomst betyr at det er overveiende sannsynlighet for at {art}en har dødd ut i området. Marine {art}er regnes som forekommende i kystfylker om de opptrer innenfor norsk territorialfarvann ved fylket. Kartet viser den historiske fylkesinndelingen per 1. januar 2018."
   },
   "criteria": {
-    "tagline": "Hvilke kriterier gjør at denne arten er rødlistet?",
-    "description": "Arten vurderes mot et sett kriterier, og de(t) som gir høyest kategori blir gjeldende. ",
+    "tagline": "Hvilke kriterier gjør at denne {art}en er rødlistet?",
+    "description": "{Art}en vurderes mot et sett kriterier, og de(t) som gir høyest kategori blir gjeldende. ",
     "subheading": "Gjeldende kriterier"
   },
   "generasjonstid": {
@@ -22,7 +22,7 @@
   },
   "TroligUtdodd": {
     "tagline": "Trolig utdødd",
-    "description": "– merkelapp på arter vurdert som <i>kritisk truet</i> CR når det mistenkes, men ikke kan fastslås med sikkerhet, at arten er utdødd."
+    "description": "– merkelapp på {art}er vurdert som <i>kritisk truet</i> CR når det mistenkes, men ikke kan fastslås med sikkerhet, at {art}en er utdødd."
   },
   "vurdert_N": {
     "tagline": "Vurdert for Norge",
@@ -38,7 +38,7 @@
   },
   "populationsize": {
     "title": "Populasjonsandel",
-    "description": "En art er ikke nødvendigvis begrenset til norske områder. Men populasjonen i norske områder utgjør noen ganger en betydelig andel av den totale populasjonen.",
+    "description": "En {art} er ikke nødvendigvis begrenset til norske områder. Men populasjonen i norske områder utgjør noen ganger en betydelig andel av den totale populasjonen.",
     "subtitle": "Nåværende populasjonsstørrelse i vurderingsområdet utgjør:",
     "AndelNåværendeBestand": "av maksimum populasjonsstørrelse etter år 1900 i samme område",
     "MaxAndelAvEuropeiskBestand": "av europeisk populasjonsstørrelse",
@@ -49,9 +49,8 @@
     "description": "Kategori med grader er kategori etter nedgradering/oppgradering av den opprinnelige kategorien (satt etter kriteriene) for vurderingsområdet. Denne justeringen blir gjort når utdøingsrisiko i vurderingsområdet er sterkt påvirket av bestander i naboregioner."
   },
   "oneliners": {
-    "litentvil": "Det er svært liten tvil om at arten er utdødd fra",   
-    "Påvirkningsfaktorer": "Påvirkningsfaktorer er i hovedsak menneskeskapte faktorer som antas å påvirke arten negativt. Klassifiseringssystemet for påvirkningsfaktorer er hierarkisk. Valg av påvirkningsfaktor på et overordnet nivå, eks. \"Påvirkning på habitat\" betyr ikke at alle underliggende nivå nødvendigvis er oppfylt, men at det kan være usikkert hvilke påvirkningsfaktorer på de lavere nivåene som gjør seg gjeldende for arten. For hver påvirkningsfaktor er tidsrom, omfang og alvorlighetsgrad angitt. Omfang og alvorlighetsgrad er relativt til den totale populasjonsstørrelsen eller forekomstarealet.",
-    "habitat_description_2015": "<p>I Rødlista 2015 benyttes Naturtyper i Norge (NiN 1.0) som klassifiseringssystem for å beskrive artenes leveområder (Halvorsen mfl. 2009). Dette klassifiseringssystemet har 4 naturtypenivå: i) landskap, ii) landskapsdel, iii) natursystem, og iv) livsmedium. Mer detaljert informasjon finnes i <a href=\"http://artsdatabanken.no/Files/16095\">veilederen til rødlistevurdering</a>(pdf) og <a href=\"http://www.artsdatabanken.no/NaturiNorge\">Naturtypebasen</a>. Ved registrering av artenes leveområde (hovedhabitat), inkluderes bare de leveområdene som er viktigst for arten. Det innebærer at habitatet skal være relevant for mer enn 20 % av bestanden.</p>",
+    "litentvil": "Det er svært liten tvil om at {art}en er utdødd fra",
+    "Påvirkningsfaktorer": "Påvirkningsfaktorer er i hovedsak menneskeskapte faktorer som antas å påvirke {art}en negativt. Klassifiseringssystemet for påvirkningsfaktorer er hierarkisk. Valg av påvirkningsfaktor på et overordnet nivå, eks. \"Påvirkning på habitat\" betyr ikke at alle underliggende nivå nødvendigvis er oppfylt, men at det kan være usikkert hvilke påvirkningsfaktorer på de lavere nivåene som gjør seg gjeldende for {art}en. For hver påvirkningsfaktor er tidsrom, omfang og alvorlighetsgrad angitt. Omfang og alvorlighetsgrad er relativt til den totale populasjonsstørrelsen eller forekomstarealet.",
     "min": "Minimum (min): ",
     "max": "Maximum (max): ",
     "probable": "Mest trolig",
@@ -61,13 +60,13 @@
   },
   "inkluderingskriterier": {
     "hvorfor": {
-      "title": "Hvorfor er denne arten vurdert?",
-      "description": "Denne arten er rødlistevurdert fordi den ",
+      "title": "Hvorfor er denne {art}en vurdert?",
+      "description": "Denne {art}en er rødlistevurdert fordi den ",
       "else": " enten har etablert bestand i vurderingsområdet, er en regelmessig gjest eller er etablert før 1800."
     },
     "EtablertFør1800": {
-      "title": "er en fremmedart som ble etablert før 1800",
-      "description": "Det vil si at den er en fremmedart, men er antatt eller dokumentert etablert med fast reproduserende populasjon per år 1800. "
+      "title": "er en fremmed{art} som ble etablert før 1800",
+      "description": "Det vil si at den er en fremmed{art}, men er antatt eller dokumentert etablert med fast reproduserende populasjon per år 1800. "
     },
     "EtablertBestandINorge": {
       "title": "har en etablert populasjon i vurderingsområdet",
@@ -78,33 +77,33 @@
       "description": "Det vil si at den ikke er fast reproduserende, men mer enn 2 % av global populasjon oppholder seg regelmessig innenfor vurderingsområdet i deler av sin års-/livssyklus."
     },
     "hvorforikke": {
-      "title": "Hvorfor er ikke arten ",
+      "title": "Hvorfor er ikke {art}en ",
       "NA": "egnet?",
       "NE": "vurdert?"
     },
     "IkkeReproduserendeGjestNA": {
       "title": "Ikke reproduserende gjest",
-      "description": "Arten er ikke etablert med fast reproduserende populasjon og mindre enn 2 % av global populasjon oppholder seg regelmessig innenfor vurderingsområdet (gjest)."
+      "description": "{Art}en er ikke etablert med fast reproduserende populasjon og mindre enn 2 % av global populasjon oppholder seg regelmessig innenfor vurderingsområdet (gjest)."
     },
     "FremmedArtNA": {
-      "title": "Fremmedart",
-      "description": "Arten er fremmed, og ble enten etablert innenfor vurderingsområdet etter år 1800 eller antas å kunne etablere seg innen 50 år (<a href=\"http://www.artsdatabanken.no/Pages/241513/Fleire_artar_bankar_paa\">dørstokkart</a>). "
+      "title": "Fremmed{art}",
+      "description": "{Art}en er fremmed, og ble enten etablert innenfor vurderingsområdet etter år 1800 eller antas å kunne etablere seg innen 50 år (<a href=\"http://www.artsdatabanken.no/Pages/241513/Fleire_artar_bankar_paa\">dørstokk{art}</a>). "
     },
     "ObservertReproduserendeIkkeEtablertNA": {
       "title": "Ikke etablert reproduserende",
-      "description": "Arten er observert reproduserende innenfor vurderingsområdet, men antas å ikke være etablert med fast reproduserende populasjon."
+      "description": "{Art}en er observert reproduserende innenfor vurderingsområdet, men antas å ikke være etablert med fast reproduserende populasjon."
     },
     "ObservertReproduktivIkkeEtablertNA": {
       "title": "Ikke etablert reproduserende ",
-      "description": "Arten er observert i reproduktivt stadium innenfor vurderingsområdet, men antas å ikke være etablert med fast reproduserende populasjon."
+      "description": "{Art}en er observert i reproduktivt stadium innenfor vurderingsområdet, men antas å ikke være etablert med fast reproduserende populasjon."
     },
     "UregelmessigGjestIkkeReproduserendeNA": {
       "title": "Uregelmessig gjest",
-      "description": "Arten opptrer uregelmessig innenfor vurderingsområdet, da som en følge av naturlig forflyttning."
+      "description": "{Art}en opptrer uregelmessig innenfor vurderingsområdet, da som en følge av naturlig forflyttning."
     },
     "IkkeDokumentertForekomstNA": {
       "title": "Ikke dokumentert forekomst",
-      "description": "Arten har ikke dokumentert forekomst innenfor vurderingsområdet."
+      "description": "{Art}en har ikke dokumentert forekomst innenfor vurderingsområdet."
     },
     "HybridartUtenReproduksjonNA": {
       "title": "Hybridart uten reproduksjon",
@@ -116,27 +115,27 @@
     },
     "ForekommerBareIHybridkombinasjonNA": {
       "title": "Forekommer bare i hybridkombinasjon",
-      "description": "Arten forekommer bare i hybridkombinasjon i vurderingsområdet."
+      "description": "{Art}en forekommer bare i hybridkombinasjon i vurderingsområdet."
     },
     "MangelfullKunnskapNE": {
       "title": "Mangelfull kunnskap",
-      "description": "Arten er ikke forsøkt rødlistevurdert på grunn av svært mangelfull kunnskap."
+      "description": "{Art}en er ikke forsøkt rødlistevurdert på grunn av svært mangelfull kunnskap."
     },
     "UavklartSystematikkNE": {
       "title": "Uavklart systematikk",
-      "description": "Arten er ikke forsøkt rødlistevurdert fordi arten eller artsgruppen den tilhører har uavklart systematikk."
+      "description": "{Art}en er ikke forsøkt rødlistevurdert fordi {art}en eller artsgruppen den tilhører har uavklart systematikk."
     },
     "UklartOmReproduserendeBestandNE": {
       "title": "Uklart om reproduserende bestand",
-      "description": "Arten er ikke forsøkt rødlistevurdert fordi det er uavklart om arten er etablert med en fast reproduserende populasjon i vurderingsområdet."
+      "description": "{Art}en er ikke forsøkt rødlistevurdert fordi det er uavklart om {art}en er etablert med en fast reproduserende populasjon i vurderingsområdet."
     },
     "ArtsgruppeIkkeRisikovurdertNE": {
-      "title": "Artsgruppe ikke risikovurdert",
-      "description": "Arten er ikke forsøkt rødlistevurdert fordi den tilhører en artsgruppe som ikke vurderes til Rødlista 2021."
+      "title": "{Art}sgruppe ikke risikovurdert",
+      "description": "{Art}en er ikke forsøkt rødlistevurdert fordi den tilhører en artsgruppe som ikke vurderes til Rødlista 2021."
     },
     "AnnetNE": {
       "title": "Annet",
-      "description": "Arten er ikke forsøkt rødlistevurdert."
+      "description": "{Art}en er ikke forsøkt rødlistevurdert."
     }
   },
   "statistics": {

--- a/Assessments.Frontend.Web/wwwroot/json/impactfactors.json
+++ b/Assessments.Frontend.Web/wwwroot/json/impactfactors.json
@@ -385,7 +385,7 @@
         "title": "Sanking/høsting"
       },
       "3.7.": {
-        "title": "Indirekte via høsting av artens næring"
+        "title": "Indirekte via høsting av {art}ens næring"
       },
       "3.6.": {
         "title": "Andre"

--- a/Assessments.Frontend.Web/wwwroot/json/kriterier.json
+++ b/Assessments.Frontend.Web/wwwroot/json/kriterier.json
@@ -11,14 +11,14 @@
             "title": "Direkte observasjoner"
           },
           "b": {
-            "title": "Egnet bestandsindeks for arten"
+            "title": "Egnet bestandsindeks for {art}en"
           },
           "c": {
             "title": "Redusert forekomstareal, utbredelsesområde og/eller forringet habitatkvalitet"
           },
           "d": {
-            "title": "faktisk eller potensiell høsting/utnytting av arten",
-            "optionaltext": "Reell eller potensiell utnytting av arten"
+            "title": "faktisk eller potensiell høsting/utnytting av {art}en",
+            "optionaltext": "Reell eller potensiell utnytting av {art}en"
           },
           "e": {
             "title": "Negativ påvirkning fra innførte arter, hybridisering, patogener, forurensning, konkurrerende arter eller parasitter"
@@ -44,14 +44,14 @@
             "title": "Direkte observasjoner"
           },
           "b": {
-            "title": "Egnet bestandsindeks for arten"
+            "title": "Egnet bestandsindeks for {art}en"
           },
           "c": {
             "title": "Redusert forekomstareal, utbredelsesområde og/eller forringet habitatkvalitet"
           },
           "d": {
-            "title": "faktisk eller potensiell høsting/utnytting av arten",
-            "optionaltext": "Reell eller potensiell utnytting av arten"
+            "title": "faktisk eller potensiell høsting/utnytting av {art}en",
+            "optionaltext": "Reell eller potensiell utnytting av {art}en"
           },
           "e": {
             "title": "Negativ påvirkning fra innførte arter, hybridisering, patogener, forurensning, konkurrerende arter eller parasitter"
@@ -74,14 +74,14 @@
         "description": "Fremtidig reduksjon over et tidsrom på 3 generasjoner, men minimum 10 år.",
         "subsub": {
           "b": {
-            "title": "Egnet bestandsindeks for arten"
+            "title": "Egnet bestandsindeks for {art}en"
           },
           "c": {
             "title": "Redusert forekomstareal, utbredelsesområde og/eller forringet habitatkvalitet"
           },
           "d": {
-            "title": "faktisk eller potensiell høsting/utnytting av arten",
-            "optionaltext": "Reell eller potensiell utnytting av arten"
+            "title": "faktisk eller potensiell høsting/utnytting av {art}en",
+            "optionaltext": "Reell eller potensiell utnytting av {art}en"
           },
           "e": {
             "title": "Negativ påvirkning fra innførte arter, hybridisering, patogener, forurensning, konkurrerende arter eller parasitter"
@@ -107,14 +107,14 @@
             "title": "Direkte observasjoner"
           },
           "b": {
-            "title": "Egnet bestandsindeks for arten"
+            "title": "Egnet bestandsindeks for {art}en"
           },
           "c": {
             "title": "Redusert forekomstareal, utbredelsesområde og/eller forringet habitatkvalitet"
           },
           "d": {
-            "title": "faktisk eller potensiell høsting/utnytting av arten",
-            "optionaltext": "Reell eller potensiell utnytting av arten"
+            "title": "faktisk eller potensiell høsting/utnytting av {art}en",
+            "optionaltext": "Reell eller potensiell utnytting av {art}en"
           },
           "e": {
             "title": "Negativ påvirkning fra innførte arter, hybridisering, patogener, forurensning, konkurrerende arter eller parasitter"
@@ -172,7 +172,7 @@
             "title": "forekomstareal"
           },
           "iii": {
-            "title": "areal eller kvalitet på artens habitat"
+            "title": "areal eller kvalitet på {art}ens habitat"
           },
           "iv": {
             "title": "antall lokaliteter eller delpopulasjoner"
@@ -203,7 +203,7 @@
     "subcriteria": {
       "B1": {
         "title": "Utbredelsesområde",
-        "description": "Utbredelsesområde er et mål for en arts geografiske utbredelse, og tilsvarer arealet av en minimum konveks polygon der de rette linjene i polygonen omfatter alle kjente og antatte nåværende forekomster. ",
+        "description": "Utbredelsesområde er et mål for en {art}s geografiske utbredelse, og tilsvarer arealet av en minimum konveks polygon der de rette linjene i polygonen omfatter alle kjente og antatte nåværende forekomster. ",
         "content": {
           "unit": "km&#178;",
           "comparator": "<",
@@ -217,7 +217,7 @@
       },
       "B2": {
         "title": "Forekomstareal",
-        "description": "Forekomstareal er et mål for det spesifikke arealet arten lever i, standardisert som summen av alle 2 km x 2 km (4 km&#178;) ruter som inneholder kjent eller antatt forekomst av arten. ",
+        "description": "Forekomstareal er et mål for det spesifikke arealet {art}en lever i, standardisert som summen av alle 2 km x 2 km (4 km&#178;) ruter som inneholder kjent eller antatt forekomst av {art}en. ",
         "content": {
           "unit": "km&#178;",
           "comparator": "<",

--- a/Assessments.Frontend.Web/wwwroot/json/speciesgroup.json
+++ b/Assessments.Frontend.Web/wwwroot/json/speciesgroup.json
@@ -46,7 +46,7 @@
   },
   "Hydrozoer": {
     "url": " https://artsdatabanken.no/Rodliste/Artsgruppene/Hydrozoer",
-    "image": "https://design.artsdatabanken.no/icons/Hydrozoa.svg",
+    "image": "https://design.artsdatabanken.no/icons/Hydrozoa.png",
     "tagline": "Hydrozoa"
   },
   "Kakerlakker": {
@@ -166,7 +166,7 @@
   },
   "Stormaneter": {
     "url": " https://artsdatabanken.no/Rodliste/Artsgruppene/Stormaneter",
-    "image": "https://design.artsdatabanken.no/icons/Stormaneter.svg",
+    "image": "https://design.artsdatabanken.no/icons/Stormaneter.png",
     "tagline": "Scyphozoa"
   },
   "Svamper": {

--- a/Assessments.Mapping/Models/Source/Species/Rodliste2019.cs
+++ b/Assessments.Mapping/Models/Source/Species/Rodliste2019.cs
@@ -292,6 +292,7 @@ namespace Assessments.Mapping.Models.Source.Species
         public string ÅrsakTilNedgraderingAvKategori { get; set; }
 
         public Taxonomy TaxonomyInfo { get; set; }
+        public string Endringslogg { get; set; }
 
         public class Taxonomy
         {

--- a/Assessments.Mapping/Models/Source/Species/Rodliste2019.cs
+++ b/Assessments.Mapping/Models/Source/Species/Rodliste2019.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Assessments.Mapping.Models.Species;
 
 namespace Assessments.Mapping.Models.Source.Species
 {
@@ -293,6 +294,12 @@ namespace Assessments.Mapping.Models.Source.Species
 
         public Taxonomy TaxonomyInfo { get; set; }
         public string Endringslogg { get; set; }
+        
+        // enhansed props - not really there
+        public DateTime RevisionDate { get; set; }
+        public int Revision { get; set; }
+        public List<Rodliste2019> Revisions { get; set; }
+        public string RevisionReason { get; set; }
 
         public class Taxonomy
         {

--- a/Assessments.Mapping/Models/Species/SpeciesAssessment2021.cs
+++ b/Assessments.Mapping/Models/Species/SpeciesAssessment2021.cs
@@ -348,5 +348,22 @@ namespace Assessments.Mapping.Models.Species
         /// Group the species belongs to, in most cases a taxonomic group
         /// </summary>
         public string SpeciesGroup { get; set; }
+
+        /// <summary>
+        /// Publish date of assessment
+        /// </summary>
+        public DateTime RevisionDate { get; set; }
+        /// <summary>
+        /// Revision number
+        /// </summary>
+        public int Revision { get; set; }
+        /// <summary>
+        ///  List of revisions (Only for Current revision - point to older)
+        /// </summary>
+        public List<SpeciesAssessment2021> Revisions { get; set; }
+        /// <summary>
+        /// A text explaining the need for a new revision - no text on oldest revision 
+        /// </summary>
+        public string RevisionReason { get; set; }
     }
 }

--- a/Assessments.Mapping/SpeciesAssessment2021Profile.cs
+++ b/Assessments.Mapping/SpeciesAssessment2021Profile.cs
@@ -144,6 +144,7 @@ namespace Assessments.Mapping
                 .ForMember(dest => dest.ReasonCategoryChange, opt => opt.MapFrom(src => SpeciesAssessment2021ProfileHelper.EvaluateCategoryChangeReason(src)))
                 .ForMember(dest => dest.RationaleCategoryAdjustment, opt => opt.MapFrom(src => HtmlCleaner.MakeHtmlSafe(src.ÅrsakTilNedgraderingAvKategori,true)))
                 .ForMember(dest=> dest.PreviousAssessments, opt=> opt.MapFrom(src => SpeciesAssessment2021ProfileHelper.GetPreviousAssessments(src)))
+                .ForMember(dest => dest.RevisionReason, opt=> opt.MapFrom(src => HtmlCleaner.MakeHtmlSafe(src.Endringslogg, true)))
                     .AfterMap((src, dest) =>
                 {
                     SpeciesAssessment2021ProfileHelper.BlankCriteriaSumarizedBasedOnCategory(dest);

--- a/Assessments.Mapping/SpeciesAssessment2021Profile.cs
+++ b/Assessments.Mapping/SpeciesAssessment2021Profile.cs
@@ -145,7 +145,10 @@ namespace Assessments.Mapping
                 .ForMember(dest => dest.RationaleCategoryAdjustment, opt => opt.MapFrom(src => HtmlCleaner.MakeHtmlSafe(src.ÅrsakTilNedgraderingAvKategori,true)))
                 .ForMember(dest=> dest.PreviousAssessments, opt=> opt.MapFrom(src => SpeciesAssessment2021ProfileHelper.GetPreviousAssessments(src)))
                 .ForMember(dest => dest.RevisionReason, opt=> opt.MapFrom(src => HtmlCleaner.MakeHtmlSafe(src.Endringslogg, true)))
-                    .AfterMap((src, dest) =>
+                .ForMember(dest => dest.Revision, opt => opt.MapFrom(src => src.Revision))
+                .ForMember(dest => dest.RevisionDate, opt => opt.MapFrom(src => src.RevisionDate))
+                .ForMember(dest => dest.Revisions, opt => opt.MapFrom(src => src.Revisions))
+                .AfterMap((src, dest) =>
                 {
                     SpeciesAssessment2021ProfileHelper.BlankCriteriaSumarizedBasedOnCategory(dest);
                     SpeciesAssessment2021ProfileHelper.BlankReasonCategoryChangeWhenNoChange(src, dest);

--- a/Assessments.Transformation/Database/Rodliste2020/Models/Assessment.cs
+++ b/Assessments.Transformation/Database/Rodliste2020/Models/Assessment.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.ObjectModel;
 
 namespace Assessments.Transformation.Database.Rodliste2020.Models
 {
@@ -24,5 +25,39 @@ namespace Assessments.Transformation.Database.Rodliste2020.Models
         public string NatureTypes { get; set; }
         public string RedListAssessedSpecies { get; set; }
         public int? AssessmentYear { get; set; }
+    }
+    public class AssessmentHistory
+    {
+        public int Id { get; set; }
+        public DateTime HistoryAt { get; set; }
+        public string Expertgroup { get; set; }
+        public string EvaluationStatus { get; set; }
+        public string LastUpdatedBy { get; set; }
+        public DateTime LastUpdatedAt { get; set; }
+        public string LockedForEditByUser { get; set; }
+        public DateTime LockedForEditAt { get; set; }
+        public string Doc { get; set; }
+        public virtual Collection<AssessmentRevision> AssessmentRevisions { get; set; }
+    }
+    public class AssessmentRevision
+    {
+        /// <summary>
+        /// Assessment Id
+        /// </summary>
+        public int Id { get; set; }
+        /// <summary>
+        /// Initial revision is 1 - then count up
+        /// </summary>
+        public int RevisionId { get; set; }
+        /// <summary>
+        /// datetime to represent this historic revision
+        /// </summary>
+        public DateTime RevisionDateTime { get; set; }
+        /// <summary>
+        /// datetime stamp to represent release of next revision - when only 1 - represents '2' --- and so forth
+        /// </summary>
+        public DateTime FutureRevisionDateTime { get; set; }
+
+        public virtual AssessmentHistory AssessmentHistory { get; set; }
     }
 }

--- a/Assessments.Transformation/Program.cs
+++ b/Assessments.Transformation/Program.cs
@@ -87,6 +87,8 @@ namespace Assessments.Transformation
             });
 
             var databaseAssessments = _dbContext.Assessments.AsNoTracking().Where(x => (bool)!x.IsDeleted && x.Expertgroup != "Testarter" && x.Expertgroup != "Moser (Svalbard)");
+            var revisions = await _dbContext.AssessmentRevisions.AsNoTracking().Include(x => x.AssessmentHistory).ToArrayAsync();
+
             var totalCount = await databaseAssessments.CountAsync();
 
             _progressBar.Tick(0, $"Transformerer {totalCount:N0} vurderinger");
@@ -95,6 +97,12 @@ namespace Assessments.Transformation
             var rodliste2019Assessments = new List<Rodliste2019>();
             var speciesAssessment2021Mapper = new MapperConfiguration(cfg => cfg.AddProfile<SpeciesAssessment2021Profile>()).CreateMapper();
             var speciesAssessment2021Assessments = new List<SpeciesAssessment2021>();
+            var revisionsTransformed = revisions.Select(x => new
+            {
+                Id = x.Id, Revision = x.RevisionId, RevDate = x.RevisionDateTime,
+                FutureRevisionDate = x.FutureRevisionDateTime,
+                Assessment = speciesAssessment2021Mapper.Map<SpeciesAssessment2021>(JsonConvert.DeserializeObject<Rodliste2019>(x.AssessmentHistory.Doc))
+            }).GroupBy(x=>x.Id).ToDictionary(x => x.Key);
 
             foreach (var item in databaseAssessments)
             {
@@ -104,6 +112,23 @@ namespace Assessments.Transformation
                 {
                     assessmentForTransformation.Id = id;
                     var transformedAssessment = speciesAssessment2021Mapper.Map<SpeciesAssessment2021>(assessmentForTransformation);
+
+                    // revisions
+                    transformedAssessment.RevisionDate = new DateTime(2021,11,24);
+                    if (revisionsTransformed.ContainsKey(transformedAssessment.Id))
+                    {
+                        var list = revisionsTransformed[transformedAssessment.Id].OrderBy(x => x.Revision).ToArray();
+                        foreach (var innerItem in list)
+                        {
+                            transformedAssessment.RevisionDate = innerItem.FutureRevisionDate;
+                            var innerAssessment = innerItem.Assessment;
+                            innerAssessment.RevisionDate = innerItem.RevDate;
+                            innerAssessment.Revision = innerItem.Revision;
+                            innerAssessment.Id = transformedAssessment.Id;
+                            if (transformedAssessment.Revisions == null) transformedAssessment.Revisions = new List<SpeciesAssessment2021>();
+                            transformedAssessment.Revisions.Add(innerAssessment);
+                        }
+                    }
                     speciesAssessment2021Assessments.Add(transformedAssessment);
                 }
 


### PR DESCRIPTION
Jeg får ikke testrigget til å fungere, så her tror jeg vi får gå for å manuelt dytte ut løsningen i test.

- Artsbegrep (testet av @matssa)
- Svg -> png (testet av @matssa )
- #492 -> se https://github.com/Artsdatabanken/assessments-frontend/pull/527

https://beta.artsdatabanken.no/lister/rodlisteforarter/2021/25442
Sistnevnte må testes grundig, i live-miljø, så fort vi får tilgang på korrekte data.
Per nå ser det ut til at @steinho sin fix ikke gir tilgang på disse dataene på samme måte som lokalt. 

