### PR TITLE
Replace api filter parameters (#686)

### DIFF
--- a/Assessments.Frontend.Web/Controllers/Api/AlienSpeciesController.cs
+++ b/Assessments.Frontend.Web/Controllers/Api/AlienSpeciesController.cs
@@ -7,6 +7,7 @@ using Assessments.Frontend.Web.Infrastructure.AlienSpecies;
 using Assessments.Frontend.Web.Models;
 using static Microsoft.AspNetCore.Http.StatusCodes;
 using Assessments.Mapping.AlienSpecies.Model;
+using Assessments.Mapping.AlienSpecies.Model.Enums;
 
 namespace Assessments.Frontend.Web.Controllers.Api
 {
@@ -14,9 +15,15 @@ namespace Assessments.Frontend.Web.Controllers.Api
     public class AlienSpeciesController : BaseApiController<AlienSpeciesController>
     {
         [HttpGet, ProducesResponseType(typeof(PaginatedResults<List<AlienSpeciesAssessment2023>>), Status200OK)]
-        public async Task<ActionResult> GetAlienSpecies2023([FromQuery] AlienSpeciesListParameters parameters, int pageNumber = 1, int pageSize = 25)
+        public async Task<ActionResult> GetAlienSpecies2023(string name, [FromQuery] AlienSpeciesAssessment2023Category[] category, int pageNumber = 1, int pageSize = 25)
         {
             var query = await DataRepository.GetAlienSpeciesAssessments();
+
+            var parameters = new AlienSpeciesListParameters
+            {
+                Name = name, 
+                Category = category.Select(x => x.ToString()).ToArray()
+            };
 
             query = QueryHelpers.ApplyParameters(parameters, query);
 

--- a/Assessments.Frontend.Web/Program.cs
+++ b/Assessments.Frontend.Web/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.IO;
+using System.Text.Json.Serialization;
 using Assessments.Frontend.Web.Infrastructure;
 using Assessments.Frontend.Web.Infrastructure.Api;
 using Assessments.Frontend.Web.Infrastructure.Services;
@@ -14,7 +15,8 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.Configure<RouteOptions>(options => { options.LowercaseUrls = true; });
 
-builder.Services.AddControllersWithViews();
+builder.Services.AddControllersWithViews()
+    .AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
 builder.Services.AddLazyCache();
 


### PR DESCRIPTION
fjerner parameter som er delt med view'et, og legger heller inn noen utvalgte parameter (gjør det enklere å filtrere data i api'et)
legger til innstilling for json i prosjektet - slik at enum blir vist som tekst og ikke tall

api'et ligger på https://localhost:44321/swagger/index.html
det er metoden GET /api/alienspecies/2023 som nå har filter på navn og kategori

close #686