### PR TITLE
Feature/alienspecies expertgroup members

### DIFF
--- a/Assessments.Frontend.Web/Controllers/AlienSpeciesController.cs
+++ b/Assessments.Frontend.Web/Controllers/AlienSpeciesController.cs
@@ -45,7 +45,8 @@ namespace Assessments.Frontend.Web.Controllers
             
             var expertGroupMembers = await DataRepository.GetData<AlienSpeciesAssessment2023ExpertGroupMember>(DataFilenames.AlienSpeciesExpertCommitteeMembers);
             
-            var assessmentExpertGroupMembers = await expertGroupMembers.Where(x => x.ExpertCommittee == assessment.ExpertGroup).ToListAsync();
+            var assessmentExpertGroupMembers = await expertGroupMembers.Where(x => x.ExpertCommittee == assessment.ExpertGroup)
+                .OrderByDescending(x => x.Admin).ToListAsync();
 
             var viewModel = new AlienSpeciesDetailViewModel(assessment)
             {

--- a/Assessments.Frontend.Web/Controllers/AlienSpeciesController.cs
+++ b/Assessments.Frontend.Web/Controllers/AlienSpeciesController.cs
@@ -5,6 +5,7 @@ using Assessments.Frontend.Web.Infrastructure;
 using Assessments.Frontend.Web.Infrastructure.AlienSpecies;
 using Assessments.Frontend.Web.Models;
 using Assessments.Mapping.AlienSpecies.Model;
+using Assessments.Shared.Helpers;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using X.PagedList;
@@ -41,8 +42,15 @@ namespace Assessments.Frontend.Web.Controllers
 
             if (assessment == null)
                 return NotFound();
+            
+            var expertGroupMembers = await DataRepository.GetData<AlienSpeciesAssessment2023ExpertGroupMember>(DataFilenames.AlienSpeciesExpertCommitteeMembers);
+            
+            var assessmentExpertGroupMembers = await expertGroupMembers.Where(x => x.ExpertCommittee == assessment.ExpertGroup).ToListAsync();
 
-            var viewModel = new AlienSpeciesDetailViewModel(assessment);
+            var viewModel = new AlienSpeciesDetailViewModel(assessment)
+            {
+                ExpertGroupMembers = assessmentExpertGroupMembers.Select(x => x.Name).JoinAnd(", ", " og ")
+            };
 
             return View("2023/AlienSpeciesDetail", viewModel);
         }

--- a/Assessments.Frontend.Web/Infrastructure/Services/ExpertCommitteeMemberService.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Services/ExpertCommitteeMemberService.cs
@@ -16,7 +16,7 @@ namespace Assessments.Frontend.Web.Infrastructure.Services
             _dataRepository = dataRepository;
         }
 
-        public async Task<List<ExpertCommitteeMember>> GetExpertCommitteeMembers(string expertCommitteeName, int year)
+        public async Task<List<string>> GetExpertCommitteeMembers(string expertCommitteeName, int year)
         {
             var data = await _dataRepository.GetData<ExpertCommitteeMember>(DataFilenames.SpeciesExpertCommitteeMembers);
 
@@ -37,23 +37,10 @@ namespace Assessments.Frontend.Web.Infrastructure.Services
                     .Replace("(Norge)", string.Empty, StringComparison.InvariantCultureIgnoreCase).Trim();
                 return x;
             }).ToList();
-
-            return results;
-        }
-
-        public async Task<string> GetExpertCommitteeName(string expertCommitteeName, int year)
-        {
-            var data = await _dataRepository.GetData<ExpertCommitteeMember>(DataFilenames.SpeciesExpertCommitteeMembers);
-
-            var name = data.FirstOrDefault(x => x.ExpertCommittee.Equals(expertCommitteeName.Trim(), StringComparison.InvariantCultureIgnoreCase) && x.Year == year)?.ExpertCommittee;
-	
-            if (string.IsNullOrEmpty(name))
-            {
-                name =  data.FirstOrDefault(x => x.Year == year && x.ExpertCommittee.Split(",", StringSplitOptions.TrimEntries).Select(y => y.ToLowerInvariant()).Contains(expertCommitteeName.Trim().ToLowerInvariant()))
-                    ?.ExpertCommittee;
-            }
-	
-            return string.IsNullOrEmpty(name) ? string.Empty : name.Split(",", StringSplitOptions.TrimEntries).JoinAnd(", ", " og ");
+            
+            var sortedexpertCommitteeMembers = expertCommitteeMembers.OrderBy(x => new List<string> { "leder", "nestleder", "medlem" }.IndexOf(x.Role.ToLowerInvariant())).ThenBy(x => x.LastName).Select(x => $"{x.LastName} {x.FirstNameInitals}").Distinct().ToList();
+            
+            return sortedexpertCommitteeMembers;
         }
     }
 

