### PR TITLE
Added fields for criteria and scores 

### DIFF
--- a/Assessments.Mapping/AlienSpecies/AlienSpeciesAssessment2023.cs
+++ b/Assessments.Mapping/AlienSpecies/AlienSpeciesAssessment2023.cs
@@ -20,6 +20,11 @@ namespace Assessments.Mapping.AlienSpecies
         public string Category { get; set; }
 
         /// <summary>
+        /// Decisive criteria according to GEIAAS method
+        /// </summary>
+        public string Criteria { get; set; }
+
+        /// <summary>
         /// Establishment category in Norway today. The alien species may not be in Norway, be represented in Norway by sporadic, ephemeral occurrences, or by populations that are locally self-sustaining or strongly expanding
         /// </summary>
         public string EstablishmentCategory { get; set; } 
@@ -38,7 +43,7 @@ namespace Assessments.Mapping.AlienSpecies
         /// The unique identifier
         /// </summary>
         public int Id { get; set; }
-        
+
         /// <summary>
         /// Free text field used to describe uncertainty around the species' status as alien
         /// </summary>
@@ -68,7 +73,17 @@ namespace Assessments.Mapping.AlienSpecies
         /// An identifier for the nomenclatural (not taxonomic) details of a scientific name
         /// </summary>
         public int ScientificNameId { get; set; }
-        
+
+        /// <summary>
+        /// The species' total score on the ecological effect axis
+        /// </summary>
+        public int? ScoreEcologicalEffect { get; set; }
+
+        /// <summary>
+        /// The species' total score on the invation axis
+        /// </summary>
+        public int? ScoreInvationPotential { get; set; }
+
         /// <summary>
         /// Taxonomy path
         /// </summary>

--- a/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
+++ b/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
@@ -1,4 +1,4 @@
-
+using System;
 
 namespace Assessments.Mapping.AlienSpecies.Helpers
 {
@@ -33,6 +33,21 @@ namespace Assessments.Mapping.AlienSpecies.Helpers
                 return string.Empty;
             }
             return speciesStatus != "C3"? speciesStatus: speciesEstablishmentCategory;
+        }
+
+        internal static int? GetScores(string category, string criteria, string v)
+        {
+            if (category is "NR" or "" or null)
+            {
+                return null;
+            }
+            else
+            {
+                int SInv = (int)Char.GetNumericValue(criteria[0]);
+                string SEco = criteria.Split(",")[1];
+                int SEco2 = (int)Char.GetNumericValue(SEco[0]);
+                return v == "inv" ? SInv : SEco2;
+            }
         }
     }
 }

--- a/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
+++ b/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
@@ -35,18 +35,18 @@ namespace Assessments.Mapping.AlienSpecies.Helpers
             return speciesStatus != "C3"? speciesStatus: speciesEstablishmentCategory;
         }
 
-        internal static int? GetScores(string category, string criteria, string v)
+        internal static int? GetScores(string category, string criteria, string axis)
         {
-            if (category is "NR" or "" or null)
+            if (string.IsNullOrEmpty(category))
             {
                 return null;
             }
             else
             {
-                int SInv = (int)Char.GetNumericValue(criteria[0]);
-                string SEco = criteria.Split(",")[1];
-                int SEco2 = (int)Char.GetNumericValue(SEco[0]);
-                return v == "inv" ? SInv : SEco2;
+                int scoreInvationAxis = (int)Char.GetNumericValue(criteria[0]);
+                string criteriaEcoEffectAxis = criteria.Split(",")[1];
+                int scoreEcoEffectAxis = (int)Char.GetNumericValue(criteriaEcoEffectAxis[0]);
+                return axis == "inv" ? scoreInvationAxis : scoreEcoEffectAxis;
             }
         }
     }

--- a/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
+++ b/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
@@ -37,7 +37,7 @@ namespace Assessments.Mapping.AlienSpecies.Helpers
 
         internal static int? GetScores(string category, string criteria, string axis)
         {
-            if (string.IsNullOrEmpty(category))
+            if (string.IsNullOrEmpty(category) || category is "NR")
             {
                 return null;
             }

--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
@@ -17,6 +17,9 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                 .ForMember(dest => dest.AlienSpeciesCategory, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAlienSpeciesCategory(src.AlienSpeciesCategory, src.ExpertGroup)))
                 .ForMember(dest => dest.ExpertGroup, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetExpertGroup(src.ExpertGroup)))
                 .ForMember(dest => dest.EstablishmentCategory, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetEstablishmentCategory(src.SpeciesEstablishmentCategory, src.SpeciesStatus)))
+                .ForMember(dest => dest.ScoreInvationPotential, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetScores(src.Category, src.Criteria, "inv")))
+                .ForMember(dest => dest.ScoreEcologicalEffect, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetScores(src.Category, src.Criteria, "eco")))
+
                 ;
                 
 


### PR DESCRIPTION
La til felt for utslagsgivende kriterier og opprettet nye felt for skår på de to aksene i risikovurderingen: Invasjonspotensial og økologisk effekt. Closes #666.

Kriterier brukes på artssidene og i filtermenyen (#634)
Skårene brukes i filtre omtalt i #631.

* La til feltene på datamodellen
* Opprettet funksjon for å plukke ut skårene for de to aksene basert på Category og Criteria (se nærmere beskrivelse i #666)