### PR TITLE
Fullfører filter for taksonomisk rank

### DIFF
--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/FilterItemHelpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/FilterItemHelpers.cs
@@ -1,6 +1,7 @@
 ﻿using Assessments.Mapping.AlienSpecies.Model.Enums;
 using Assessments.Shared.Helpers;
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
 namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
@@ -28,22 +29,58 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
 
     public class TaxonRank
     {
+        public enum TaxonRankEnum
+        {
+            Art = 22,
+            Underart = 23,
+            Varietet = 24,
+
+            [Display(Name = "Taksonomisk nivå")]
+            ttn,
+
+            [Display(Name = "Vurderes på et annet taksonomisk nivå ")]
+            tva,
+
+            [Display(Name = "Vurderes ikke på et annet taksonomisk nivå ")]
+            tvi
+        }
+
+        public static readonly Filter.FilterItem[] TaxonRanks2023 =
+        {
+            new()
+            {
+                Name = nameof(TaxonRankEnum.Art),
+                NameShort = TaxonRankEnum.Art.GetHashCode().ToString()
+            },
+            new()
+            {
+                Name = nameof(TaxonRankEnum.Underart),
+                NameShort = TaxonRankEnum.Underart.GetHashCode().ToString()
+            },
+            new()
+            {
+                Name = nameof(TaxonRankEnum.Varietet),
+                NameShort = TaxonRankEnum.Varietet.GetHashCode().ToString()
+            }
+        };
+
         public static readonly Filter.FilterItem[] AlienSpecies2023TaxonRanks =
         {
             new()
             {
-                Name = "Art",
-                NameShort = "art"
+                Name = TaxonRankEnum.ttn.DisplayName(),
+                NameShort = TaxonRankEnum.ttn.ToString(),
+                SubGroup = TaxonRanks2023
             },
             new()
             {
-                Name = "Underart",
-                NameShort = "uar"
+                Name = TaxonRankEnum.tva.DisplayName(),
+                NameShort = TaxonRankEnum.tva.ToString()
             },
             new()
             {
-                Name = "Varietet",
-                NameShort = "var"
+                Name = TaxonRankEnum.tvi.DisplayName(),
+                NameShort = TaxonRankEnum.tvi.ToString()
             }
         };
     }

--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
@@ -31,6 +31,9 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
             if (parameters.SpeciesGroups.Any())
                 query = query.Where(x => parameters.SpeciesGroups.Any(y => AlienSpeciesHelpers.GetSpeciesGroupByShortName(y) == x.SpeciesGroup));
 
+            if (parameters.TaxonRank.Any())
+                query = ApplyTaxonRank(parameters.TaxonRank, query);
+
             if (string.IsNullOrEmpty(parameters.SortBy) || parameters.SortBy.Equals(nameof(AlienSpeciesAssessment2023.ScientificName), StringComparison.InvariantCultureIgnoreCase))
                 query = query.OrderBy(x => x.ScientificName);
             else if (parameters.SortBy.Equals(nameof(AlienSpeciesAssessment2023.VernacularName), StringComparison.InvariantCultureIgnoreCase))
@@ -81,6 +84,26 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
 
             return query.Where(x => speciesStatus.Contains(x.SpeciesStatus) ||
                                     (speciesStatus.Contains(doorKnockerShort) && (x.AlienSpeciesCategory == AlienSpeciecAssessment2023AlienSpeciesCategory.DoorKnocker || x.AlienSpeciesCategory == AlienSpeciecAssessment2023AlienSpeciesCategory.EffectWithoutReproduction)));
+        }
+
+        private static IQueryable<AlienSpeciesAssessment2023> ApplyTaxonRank(string[] taxonFilters, IQueryable<AlienSpeciesAssessment2023> query)
+        {
+            var newQuery = Enumerable.Empty<AlienSpeciesAssessment2023>().AsQueryable();
+            var evaluatedAtAnotherLevel = AlienSpeciecAssessment2023AlienSpeciesCategory.TaxonEvaluatedAtAnotherLevel;
+
+            foreach (var filter in taxonFilters)
+            {
+                var isInt = int.TryParse(filter, out int result);
+                var assessments = filter switch
+                {
+                    nameof(TaxonRank.TaxonRankEnum.tva) => query.Where(x => x.AlienSpeciesCategory == evaluatedAtAnotherLevel),
+                    nameof(TaxonRank.TaxonRankEnum.tvi) => query.Where(x => x.AlienSpeciesCategory != evaluatedAtAnotherLevel),
+                    _ => isInt ? query.Where(x => x.ScientificNameRank == result) : null
+                };
+                if (assessments != null)
+                    newQuery = newQuery.Concat(assessments);
+            }
+            return newQuery.Distinct();
         }
     }
 }