--- a/Assessments.Frontend.Web/Models/AlienSpeciesDetailViewModel.cs
+++ b/Assessments.Frontend.Web/Models/AlienSpeciesDetailViewModel.cs
@@ -1,6 +1,9 @@
-﻿using Assessments.Mapping.AlienSpecies.Model;
+﻿using System;
+using System.Collections.Generic;
+using Assessments.Mapping.AlienSpecies.Model;
 using Assessments.Shared.Helpers;
 using System.Linq;
+using Assessments.Frontend.Web.Infrastructure;
 
 namespace Assessments.Frontend.Web.Models
 {
@@ -55,5 +58,7 @@ namespace Assessments.Frontend.Web.Models
         public ExpertStatementViewModel ExpertStatementViewModel { get; set; }
 
         public SideBarContentViewModel SideBarContentViewModel { get; set; }
+
+        public string ExpertGroupMembers { get; set; }
     }
 }

--- a/Assessments.Frontend.Web/Models/PartialViewModels.cs
+++ b/Assessments.Frontend.Web/Models/PartialViewModels.cs
@@ -1,5 +1,7 @@
 using Assessments.Mapping.AlienSpecies.Model.Enums;
 using System;
+using System.Collections.Generic;
+using Assessments.Mapping.AlienSpecies.Model;
 
 namespace Assessments.Frontend.Web.Models
 {
@@ -47,6 +49,8 @@ namespace Assessments.Frontend.Web.Models
         public string RevisionReason { get; set; }
 
         public int YearPreviousAssessment { get; set; }
+
+        public string ExpertGroupMembers { get; set; }
     }
 
     public class CitationForListViewModel

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesDetail.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesDetail.cshtml
@@ -41,7 +41,8 @@
         PublicationText = $"{Constants.AlienSpecies2023PageMenuHeaderText}.  {Constants.Artsdatabanken}.",
         RevisionDate = new DateTime(), // TODO: add if we handle revisions in this list
         RevisionReason = string.Empty, // TODO: add if we handle revisions in this list
-        YearPreviousAssessment = assessment.PreviousAssessments?.Select(x => x.RevisionYear).OrderByDescending(x => x).FirstOrDefault() ?? 0
+        YearPreviousAssessment = assessment.PreviousAssessments?.Select(x => x.RevisionYear).OrderByDescending(x => x).FirstOrDefault() ?? 0,
+        ExpertGroupMembers = Model.ExpertGroupMembers
     };
 
     var categoryDescriptionViewModel = new CategoryDescriptionViewModel()
@@ -76,27 +77,6 @@
     if (Enum.TryParse(Model.Assessment.ScientificNameRank.ToString(), out scientificNameRank))
         if (scientificNameRank != 0)
             taxonRank = scientificNameRank.DisplayName();
-
-    var sideBarContentViewModel = new SideBarContentViewModel()
-    {
-         AssessmentYear = 2023,
-         Category = Categories.AlienSpecies2023Categories
-                                                        .Where(x => x.NameShort == assessment.Category.ToString())
-                                                        .Select(x => x.Name).FirstOrDefault(),
-         CategoryShort = assessment.Category.ToString(),
-         PreviousAssessments = assessment.PreviousAssessments.Select(x => new SideBarContentViewModel.SideBarPreviousAssessment()
-         {
-             Category = Categories.AlienSpecies2023Categories
-                                                        .Where(y => y.NameShort == x.MainCategory)
-                                                        .Select(y => y.Name).FirstOrDefault(),
-             CategoryShort = x.MainCategory,
-             Url = "https://artsdatabanken.no/fremmedarter/2018/N/" + x.AssessmentId, // TODO: get real url when the model is ready
-             Year = x.RevisionYear
-         }).ToArray(),
-         ScientificName = Model.Assessment.ScientificName,
-         ScientificNameId = Model.Assessment.ScientificNameId,
-         TaxonRank = taxonRank
-    };
 }
 
 <partial name="/Views/AlienSpecies/2023/AssessmentPartials/_Breadcrumb.cshtml" />

--- a/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/SpeciesAssessment2021.cshtml
+++ b/Assessments.Frontend.Web/Views/Redlist/Species/2021/Assessment/SpeciesAssessment2021.cshtml
@@ -1,6 +1,7 @@
 ﻿@model SpeciesAssessment2021
 @using Assessments.Frontend.Web.Infrastructure.Services
-@inject ExpertCommitteeMemberService _expertCommitteeMemberService
+@inject ExpertCommitteeMemberService ExpertCommitteeMemberService
+
 @{
     ViewBag.Title = Model.ScientificName + " - Rødlista 2021";
 
@@ -13,7 +14,6 @@
         speciesGroupImageUrl = speciesGroups[Model.SpeciesGroup]["image"];
     }
 
