### PR TITLE
Map alienspeciescategory displayname in export (#685)

### DIFF
--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023ExportProfile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023ExportProfile.cs
@@ -1,4 +1,5 @@
 ﻿using Assessments.Mapping.AlienSpecies.Model;
+using Assessments.Shared.Helpers;
 using AutoMapper;
 
 namespace Assessments.Mapping.AlienSpecies.Profiles
@@ -7,7 +8,8 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
     {
         public AlienSpeciesAssessment2023ExportProfile()
         {
-            CreateMap<AlienSpeciesAssessment2023, AlienSpeciesAssessment2023Export>();
+            CreateMap<AlienSpeciesAssessment2023, AlienSpeciesAssessment2023Export>()
+                .ForMember(dest => dest.AlienSpeciesCategory, opt => opt.MapFrom(src => src.AlienSpeciesCategory.DisplayName()));
         }
     }
 }


### PR DESCRIPTION
bruker displayname på "alienspeciescategory" i stedet for enumverdien i eksporten
close #685