### PR TITLE
Convert strip html to extension (#718)

### DIFF
--- a/Assessments.Mapping/Assessments.Mapping.csproj
+++ b/Assessments.Mapping/Assessments.Mapping.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.0" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
   </ItemGroup>

--- a/Assessments.Mapping/RedlistSpecies/Profiles/SpeciesAssessment2021ExportProfile.cs
+++ b/Assessments.Mapping/RedlistSpecies/Profiles/SpeciesAssessment2021ExportProfile.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using Assessments.Shared.Helpers;
 using AutoMapper;
-using HtmlAgilityPack;
 
 namespace Assessments.Mapping.RedlistSpecies.Profiles
 {
@@ -28,9 +27,9 @@ namespace Assessments.Mapping.RedlistSpecies.Profiles
                 .ForMember(dest => dest.AssessmentYear, opt => opt.MapFrom(src => src.AssessmentYear))
                 .ForMember(dest => dest.Category, opt => opt.MapFrom(src => src.Category.Replace("º", "°")))
                 .ForMember(dest => dest.CriteriaSummarized, opt => opt.MapFrom(src => src.CriteriaSummarized))
-                .ForMember(dest => dest.ExpertStatement, opt => opt.MapFrom(src => StripHtml(src.ExpertStatement)))
+                .ForMember(dest => dest.ExpertStatement, opt => opt.MapFrom(src => src.ExpertStatement.StripHtml()))
                 .ForMember(dest => dest.RationaleCategoryAdjustment, opt => opt.MapFrom(src => src.ExtinctionRiskAffected == "Nei" ?
-                string.Empty : StripHtml(src.RationaleCategoryAdjustment)))
+                string.Empty : src.RationaleCategoryAdjustment.StripHtml()))
                 .ForMember(dest => dest.ExtinctionRiskAffected, opt => opt.MapFrom(src => src.ExtinctionRiskAffected))
                 .ForMember(dest => dest.PresumedExtinct, opt => opt.MapFrom(src => src.PresumedExtinct ? "Ja" : "Nei"))
                 .ForMember(dest => dest.ReasonCategoryChange, opt => opt.MapFrom(src => src.ReasonCategoryChange.Description()))
@@ -92,16 +91,6 @@ namespace Assessments.Mapping.RedlistSpecies.Profiles
             };
 
             return string.Join(";", mainHabitats.Select(GetProperDescription).ToList());
-        }
-
-        private static string StripHtml(string input)
-        {
-            if (input == null)
-                return string.Empty;
-
-            var htmlDocument = new HtmlDocument();
-            htmlDocument.LoadHtml(input);
-            return htmlDocument.DocumentNode.InnerText;
         }
 
         private static string ResolveRegionState(IEnumerable<SpeciesAssessment2021RegionOccurrence> regionOccurrences, string name)

--- a/Assessments.Shared/Assessments.Shared.csproj
+++ b/Assessments.Shared/Assessments.Shared.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+  </ItemGroup>
+
 </Project>

--- a/Assessments.Shared/Helpers/Extensions.cs
+++ b/Assessments.Shared/Helpers/Extensions.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
+using HtmlAgilityPack;
 
 namespace Assessments.Shared.Helpers
 {
@@ -43,6 +44,16 @@ namespace Assessments.Shared.Helpers
         public static IEnumerable<T> ToEnumerable<T>(this IEnumerable<string> array)
         {
             return array.Where(c => Enum.IsDefined(typeof(T), c)).Select(a => (T) Enum.Parse(typeof(T), a));
+        }
+
+        public static string StripHtml(this string input)
+        {
+            if (input == null)
+                return string.Empty;
+
+            var htmlDocument = new HtmlDocument();
+            htmlDocument.LoadHtml(input);
+            return htmlDocument.DocumentNode.InnerText;
         }
     }
 }


### PR DESCRIPTION
Close #718 

gjør om en metode for å fjerne html brukt i rødlista, til en delt utvidelse - forenkler koden som fjerner html fra tekstfelt

eksempel:              
 ` .ForMember(dest => dest.ExpertStatement, opt => opt.MapFrom(src => src.ExpertStatement.StripHtml()))`