-    var expertCommitteeName = await _expertCommitteeMemberService.GetExpertCommitteeName(Model.ExpertCommittee, Model.AssessmentYear);
     var assessmentPageHeaderViewModel = new AssessmentPageHeaderViewModel()
     {
         AssessmentArea = Model.AssessmentArea == "S" ? "Svalbard" : "Norge",
@@ -42,6 +42,8 @@
         .Replace("@species", $"{Model.PopularName} {Helpers.getScientificNameElement(Model.ScientificName)}")
         .Replace("@area", $"{ViewBag.glossary["areas"][Model.AssessmentArea]["title"]}");
 
+    var expertCommitteeMembers = await ExpertCommitteeMemberService.GetExpertCommitteeMembers(Model.ExpertCommittee, Model.AssessmentYear);
+
     var citationViewModel = new CitationForAssessmentViewModel
     {
         AssessmentName = assessmentName,
@@ -49,10 +51,11 @@
         ExpertCommittee = Model.ExpertCommittee,
         FirstPublished = Constants.RedlistSpecies2021FirstPublished,
         CitationHeading = ViewBag.glossary["citation"]["title"],
-        PublicationText = ViewBag.glossary["pagetitle"]["title"] + ". " + ViewBag.glossary["adb"] +". ",
+        PublicationText = ViewBag.glossary["pagetitle"]["title"] + ". " + ViewBag.glossary["adb"] + ". ",
         RevisionDate = Model.RevisionDate,
         RevisionReason = Model.RevisionReason,
-        YearPreviousAssessment = Model.YearPreviousAssessment
+        YearPreviousAssessment = Model.YearPreviousAssessment,
+        ExpertGroupMembers = expertCommitteeMembers.JoinAnd(", ", " og ")
     };
 
     var pageMenuViewModel = new PageMenuViewModel
@@ -64,65 +67,74 @@
 
     var sideBarContentViewModel = new SideBarContentViewModel()
     {
-         AssessmentYear = Model.AssessmentYear,
-         Category = @ViewBag.categories[Model.Category.Substring(0, 2)]["presentationstring"],
-         CategoryShort = Model.Category,
-         PreviousAssessments = Model.PreviousAssessments.Select(x => new SideBarContentViewModel.SideBarPreviousAssessment()
-         {
-             Category = @ViewBag.categories[x.Category.Substring(0, 2)]["presentationstring"],
-             CategoryShort = x.Category,
-             Url = x.AssessmentUrl,
-             Year = x.Year
-         }).ToArray(),
-         ScientificName = Model.ScientificName,
-         ScientificNameId = Model.ScientificNameId,
-         TaxonRank = Model.TaxonRank,
+        AssessmentYear = Model.AssessmentYear,
+        Category = @ViewBag.categories[Model.Category.Substring(0, 2)]["presentationstring"],
+        CategoryShort = Model.Category,
+        PreviousAssessments = Model.PreviousAssessments.Select(x => new SideBarContentViewModel.SideBarPreviousAssessment()
+        {
+            Category = @ViewBag.categories[x.Category.Substring(0, 2)]["presentationstring"],
+            CategoryShort = x.Category,
+            Url = x.AssessmentUrl,
+            Year = x.Year
+        }).ToArray(),
+        ScientificName = Model.ScientificName,
+        ScientificNameId = Model.ScientificNameId,
+        TaxonRank = Model.TaxonRank,
     };
 
     var categoryDescriptionViewModel = new CategoryDescriptionViewModel()
+    {
+        CategoryShort = Model.Category,
+        CategoryBar = new CategoryBarListElement[]
+        {
+            new CategoryBarListElement
             {
-                CategoryShort = Model.Category,
-                CategoryBar = new CategoryBarListElement[]
-                {
-                     new CategoryBarListElement {
-                        Name = "Regionalt utdødd",
-                        NameShort = "RE"
-                    },
-                    new CategoryBarListElement {
-                        Name = "Kritisk truet",
-                        NameShort = "CR"
-                    },
-                    new CategoryBarListElement {
-                        Name = "Sterkt truet",
-                        NameShort = "EN"
-                    },
-                    new CategoryBarListElement {
-                        Name = "Sårbar",
-                        NameShort = "VU"
-                    },
-                    new CategoryBarListElement {
-                        Name = "Nær truet",
-                        NameShort = "NT"
-                    },
-                    new CategoryBarListElement {
-                        Name = "Data- mangel",
-                        NameShort = "DD"
-                    },
-                    new CategoryBarListElement {
-                        Name = "Livs- kraftig",
-                        NameShort = "LC"
-                    },
-                    new CategoryBarListElement {
-                        Name = "Ikke egnet",
-                        NameShort = "NA"
-                    },
-                    new CategoryBarListElement {
-                        Name = "Ikke vurdert",
-                        NameShort = "NE"
-                    },
-                },
-                MethodUrl = "https://www.artsdatabanken.no/rodlisteforarter2021/Metode#316483"
-            };
+                Name = "Regionalt utdødd",
+                NameShort = "RE"
+            },
+            new CategoryBarListElement
+            {
+                Name = "Kritisk truet",
+                NameShort = "CR"
+            },
+            new CategoryBarListElement
+            {
+                Name = "Sterkt truet",
+                NameShort = "EN"
+            },
+            new CategoryBarListElement
+            {
+                Name = "Sårbar",
+                NameShort = "VU"
+            },
+            new CategoryBarListElement
+            {
+                Name = "Nær truet",
+                NameShort = "NT"
+            },
+            new CategoryBarListElement
+            {
+                Name = "Data- mangel",
+                NameShort = "DD"
+            },
+            new CategoryBarListElement
+            {
+                Name = "Livs- kraftig",
+                NameShort = "LC"
+            },
+            new CategoryBarListElement
+            {
+                Name = "Ikke egnet",
+                NameShort = "NA"
+            },
+            new CategoryBarListElement
+            {
+                Name = "Ikke vurdert",
+                NameShort = "NE"
+            },
+        },
+        MethodUrl = "https://www.artsdatabanken.no/rodlisteforarter2021/Metode#316483"
+    };
 
     var naturtypehovedenhet = Model.MainHabitat;
     string geografi = Model.AssessmentArea;

