### PR TITLE
Fix citation url in list view

### DIFF
--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/List/partials/_Citation.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/List/partials/_Citation.cshtml
@@ -1,7 +1,8 @@
-﻿
+﻿@using Microsoft.AspNetCore.Http.Extensions
+
 <div class="mobile_padding">
     <h2>Sitering</h2>
     <p class="citation">
-        Artsdatabanken (2021, 24. november). Norsk rødliste for arter 2021. https://www.artsdatabanken.no/rodlisteforarter/2021
+        Artsdatabanken (2021, 24. november). Norsk rødliste for arter 2021. @Context.Request.GetEncodedUrl().Split('?', '#')[0]
     </p>
 </div>


### PR DESCRIPTION
gjør om hardkodet url (som var feil) i listevisningen til å vise faktisk side man er på (uten url parametere)
url blir nå riktig i alle miljø og på alle domener (også om applikasjonen flyttes, eller url endres via f.eks routing)