### PR TITLE
fix bad link navigating to assessment

### DIFF
--- a/Assessments.Frontend.Web/wwwroot/js/search.js
+++ b/Assessments.Frontend.Web/wwwroot/js/search.js
@@ -122,7 +122,7 @@ function searchForTaxa(sciname) {
 }
 
 function goToAssesment(id) {
-    window.location.href = window.location.pathname + '/' + id;
+    window.location.href = (window.location.pathname + '/' + id).replace('//', '/');
 }
 
 const createList = (json,searchstring) => {


### PR DESCRIPTION
fixes #564 
Mulig noen nettlesere slenger på en '/' bak window.location.pathname, mens andre ikke gjør det.. Det skal nå funke i begge tilfeller.