--- a/Assessments.Frontend.Web/Views/Shared/_CitationForAssessment.cshtml
+++ b/Assessments.Frontend.Web/Views/Shared/_CitationForAssessment.cshtml
@@ -1,20 +1,7 @@
 ﻿@using Microsoft.AspNetCore.Http.Extensions
-@using Assessments.Frontend.Web.Infrastructure.Services
-
 @model CitationForAssessmentViewModel
 
-@inject ExpertCommitteeMemberService _expertCommitteeMemberService
-
 @{
-    // Authors
-    var expertCommitteeMembers = await _expertCommitteeMemberService.GetExpertCommitteeMembers(Model.ExpertCommittee, Model.AssessmentYear);
-    var sortedExperts = expertCommitteeMembers
-        .OrderBy(x => new List<string> { "leder", "nestleder", "medlem" }.IndexOf(x.Role.ToLowerInvariant()))
-        .ThenBy(x => x.LastName);
-
-    var formattedExperts = sortedExperts.Select(x => $"{x.LastName} {x.FirstNameInitals}").Distinct().ToList();
-    var authors = formattedExperts.JoinAnd(", ", " og ");
-
     // Date
     var firspublished = Helpers.getPublishedDate(Model.AssessmentYear, Model.YearPreviousAssessment, Model.FirstPublished);
     var revisiondate = Helpers.getRevisionDate(Model.RevisionDate, firspublished);
@@ -25,11 +12,11 @@
     }
 }
 
-@if (expertCommitteeMembers.Any())
+@if (!string.IsNullOrEmpty(Model.ExpertGroupMembers))
 {
-<h2>@Model.CitationHeading</h2>
+    <h2>@Model.CitationHeading</h2>
     <p class="citation">
-        @authors
+        @Model.ExpertGroupMembers
         (@date).
         @Html.Raw(Model.AssessmentName)
         @Model.PublicationText

--- a/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
+++ b/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
@@ -54,14 +54,18 @@ namespace Assessments.Mapping.AlienSpecies.Helpers
 
         internal static string GetExpertGroup(string expertGroup)
         {
+            // NOTE: synchronise logic with ExpertGroupExport in TransformAlienSpecies
+
             if (expertGroup.Contains("(Svalbard)"))
             {
                 return expertGroup.Replace("(Svalbard)", "");
             }
-            if (expertGroup is "Bakterier" or "Kromister" or "Sopper")
+
+            if (expertGroup is "Bakterier" or "Kromister" or "Sopper") 
             {
                 return "Sopper, det gule riket og bakterier";
             }
+
             return expertGroup;
         }
 

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023ExpertGroupMember.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023ExpertGroupMember.cs
@@ -5,5 +5,7 @@
         public string ExpertCommittee { get; set; }
 
         public string Name { get; set; }
+
+        public bool Admin { get; set; }
     }
 }

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023ExpertGroupMember.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023ExpertGroupMember.cs
@@ -1,0 +1,9 @@
+﻿namespace Assessments.Mapping.AlienSpecies.Model
+{
+    public class AlienSpeciesAssessment2023ExpertGroupMember
+    {
+        public string ExpertCommittee { get; set; }
+
+        public string Name { get; set; }
+    }
+}

