### PR TITLE
Datamodel/alien species category to enum

### DIFF
--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
@@ -15,7 +15,7 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
                 query = query.Where(x => x.ScientificName.ToLowerInvariant().Contains(parameters.Name.ToLowerInvariant()));
 
             if (parameters.Area.Any())
-                query = query.Where(x => parameters.Area.ToEnumerable<AlienSpeciesAssessment2023EvaluationContext>().Contains(x.EvaluationContext) && x.AlienSpeciesCategory != "RegionallyAlien"); // remove "regionallyalien" assessments when filtering by evaluation context
+                query = query.Where(x => parameters.Area.ToEnumerable<AlienSpeciesAssessment2023EvaluationContext>().Contains(x.EvaluationContext) && !x.AlienSpeciesCategory.Equals("RegionallyAlien")); // remove "regionallyalien" assessments when filtering by evaluation context
 
             if (parameters.Category.Any())
                 query = query.Where(x => parameters.Category.ToEnumerable<AlienSpeciesAssessment2023Category>().Contains(x.Category));

--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
@@ -15,7 +15,7 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
                 query = query.Where(x => x.ScientificName.ToLowerInvariant().Contains(parameters.Name.ToLowerInvariant()));
 
             if (parameters.Area.Any())
-                query = query.Where(x => parameters.Area.ToEnumerable<AlienSpeciesAssessment2023EvaluationContext>().Contains(x.EvaluationContext) && !x.AlienSpeciesCategory.Equals("RegionallyAlien")); // remove "regionallyalien" assessments when filtering by evaluation context
+                query = query.Where(x => parameters.Area.ToEnumerable<AlienSpeciesAssessment2023EvaluationContext>().Contains(x.EvaluationContext) && x.AlienSpeciesCategory != AlienSpeciecAssessment2023AlienSpeciesCategory.RegionallyAlien); // remove "regionallyalien" assessments when filtering by evaluation context
 
             if (parameters.Category.Any())
                 query = query.Where(x => parameters.Category.ToEnumerable<AlienSpeciesAssessment2023Category>().Contains(x.Category));

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
@@ -8,7 +8,8 @@ namespace Assessments.Mapping.AlienSpecies.Model
         /// <summary>
         /// Evaluation  'tag' for the species. Evaluated categories are "AlienSpecie", "DoorKnocker", "RegionallyAlien" and "EffectWithoutReproduction"
         /// </summary>
-        public string AlienSpeciesCategory { get; set; }
+
+        public AlienSpeciecAssessment2023AlienSpeciesCategory AlienSpeciesCategory { get; set; }
 
         /// <summary>
         /// Was the alien species established by year 1800? If true the alien species is not risk assessed

--- a/Assessments.Mapping/AlienSpecies/Model/Enums/AlienSpeciecAssessment2023AlienSpeciesCategory.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/Enums/AlienSpeciecAssessment2023AlienSpeciesCategory.cs
@@ -1,0 +1,39 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Assessments.Mapping.AlienSpecies.Model.Enums
+{
+    public enum AlienSpeciecAssessment2023AlienSpeciesCategory
+    {
+        [Display(Name = "Selvstendig reproduserende")]
+        AlienSpecie,
+
+        [Display(Name = "Dørstokkart")]
+        DoorKnocker,
+
+        [Display(Name = "Økologisk effekt uten selvstendig reproduksjon innen 50 år")] //treated like a doorknocker and will be visualised with "Dørstokkart" in the filter meny, but use this displayname in the species assessment site. 
+        EffectWithoutReproduction,
+
+        [Display(Name = "Regionalt fremmed")] //These are only alien in parts of Norway (they are resident species of Norway) and are therefore excluded from the filter on assessment area (EvaluationContext). 
+        RegionallyAlien,
+
+        [Display(Name = "Ikke fremmed")]
+        NotAlienSpecie,
+
+        [Display(Name = "Vurderes på et annet taksonomisk nivå")]
+        TaxonEvaluatedAtAnotherLevel,
+
+        [Display(Name = "Etablert per år 1800")]
+        UncertainBefore1800,
+
+        // TODO: Remove values below when no assessments have any of these values in AlienSpeciesCategory. At latest, these should be removed before 'innsynet' opens to the public.
+
+        [Display(Name = "Ikke avgjort")]
+        NotDefined,
+
+        [Display(Name = "Ikke avgjort")]
+        NotApplicable,
+
+        [Display(Name = "Ikke avgjort")]
+        EcoEffectWithoutEstablishment
+    }
+}


### PR DESCRIPTION
Gjorde om AlienSpeciesCategory fra string til Enum. Closes #684. 

- Opprettet ny fil i mappa Enum med AlienSpeciesCategory som enum
- Endret QueryHelpers så spørringen er tilpasset enum i stedet for strings. 