### PR TITLE
Add querystring extension, keep query parameters in pagers

### DIFF
--- a/Assessments.Frontend.Web/Infrastructure/Extensions.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Extensions.cs
@@ -1,6 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Text;
+using DocumentFormat.OpenXml.InkML;
+using System.Web;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 
 namespace Assessments.Frontend.Web.Infrastructure
 {
@@ -45,6 +50,19 @@ namespace Assessments.Frontend.Web.Infrastructure
 
             return sb.ToString();
         }
+        
+        public static RouteValueDictionary ToRouteValues(this QueryString queryString, object obj)
+        {
+            var valueCollection = HttpUtility.ParseQueryString(queryString.ToString());
 
+            var values = new RouteValueDictionary(obj);
+
+            foreach (string key in valueCollection)
+            {
+                if (key != null && !values.ContainsKey(key)) values[key] = valueCollection[key];
+            }
+
+            return values;
+        }
     }
 }

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesIndex.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesIndex.cshtml
@@ -1,4 +1,5 @@
-﻿@model AlienSpeciesListViewModel
+﻿@using Microsoft.AspNetCore.Mvc.TagHelpers
+@model AlienSpeciesListViewModel
 
 @{
     CitationViewModel citationViewModel = new CitationViewModel
@@ -72,10 +73,7 @@
                     Viser side @Model.Results.PageNumber av @Model.Results.PageCount.ToString("N0")
                 </p>
 
-                @Html.PagedListPager(Model.Results, page => Url.Action("Index", new
-                {
-                Page = page
-                }), new PagedListRenderOptions
+                @Html.PagedListPager(Model.Results, page => Url.Action("Index", Context.Request.QueryString.ToRouteValues(new { Page = page })), new PagedListRenderOptions
                 {
                 PageClasses = new[] { "page-link" },
                 UlElementClasses = new[] { "pagination" },

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesIndex.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesIndex.cshtml
@@ -49,37 +49,13 @@
             </form>
 
             <div is-visible="@Model.Results.Any()">
-
                 <form>
                     <button type="submit" name="Export" value="true" formtarget="_blank">
                         <span class="material-icons">file_download</span> Eksporter
                     </button>
                 </form>
-
-                <ul>
-                    @foreach (var item in Model.Results)
-                    {
-                        <li>
-                            <a asp-action="Detail" asp-route-id="@item.Id">
-                                @item.Id  @item.ScientificName
-                            </a>
-                        </li>
-                    }
-                </ul>
             </div>
 
-            <div is-visible="@Model.Results.PageCount > 1">
-                <p class="page_count">
-                    Viser side @Model.Results.PageNumber av @Model.Results.PageCount.ToString("N0")
-                </p>
-
-                @Html.PagedListPager(Model.Results, page => Url.Action("Index", Context.Request.QueryString.ToRouteValues(new { Page = page })), new PagedListRenderOptions
-                {
-                PageClasses = new[] { "page-link" },
-                UlElementClasses = new[] { "pagination" },
-                LiElementClasses = new[] { "page-item" }
-                })
-            </div>
             <partial name="/Views/Shared/_Citation.cshtml" model="citationViewModel"/>
         </div>
     </div>

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/ListPartials/_Paginator.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/ListPartials/_Paginator.cshtml
@@ -1,6 +1,4 @@
 @model AlienSpeciesListViewModel
-@using X.PagedList.Mvc.Core;
-@using X.PagedList.Web.Common
 
 @if (Model.Results.PageCount > 1
     @*&& Model.View != "stat"*@
@@ -10,21 +8,7 @@
         Viser side @Model.Results.PageNumber av @Model.Results.PageCount.ToString("N0")
     </p>
 
-    @Html.PagedListPager(Model.Results, page => Url.Action("Index", new
-    {
-        Page = page,
-        Name = Context.Request.Query["Parameters.Name"],
-        SortBy = Context.Request.Query["Parameters.SortBy"],
-        Area = Context.Request.Query["Parameters.Area"],
-        Category = Context.Request.Query["Parameters.Category"],
-        //Criterias = Context.Request.Query["Parameters.Criterias"],
-        //TaxonRank = Context.Request.Query["Parameters.TaxonRank"],
-        Regions = Context.Request.Query["Parameters.Regions"],
-        Habitats = Context.Request.Query["Parameters.Habitats"],
-        SpeciesGroups = Context.Request.Query["Parameters.SpeciesGroups"],
-        IsCheck = Context.Request.Query["Parameters.IsCheck"],
-        Meta = Context.Request.Query["Parameters.Meta"]
-    }), new PagedListRenderOptions
+    @Html.PagedListPager(Model.Results, page => Url.Action("Index", Context.Request.QueryString.ToRouteValues(new { Page = page })), new PagedListRenderOptions
     {
         PageClasses = new[] { "page-link" },
         UlElementClasses = new[] { "pagination" },

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/List/partials/_Paginator.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/List/partials/_Paginator.cshtml
@@ -1,6 +1,4 @@
 @model RL2021ViewModel
-@using X.PagedList.Mvc.Core;
-@using X.PagedList.Web.Common
 
 @if (Model.Redlist2021Results.PageCount > 1 && Model.View != "stat")
 {
@@ -8,23 +6,7 @@
         Viser side @Model.Redlist2021Results.PageNumber av @Model.Redlist2021Results.PageCount.ToString("N0")
     </p>
 
-    @Html.PagedListPager(Model.Redlist2021Results, page => Url.Action("Index2021", new
-    {
-        Page = page,
-        Name = Context.Request.Query["Name"],
-        SortBy = Context.Request.Query["SortBy"],
-        Area = Context.Request.Query["Area"],
-        Category = Context.Request.Query["Category"],
-        Criterias = Context.Request.Query["Criterias"],
-        TaxonRank = Context.Request.Query["TaxonRank"],
-        EuroPop = Context.Request.Query["EuroPop"],
-        Regions = Context.Request.Query["Regions"],
-        Habitats = Context.Request.Query["Habitats"],
-        SpeciesGroups = Context.Request.Query["SpeciesGroups"],
-        PresumedExtinct = Context.Request.Query["PresumedExtinct"],
-        IsCheck = Context.Request.Query["IsCheck"],
-        Meta = Context.Request.Query["Meta"]
-    }), new PagedListRenderOptions
+    @Html.PagedListPager(Model.Redlist2021Results, page => Url.Action("Index2021", Context.Request.QueryString.ToRouteValues(new { Page = page })), new PagedListRenderOptions
     {
         PageClasses = new[] { "page-link" },
         UlElementClasses = new[] { "pagination" },


### PR DESCRIPTION
la til utvidelse som hjelper å sette inn alle querystring parametere i lenkene for paginering - slik at man slipper å sette inn disse manuelt

- fjernet gammel kode med liste og paginering
- implementert i pagingering på rødlista også