--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
@@ -17,7 +17,7 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                 .ForMember(dest => dest.ScientificNameRank, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetTaxonRank(src.EvaluatedScientificNameRank)))
                 .ForMember(dest => dest.VernacularName, opt => opt.MapFrom(src => src.EvaluatedVernacularName))
                 .ForMember(dest => dest.AlienSpeciesCategory, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAlienSpeciesCategory(src.AlienSpeciesCategory, src.ExpertGroup)))
-                .ForMember(dest => dest.ExpertGroup, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetExpertGroup(src.ExpertGroup)))
+                .ForMember(dest => dest.ExpertGroup, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetExpertGroup(src.ExpertGroup).Trim()))
                 .ForMember(dest => dest.EstablishmentCategory, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetEstablishmentCategory(src.SpeciesEstablishmentCategory, src.SpeciesStatus)))
                 .ForMember(dest => dest.ScoreInvasionPotential, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetScores(src.Category, src.Criteria, "inv")))
                 .ForMember(dest => dest.ScoreEcologicalEffect, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetScores(src.Category, src.Criteria, "eco")))

--- a/Assessments.Shared/Helpers/DataFilenames.cs
+++ b/Assessments.Shared/Helpers/DataFilenames.cs
@@ -16,5 +16,8 @@
         public const string AlienSpecies2023 = "alienspecies-2023.json";
 
         public const string AlienSpecies2023Temp = "alienspecies-temp-2023.json";
+
+        public const string AlienSpeciesExpertCommitteeMembers = "alienspecies-experts.json";
+
     }
 }

--- a/Assessments.Shared/Helpers/Extensions.cs
+++ b/Assessments.Shared/Helpers/Extensions.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 
 namespace Assessments.Shared.Helpers
@@ -92,5 +93,7 @@ namespace Assessments.Shared.Helpers
 
             return document.DocumentNode.InnerHtml;
         }
+
+        public static string RemoveExcessWhitepace(this string input) => Regex.Replace(input, @"\s+", " ");
     }
 }

--- a/Assessments.Transformation/Database/Fab4/Fab4Context.cs
+++ b/Assessments.Transformation/Database/Fab4/Fab4Context.cs
@@ -1,28 +1,37 @@
-﻿using Assessments.Transformation.Database.Fab4.Models;
+﻿using System;
+using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Assessments.Transformation.Database.Fab4.Models;
 
 namespace Assessments.Transformation.Database.Fab4
 {
-    public class Fab4Context : DbContext
+    public partial class Fab4Context : DbContext
     {
-        public Fab4Context() {}
+        public Fab4Context()
+        {
+        }
 
-        public Fab4Context(DbContextOptions<Fab4Context> options) : base(options) {}
+        public Fab4Context(DbContextOptions<Fab4Context> options)
+            : base(options)
+        {
+        }
 
         public virtual DbSet<Assessment> Assessments { get; set; }
+        public virtual DbSet<User> Users { get; set; }
+        public virtual DbSet<UserRoleInExpertGroup> UserRoleInExpertGroups { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             if (!optionsBuilder.IsConfigured)
             {
-                // database stored locally
-                optionsBuilder.UseSqlServer("Server=.;Database=fab4;Trusted_Connection=True");
+                optionsBuilder.UseSqlServer("Server=.;Database=Fab4;Trusted_Connection=True");
             }
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
-            modelBuilder.HasAnnotation("Relational:Collation", "SQL_Latin1_General_CP1_CI_AS");
+            modelBuilder.UseCollation("SQL_Latin1_General_CP1_CI_AS");
 
             modelBuilder.Entity<Assessment>(entity =>
             {
@@ -42,8 +51,56 @@ namespace Assessments.Transformation.Database.Fab4
                     .HasComputedColumnSql("(isnull(CONVERT([nvarchar](150),json_value([Doc],'$.ExpertGroup')),'mangler'))", false);
 
                 entity.Property(e => e.IsDeleted).HasComputedColumnSql("(CONVERT([bit],case when json_value([Doc],'$.IsDeleted')='true' then (1) else (0) end))", false);
+
+                entity.HasOne(d => d.LastUpdatedByUser)
+                    .WithMany(p => p.AssessmentLastUpdatedByUsers)
+                    .HasForeignKey(d => d.LastUpdatedByUserId)
+                    .OnDelete(DeleteBehavior.ClientSetNull);
+
+                entity.HasOne(d => d.LockedForEditByUser)
+                    .WithMany(p => p.AssessmentLockedForEditByUsers)
+                    .HasForeignKey(d => d.LockedForEditByUserId);
             });
 
+            modelBuilder.Entity<User>(entity =>
+            {
+                entity.Property(e => e.Id).ValueGeneratedNever();
+
+                entity.Property(e => e.Application).HasMaxLength(2000);
+
+                entity.Property(e => e.DateCreated).HasDefaultValueSql("('2020-01-01T00:00:00.0000000')");
+
+                entity.Property(e => e.DateLastActive).HasDefaultValueSql("('2020-01-01T00:00:00.0000000')");
+
+                entity.Property(e => e.Email)
+                    .IsRequired()
+                    .HasMaxLength(200);
+
+                entity.Property(e => e.FullName)
+                    .IsRequired()
+                    .HasMaxLength(200);
+
+                entity.Property(e => e.UserName)
+                    .IsRequired()
+                    .HasMaxLength(100);
+            });
+
+            modelBuilder.Entity<UserRoleInExpertGroup>(entity =>
+            {
+                entity.HasKey(e => new { e.UserId, e.ExpertGroupName });
+
+                entity.ToTable("UserRoleInExpertGroup");
+
+                entity.Property(e => e.ExpertGroupName).HasMaxLength(200);
+
+                entity.HasOne(d => d.User)
+                    .WithMany(p => p.UserRoleInExpertGroups)
+                    .HasForeignKey(d => d.UserId);
+            });
+
+            OnModelCreatingPartial(modelBuilder);
         }
+
+        partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
     }
 }

