### PR TITLE
bugfix - "fjern søk"-knappen

### DIFF
--- a/Assessments.Frontend.Web/Controllers/AlienSpeciesController.cs
+++ b/Assessments.Frontend.Web/Controllers/AlienSpeciesController.cs
@@ -1,13 +1,12 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Assessments.Frontend.Web.Infrastructure;
+﻿using Assessments.Frontend.Web.Infrastructure;
 using Assessments.Frontend.Web.Infrastructure.AlienSpecies;
 using Assessments.Frontend.Web.Models;
-using Assessments.Mapping.AlienSpecies;
 using Assessments.Mapping.AlienSpecies.Model;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using X.PagedList;
 
 namespace Assessments.Frontend.Web.Controllers
@@ -23,7 +22,10 @@ namespace Assessments.Frontend.Web.Controllers
         {
             var query = await DataRepository.GetAlienSpeciesAssessments();
 
-            viewModel.Parameters = QueryHelpers.UpdateParameters(viewModel.Parameters);
+            // Need to redirect to remove filters or search string parameters from the url
+            var redirectUrl = QueryHelpers.UpdateParameters(HttpContext.Request, viewModel.Parameters);
+            if (!string.IsNullOrEmpty(redirectUrl))
+                Response.Redirect(redirectUrl);
 
             query = QueryHelpers.ApplyParameters(viewModel.Parameters, query);
 
@@ -45,11 +47,11 @@ namespace Assessments.Frontend.Web.Controllers
             if (assessment == null)
                 return NotFound();
 
-            var viewModel = new AlienSpeciesDetailViewModel { Assessment = assessment};
+            var viewModel = new AlienSpeciesDetailViewModel { Assessment = assessment };
 
             return View("2023/AlienSpeciesDetail", viewModel);
         }
-        
+
         private IActionResult GetExport(IEnumerable<AlienSpeciesAssessment2023> query)
         {
             var assessmentsForExport = Mapper.Map<IEnumerable<AlienSpeciesAssessment2023Export>>(query.ToList());

--- a/Assessments.Frontend.Web/Models/AlienSpeciesViewModels.cs
+++ b/Assessments.Frontend.Web/Models/AlienSpeciesViewModels.cs
@@ -60,6 +60,8 @@ namespace Assessments.Frontend.Web.Models
 
         public string RemoveFilters { get; set; }
 
+        public string RemoveSearch { get; set; }
+
         public string SortBy { get; set; }
 
         public string[] SpeciesGroups { get; set; }

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/ListPartials/_Filters.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/ListPartials/_Filters.cshtml
@@ -162,7 +162,7 @@
                     {
                         string searchstring = " for " + '"' + @GetActiveSelection(Model.Parameters) + '"';
                         <span>@searchstring</span>
-                        <button class="button tinybutton tertiary search_related" name="remove_search" value="true">
+                        <button class="button tinybutton tertiary search_related" name="Parameters.@nameof(Model.Parameters.RemoveSearch)" value="true">
                             <span class="material-icons">close</span>Fjern søk
                         </button>
                     }


### PR DESCRIPTION
Fixes #687

Har lagt til støtte i kontrolleren for å fjerne søkestrengen. 
Omskrevet hvordan filter fjernes til samme måte. Filtrene ble ikke fjernet fra søkestrengen tidligere heller, så deling av lenker hadde potensielt blitt kjipt.