### PR TITLE
make category enum

### DIFF
--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
@@ -13,6 +13,11 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
                 query = query.Where(x => x.ScientificName.ToLowerInvariant()
                     .Contains(parameters.Name.ToLowerInvariant()));
 
+            if (parameters.Category.Any())
+            {
+                // TODO: implementere filter
+            }
+
             if (string.IsNullOrEmpty(parameters.SortBy) || parameters.SortBy.Equals(nameof(AlienSpeciesAssessment2023.ScientificName), StringComparison.InvariantCultureIgnoreCase))
             {
                 query = query.OrderBy(x => x.ScientificName);

--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
@@ -14,9 +14,7 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
                     .Contains(parameters.Name.ToLowerInvariant()));
 
             if (parameters.Category.Any())
-            {
-                // TODO: implementere filter
-            }
+                query = query.Where(x => parameters.Category.Select(y => (AlienSpeciesAssessment2023Category)Enum.Parse(typeof(AlienSpeciesAssessment2023Category), y)).Contains(x.Category));
 
             if (string.IsNullOrEmpty(parameters.SortBy) || parameters.SortBy.Equals(nameof(AlienSpeciesAssessment2023.ScientificName), StringComparison.InvariantCultureIgnoreCase))
             {

--- a/Assessments.Frontend.Web/Infrastructure/Categories.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Categories.cs
@@ -1,54 +1,21 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Assessments.Mapping.AlienSpecies;
+using Assessments.Shared.Helpers;
 
 namespace Assessments.Frontend.Web.Infrastructure
 {
     public class Categories
     {
         public static readonly Filter.FilterItem[] AlienSpecies2023Categories =
-        {
-            new Filter.FilterItem()
-            {
-                NameShort = "SE",
-                Name = "Svært høy risiko",
-                Description = "svært høy risiko"
-            },
-            new Filter.FilterItem()
-            {
-                NameShort = "HI",
-                Name = "Høy risiko",
-                Description = "høy risiko"
-            },
-            new Filter.FilterItem()
-            {
-                NameShort = "PH",
-                Name = "Potensielt høy risiko",
-                Description = "potensielt høy risiko"
-            },
-            new Filter.FilterItem()
-            {
-                NameShort = "LO",
-                Name = "Lav risiko",
-                Description = "lav risiko"
-            },
-            new Filter.FilterItem()
-            {
-                NameShort = "NK",
-                Name = "Ingen kjent risiko",
-                Description = "ingen kjent risiko"
-            },
-            new Filter.FilterItem()
-            {
-                NameShort = "NR",
-                Name = "Ikke vurdert",
-                Description = "ikke vurdert"
-            }
-        };
+            new List<AlienSpeciesAssessment2023Category>(
+                    (AlienSpeciesAssessment2023Category[])Enum.GetValues(typeof(AlienSpeciesAssessment2023Category)))
+                .Select(x => new Filter.FilterItem
+                {
+                    NameShort = x.ToString(),
+                    Name = x.DisplayName().ToLowerInvariant(),
+                    Description = x.DisplayName()
+                }).ToArray();
     }
 }
-
-
-//"CR": {
-//    "tagline": "Kritisk truet",
-//    "description": "– ekstremt høy risiko for utdøing.",
-//    "presentationstring": "kritisk truet "
-//  },

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesDetail.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesDetail.cshtml
@@ -46,9 +46,9 @@
     {
          AssessmentYear = 2023,
          Category = Categories.AlienSpecies2023Categories
-                                                        .Where(x => x.NameShort == assessment.Category)
+                                                        .Where(x => x.NameShort == assessment.Category.ToString())
                                                         .Select(x => x.Name).FirstOrDefault(),
-         CategoryShort = assessment.Category,
+         CategoryShort = assessment.Category.ToString(),
          PreviousAssessments = assessment.PreviousAssessments.Select(x => new SideBarContentViewModel.SideBarPreviousAssessment()
          {
              Category = Categories.AlienSpecies2023Categories

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/ListPartials/_ListView.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/ListPartials/_ListView.cshtml
@@ -40,16 +40,12 @@
                     </span>
 
                     <span class="list_cell categoryname capitalized">
-                        @if (!string.IsNullOrEmpty(item.AlienSpeciesCategory))
-                        {
-                            @item.AlienSpeciesCategory
-                            <span class="degrees">@Helpers.findDegrees(item.AlienSpeciesCategory, false)</span>
-                        }
+                        @item.Category.DisplayName()
                     </span>
 
                     <span class="list_cell categorytag">
-                        <span class="@item.AlienSpeciesCategory.Substring(0,2) category_tag">
-                            <span class="category_tag_label">@item.AlienSpeciesCategory</span>
+                        <span class="@item.Category category_tag">
+                            <span class="category_tag_label">@item.Category</span>
                         </span>
                     </span>
 

--- a/Assessments.Mapping/AlienSpecies/AlienSpeciesAssessment2023.cs
+++ b/Assessments.Mapping/AlienSpecies/AlienSpeciesAssessment2023.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
 namespace Assessments.Mapping.AlienSpecies

--- a/Assessments.Mapping/AlienSpecies/AlienSpeciesAssessment2023.cs
+++ b/Assessments.Mapping/AlienSpecies/AlienSpeciesAssessment2023.cs
@@ -102,7 +102,7 @@ namespace Assessments.Mapping.AlienSpecies
         [Display(Name = "Ingen kjent risiko")] 
         NK,
 
-        [Display(Name = "Ikke risikovurdert ")]
+        [Display(Name = "Ikke risikovurdert")]
         NR
     }
 

--- a/Assessments.Mapping/AlienSpecies/AlienSpeciesAssessment2023.cs
+++ b/Assessments.Mapping/AlienSpecies/AlienSpeciesAssessment2023.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 
 namespace Assessments.Mapping.AlienSpecies
 {
@@ -12,23 +14,23 @@ namespace Assessments.Mapping.AlienSpecies
         /// <summary>
         /// Was the alien species established by year 1800? If true the alien species is not risk assessed
         /// </summary>
-        public bool? AlienSpecieUncertainIfEstablishedBefore1800 { get; set;}
-        
+        public bool? AlienSpecieUncertainIfEstablishedBefore1800 { get; set; }
+
         /// <summary>
         /// Final category according to GEIAAS categories and criteria
         /// </summary>
-        public string Category { get; set; }
+        public AlienSpeciesAssessment2023Category Category { get; set; }
 
         /// <summary>
         /// Establishment category in Norway today. The alien species may not be in Norway, be represented in Norway by sporadic, ephemeral occurrences, or by populations that are locally self-sustaining or strongly expanding
         /// </summary>
-        public string EstablishmentCategory { get; set; } 
-        
+        public string EstablishmentCategory { get; set; }
+
         /// <summary>
         /// Geographic area assessed
         /// </summary>
         public string EvaluationContext { get; set; }
-        
+
         /// <summary>
         /// Name of ekspert committee that conducted the assessments 
         /// </summary>
@@ -38,11 +40,11 @@ namespace Assessments.Mapping.AlienSpecies
         /// The unique identifier
         /// </summary>
         public int Id { get; set; }
-        
+
         /// <summary>
         /// Free text field used to describe uncertainty around the species' status as alien
         /// </summary>
-        public string IsAlien { get; set; } 
+        public string IsAlien { get; set; }
 
         /// <summary>
         /// List including category and decisive criteria from previous assessments
@@ -63,12 +65,12 @@ namespace Assessments.Mapping.AlienSpecies
         /// Author of the scienfic name
         /// </summary>
         public string ScientificNameAuthor { get; set; }
-        
+
         /// <summary>
         /// An identifier for the nomenclatural (not taxonomic) details of a scientific name
         /// </summary>
         public int ScientificNameId { get; set; }
-        
+
         /// <summary>
         /// Taxonomy path
         /// </summary>
@@ -78,8 +80,31 @@ namespace Assessments.Mapping.AlienSpecies
         /// Norwegian common names
         /// </summary>
         public string VernacularName { get; set; }
-        
-        
+    }
+
+    public enum AlienSpeciesAssessment2023Category
+    {
+        // ReSharper disable InconsistentNaming
+        [Display(Name = "Ukjent")] 
+        Undefined,
+
+        [Display(Name = "Svært høy risiko")] 
+        SE,
+
+        [Display(Name = "Høy risiko")]
+        HI,
+
+        [Display(Name = "Potensielt høy risiko")]
+        PH,
+
+        [Display(Name = "Lav risiko")] 
+        LO,
+
+        [Display(Name = "Ingen kjent risiko")] 
+        NK,
+
+        [Display(Name = "Ikke risikovurdert ")]
+        NR
     }
 
     public class AlienSpeciesAssessment2023PreviousAssessment
@@ -87,7 +112,7 @@ namespace Assessments.Mapping.AlienSpecies
         public int RevisionYear { get; set; } = 2018;
 
         public string AssessmentId { get; set; }
-        public int RiskLevel { get; set;}
+        public int RiskLevel { get; set; }
         /// <summary>
         /// Evaluation  'tag' for the species in 2018 or 2012
         /// </summary>

--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
@@ -17,7 +17,6 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                 .ForMember(dest => dest.AlienSpeciesCategory, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAlienSpeciesCategory(src.AlienSpeciesCategory, src.ExpertGroup)))
                 .ForMember(dest => dest.ExpertGroup, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetExpertGroup(src.ExpertGroup)))
                 .ForMember(dest => dest.EstablishmentCategory, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetEstablishmentCategory(src.SpeciesEstablishmentCategory, src.SpeciesStatus)))