--- a/Assessments.Transformation/Database/Fab4/Models/Assessment.cs
+++ b/Assessments.Transformation/Database/Fab4/Models/Assessment.cs
@@ -1,8 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Assessments.Transformation.Database.Fab4.Models
 {
-    public class Assessment
+    public partial class Assessment
     {
         public int Id { get; set; }
         public DateTime ChangedAt { get; set; }
@@ -14,5 +15,8 @@ namespace Assessments.Transformation.Database.Fab4.Models
         public string Doc { get; set; }
         public bool? IsDeleted { get; set; }
         public int ScientificNameId { get; set; }
+
+        public virtual User LastUpdatedByUser { get; set; }
+        public virtual User LockedForEditByUser { get; set; }
     }
 }

--- a/Assessments.Transformation/Database/Fab4/Models/User.cs
+++ b/Assessments.Transformation/Database/Fab4/Models/User.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Assessments.Transformation.Database.Fab4.Models
+{
+    public partial class User
+    {
+        public User()
+        {
+            AssessmentLastUpdatedByUsers = new HashSet<Assessment>();
+            AssessmentLockedForEditByUsers = new HashSet<Assessment>();
+            UserRoleInExpertGroups = new HashSet<UserRoleInExpertGroup>();
+        }
+
+        public Guid Id { get; set; }
+        public bool IsAdmin { get; set; }
+        public string UserName { get; set; }
+        public string FullName { get; set; }
+        public string Email { get; set; }
+        public string Application { get; set; }
+        public bool HasAccess { get; set; }
+        public bool HasAppliedForAccess { get; set; }
+        public bool AccessDenied { get; set; }
+        public DateTime DateGivenAccess { get; set; }
+        public DateTime DateCreated { get; set; }
+        public DateTime DateLastActive { get; set; }
+
+        public virtual ICollection<Assessment> AssessmentLastUpdatedByUsers { get; set; }
+        public virtual ICollection<Assessment> AssessmentLockedForEditByUsers { get; set; }
+        public virtual ICollection<UserRoleInExpertGroup> UserRoleInExpertGroups { get; set; }
+    }
+}

--- a/Assessments.Transformation/Database/Fab4/Models/UserRoleInExpertGroup.cs
+++ b/Assessments.Transformation/Database/Fab4/Models/UserRoleInExpertGroup.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Assessments.Transformation.Database.Fab4.Models
+{
+    public partial class UserRoleInExpertGroup
+    {
+        public string ExpertGroupName { get; set; }
+        public Guid UserId { get; set; }
+        public bool Admin { get; set; }
+        public bool WriteAccess { get; set; }
+        public DateTime DateCreated { get; set; }
+        public Guid RoleGivenByUserId { get; set; }
+
+        public virtual User User { get; set; }
+    }
+}

--- a/Assessments.Transformation/Program.cs
+++ b/Assessments.Transformation/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Assessments.Transformation.Helpers;
 using Microsoft.Extensions.Configuration;
@@ -18,12 +19,22 @@ namespace Assessments.Transformation
             Console.Clear();
             Console.CursorVisible = false;
 
+            var dataFolder = configuration.GetValue<string>("FilesFolder");
+
+            if (string.IsNullOrEmpty(dataFolder))
+                throw new Exception("Innstilling for 'FilesFolder' mangler");
+
+            if (!Directory.Exists(dataFolder))
+                Directory.CreateDirectory(dataFolder);
+
             var menuItems = new List<string>
             {
                 "Rødlista 2021 - til filer lokalt",
                 "Rødlista 2021 - last opp i Azure",
                 "Fremmedartslista 2023 - til filer lokalt",
                 "Fremmedartslista 2023 - last opp i Azure",
+                "Fremmedartslista 2023 Eksperter - til fil lokalt",
+                "Fremmedartslista 2023 Eksperter - last opp i Azure",
                 "Avslutt"
             };
 