--- a/Assessments.Frontend.Web/wwwroot/css/filter.css
+++ b/Assessments.Frontend.Web/wwwroot/css/filter.css
@@ -565,7 +565,7 @@ button.list_header {
 .only_js input[type=checkbox]:not(:checked)#show_sal ~ .filter_subgroup,
 .only_js input[type=checkbox]:not(:checked)#show_sin ~ .filter_subgroup,
 .only_js input[type=checkbox]:not(:checked)#show_skr ~ .filter_subgroup,
-
+.only_js input[type=checkbox]:not(:checked)#show_ttn ~ .filter_subgroup,
 /*groups*/
 .only_js input[type=checkbox]:not(:checked)#show_area ~ .filter_area,
 .only_js input[type=checkbox]:not(:checked)#show_category ~ .filter_category,
@@ -591,7 +591,7 @@ button.list_header {
 .only_js input[type=checkbox]:checked#show_sin ~ .filter_subgroup,
 .only_js input[type=checkbox]:checked#show_skr ~ .filter_subgroup,
 .only_js input[type=checkbox]:checked#show_insects ~ .filter_insects,
-.only_js input[type=checkbox]:checked#show_Krepsdyr ~ .filter_subgroup {
+.only_js input[type=checkbox]:checked#show_ttn ~ .filter_subgroup {
     display: block;
 }
 

--- a/Assessments.Frontend.Web/wwwroot/js/filter.js
+++ b/Assessments.Frontend.Web/wwwroot/js/filter.js
@@ -29,7 +29,8 @@ if (filters) {
         "show_sal",
         "show_insects",
         "show_skr",
-        "show_sin"
+        "show_sin",
+        "show_ttn"
     ];
 
     const markAllInputs = document.querySelectorAll(".mark_all > input:first-of-type");

--- a/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
+++ b/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
@@ -67,5 +67,15 @@ namespace Assessments.Mapping.AlienSpecies.Helpers
             }
             return String.Empty;
         }
+
+        internal static int GetTaxonRank(string taxonRank)
+        {
+            var result = 0;
+            var isParsable = int.TryParse(taxonRank, out result);
+            if (!isParsable && taxonRank == "Species")
+                result = 22;
+
+            return result;
+        }
     }
 }

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
@@ -77,6 +77,11 @@ namespace Assessments.Mapping.AlienSpecies.Model
         public int ScientificNameId { get; set; }
 
         /// <summary>
+        /// The taxonomic rank of the evaluated scientific name
+        /// </summary>
+        public int ScientificNameRank { get; set; }
+
+        /// <summary>
         /// The species' total score on the ecological effect axis
         /// </summary>
         public int? ScoreEcologicalEffect { get; set; }

--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
@@ -14,6 +14,7 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                 .ForMember(dest => dest.ScientificName, opt => opt.MapFrom(src => src.EvaluatedScientificName))
                 .ForMember(dest => dest.ScientificNameId, opt => opt.MapFrom(src => src.EvaluatedScientificNameId))
                 .ForMember(dest => dest.ScientificNameAuthor, opt => opt.MapFrom(src => src.EvaluatedScientificNameAuthor))
+                .ForMember(dest => dest.ScientificNameRank, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetTaxonRank(src.EvaluatedScientificNameRank)))
                 .ForMember(dest => dest.VernacularName, opt => opt.MapFrom(src => src.EvaluatedVernacularName))
                 .ForMember(dest => dest.AlienSpeciesCategory, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAlienSpeciesCategory(src.AlienSpeciesCategory, src.ExpertGroup)))
                 .ForMember(dest => dest.ExpertGroup, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetExpertGroup(src.ExpertGroup)))


### PR DESCRIPTION
Fixes #698 

Trodde først denne koden ville føre til konflikter med kode som ikke ennå er merget inn, men dette filteret fantes fra før, så jeg tror vi berger bra. 😄 
Og muligens vil det komme en oppdatering i hvordan FA4.EvaluatedScientificName ser ut også. Inntil videre gjør denne koden jobben, så får vi heller fjerne/endre denne koden når dataen kommer på plass. Er jo mange vurderinger som ikke har noen rank...