-                .ForMember(dest => dest.Category, opt => opt.MapFrom(src => src.Category))
                 ;
 
             CreateMap<FA4.PreviousAssessment, AlienSpeciesAssessment2023PreviousAssessment>();

--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
@@ -17,12 +17,10 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                 .ForMember(dest => dest.AlienSpeciesCategory, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAlienSpeciesCategory(src.AlienSpeciesCategory, src.ExpertGroup)))
                 .ForMember(dest => dest.ExpertGroup, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetExpertGroup(src.ExpertGroup)))
                 .ForMember(dest => dest.EstablishmentCategory, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetEstablishmentCategory(src.SpeciesEstablishmentCategory, src.SpeciesStatus)))
+                .ForMember(dest => dest.Category, opt => opt.MapFrom(src => src.Category))
                 ;
-                
-
 
             CreateMap<FA4.PreviousAssessment, AlienSpeciesAssessment2023PreviousAssessment>();
-
         }
     }
 }

--- a/Assessments.Shared/Helpers/Extensions.cs
+++ b/Assessments.Shared/Helpers/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
 
@@ -30,6 +31,12 @@ namespace Assessments.Shared.Helpers
         {
             var attribute = value.GetAttribute<DescriptionAttribute>();
             return attribute == null ? value.ToString() : attribute.Description;
+        }
+
+        public static string DisplayName(this Enum value)
+        {
+            var attribute = value.GetAttribute<DisplayAttribute>();
+            return attribute == null ? value.ToString() : attribute.Name;
         }
     }
 }


### PR DESCRIPTION
gjøre om category til enum, close #657 

- category er nå gjort om til enum, endret datamodellen og la til mapping
- category inneholder navn (via en "displayname" attributt) og verdi (selve kategorien)
- la til utvidelse for å vise "displayname"
- erstattet hardkodet liste med kategorier med ny enum (mulig å legge til beskrivelse på enum også, men virket som den originale listen bare brukte beskrivelse i små bokstaver fra navn(!?)
- byttet fra alienspeciescategory (som var tatt i bruk for tidlig) til category i visning

alle vurderinger har nå category, la til en som heter "Undefined" for de som mangler
disse vises også i listen, vi kan velge å ta de bort når vi transformerer data fra databasen, eller la de ligge så lenge så man ser de (siden de faktisk er med slik det er i koden som generer data nå)
"Undefined" skal sikkert heller ikke vises i filteret på et tidspunkt, men kanskje greit å ha den eksponert så lenge også

det var knotete å bytte om til enum "overalt" siden filter er satt opp litt avansert - løser det ved å konvertere frem og tilbake til string og lar det ellers være sånn det var..