@@ -47,6 +58,14 @@ namespace Assessments.Transformation
                         break;
                     case "Fremmedartslista 2023 - last opp i Azure":
                         await TransformAlienSpecies.TransformDataModels(configuration, upload: true);
+                        Environment.Exit(0);
+                        break;
+                    case "Fremmedartslista 2023 Eksperter - til fil lokalt":
+                        await TransformAlienSpecies.ExpertGroupExport(configuration, upload: false);
+                        Environment.Exit(0);
+                        break;
+                    case "Fremmedartslista 2023 Eksperter - last opp i Azure":
+                        await TransformAlienSpecies.ExpertGroupExport(configuration, upload: true);
                         Environment.Exit(0);
                         break;
                     case "Avslutt":

--- a/Assessments.Transformation/TransformAlienSpecies.cs
+++ b/Assessments.Transformation/TransformAlienSpecies.cs
@@ -109,19 +109,19 @@ namespace Assessments.Transformation
                 EnableTaskBarProgress = true
             });
 
-            var expertGroupMembers = await _dbContext.UserRoleInExpertGroups.Include(x => x.User)
+            var expertGroupMembers = _dbContext.UserRoleInExpertGroups.Include(x => x.User)
                 .Where(x => x.WriteAccess
                             && !x.User.FullName.Contains("(Test)")
                             && x.ExpertGroupName != "Testedyr"
                             && !x.User.Email.EndsWith("@artsdatabanken.no")
                 )
-                .OrderBy(x => x.User.IsAdmin)
                 .Select(x => new AlienSpeciesAssessment2023ExpertGroupMember
                 {
                     ExpertCommittee = x.ExpertGroupName.Replace("(Svalbard)", "").Trim(),
-                    Name = x.User.FullName.RemoveExcessWhitepace()
+                    Name = x.User.FullName.RemoveExcessWhitepace(),
+                    Admin = x.Admin
                 })
-                .Distinct().OrderBy(x => x.ExpertCommittee).ToListAsync();
+                .Distinct().OrderBy(x => x.ExpertCommittee).ThenByDescending(x => x.Admin).ToList();
 
             foreach (var expertGroupMember in expertGroupMembers.Where(x => x.ExpertCommittee is "Bakterier" or "Kromister" or "Sopper"))
                 expertGroupMember.ExpertCommittee = "Sopper, det gule riket og bakterier";

--- a/Assessments.Transformation/TransformAlienSpecies.cs
+++ b/Assessments.Transformation/TransformAlienSpecies.cs
@@ -8,7 +8,6 @@ using Assessments.Mapping.AlienSpecies.Profiles;
 using Assessments.Mapping.AlienSpecies.Source;
 using Assessments.Shared.Helpers;
 using Assessments.Transformation.Database.Fab4;
-using Assessments.Transformation.Database.Fab4.Models;
 using Assessments.Transformation.Helpers;
 using AutoMapper;
 using Microsoft.EntityFrameworkCore;
@@ -24,13 +23,19 @@ namespace Assessments.Transformation
 
         public static async Task TransformDataModels(IConfigurationRoot configuration, bool upload)
         {
+            await SetupDatabaseContext(configuration);
+
             Progress.ProgressBar = new ProgressBar(100, "Henter vurderinger", new ProgressBarOptions
             {
                 DisplayTimeInRealTime = false,
                 EnableTaskBarProgress = true
             });
 
-            var databaseAssessments = await GetAssessments(configuration);
+            var excludedExpertGroups = new List<string> { "Testedyr", "Ikke-marine invertebrater" };
+
+            var databaseAssessments = _dbContext.Assessments.AsNoTracking()
+                .Where(x => (bool) !x.IsDeleted && !excludedExpertGroups.Contains(x.Expertgroup));
+
             var totalCount = await databaseAssessments.CountAsync();
 
             Progress.ProgressBar.Tick(0, $"Transformerer {totalCount:N0} vurderinger");
@@ -82,17 +87,9 @@ namespace Assessments.Transformation
                 }
             };
 
-            var dataFolder = configuration.GetValue<string>("FilesFolder");
-
-            if (string.IsNullOrEmpty(dataFolder))
-                throw new Exception("Innstilling for 'FilesFolder' mangler");
-
-            if (!Directory.Exists(dataFolder))
-                Directory.CreateDirectory(dataFolder);
-
             foreach (var (key, value) in files)
             {
-                await File.WriteAllTextAsync(Path.Combine(dataFolder, key), value);
+                await File.WriteAllTextAsync(Path.Combine(configuration.GetValue<string>("FilesFolder"), key), value);
 
                 if (upload)
                     await Storage.Upload(configuration, key, value);
@@ -102,7 +99,45 @@ namespace Assessments.Transformation
             Progress.ProgressBar.Dispose();
         }
 
-        private static async Task<IQueryable<Assessment>> GetAssessments(IConfiguration configuration)
+        public static async Task ExpertGroupExport(IConfigurationRoot configuration, bool upload)
+        {
+            await SetupDatabaseContext(configuration);
+
+            Progress.ProgressBar = new ProgressBar(100, "Eksporterer ekspertgruppe medlemmer", new ProgressBarOptions
+            {
+                DisplayTimeInRealTime = false,
+                EnableTaskBarProgress = true
+            });
+
+            var expertGroupMembers = await _dbContext.UserRoleInExpertGroups.Include(x => x.User)
+                .Where(x => x.WriteAccess
+                            && !x.User.FullName.Contains("(Test)")
+                            && x.ExpertGroupName != "Testedyr"
+                            && !x.User.Email.EndsWith("@artsdatabanken.no")
+                )
+                .OrderBy(x => x.User.IsAdmin)
+                .Select(x => new AlienSpeciesAssessment2023ExpertGroupMember
+                {
+                    ExpertCommittee = x.ExpertGroupName.Replace("(Svalbard)", "").Trim(),
+                    Name = x.User.FullName.RemoveExcessWhitepace()
+                })
+                .Distinct().OrderBy(x => x.ExpertCommittee).ToListAsync();
+
+            foreach (var expertGroupMember in expertGroupMembers.Where(x => x.ExpertCommittee is "Bakterier" or "Kromister" or "Sopper"))
+                expertGroupMember.ExpertCommittee = "Sopper, det gule riket og bakterier";
+            
+            var serializedData = JsonSerializer.Serialize(expertGroupMembers);
+
+            await File.WriteAllTextAsync(Path.Combine(configuration.GetValue<string>("FilesFolder"), DataFilenames.AlienSpeciesExpertCommitteeMembers), serializedData);
+
+            if (upload)
+                await Storage.Upload(configuration, DataFilenames.AlienSpeciesExpertCommitteeMembers, serializedData);
+
+            Progress.ProgressBar.Tick(Progress.ProgressBar.MaxTicks, "Lagret ekspertgruppe medlemmer");
+            Progress.ProgressBar.Dispose();
+        }
+
+        private static async Task SetupDatabaseContext(IConfiguration configuration)
         {
             var connectionString = configuration.GetConnectionString("Fab4");
 
@@ -114,13 +149,6 @@ namespace Assessments.Transformation
 
             if (!await _dbContext.Database.CanConnectAsync())
                 throw new Exception("Kan ikke koble til databasen");
-
-            var excludedExpertGroups = new List<string> { "Testedyr", "Ikke-marine invertebrater" };
-
-            var assessments = _dbContext.Assessments.AsNoTracking()
-                .Where(x => (bool)!x.IsDeleted && !excludedExpertGroups.Contains(x.Expertgroup));
-
-            return assessments;
         }
     }
 }

--- a/Assessments.Transformation/TransformRedlistSpecies.cs
+++ b/Assessments.Transformation/TransformRedlistSpecies.cs
@@ -114,17 +114,9 @@ namespace Assessments.Transformation
                 }
             };
 
-            var dataFolder = configuration.GetValue<string>("FilesFolder");
-
-            if (string.IsNullOrEmpty(dataFolder))
-                throw new Exception("Innstilling for 'FilesFolder' mangler");
-
-            if (!Directory.Exists(dataFolder))
-                Directory.CreateDirectory(dataFolder);
-
             foreach (var (key, value) in files)
             {
-                await File.WriteAllTextAsync(Path.Combine(dataFolder, key), value);
+                await File.WriteAllTextAsync(Path.Combine(configuration.GetValue<string>("FilesFolder"), key), value);
 
                 if (upload)
                     await Storage.Upload(configuration, key, value);


### PR DESCRIPTION
henter ekspertgruppemedlemmer fra databasen (i konsollapplikasjonen) og lagrer disse som json i azure
det brukes endel filter og gjøres litt endring på data, spesielt ekspergruppenavn - som har samme logikk som i transformeringen på vurderinger

sitering med ekspertgruppe vises på samme måte som rødlista, ryddet og forenklet koden endel

rødlista bruker initialer, som mangler akkurat nå - litt usikker på om det skal gjøres om og hvordan vi løser det (i kode?)
det er også en annen heading ("sitering" på rødlista og "Siden siteres som" på fremmedartlista), usikker om det stemmer..