### PR TITLE
Feature/riskassessmentcriteria mapping

### DIFF
--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
@@ -106,16 +106,16 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
             {
                 var assessments = criteria switch
                 {
-                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dcexa) => query.Where(x => x.Criteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dcexa.DisplayName())),
-                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dcexb) => query.Where(x => x.Criteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dcexb.DisplayName())),
-                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dcipab) => query.Where(x => DeciciveCriteria.DecisiveCriteriaEnum.dcipab.DisplayName().Any(y => x.Criteria.Contains(y))),
-                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dcipc) => query.Where(x => x.Criteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dcipc.DisplayName())),
-                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dceed) => query.Where(x => x.Criteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dceed.DisplayName())),
-                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dcipe) => query.Where(x => x.Criteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dcipe.DisplayName())),
-                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dceef) => query.Where(x => x.Criteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dceef.DisplayName())),
-                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dcipg) => query.Where(x => x.Criteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dcipg.DisplayName())),
-                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dceeh) => query.Where(x => x.Criteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dceeh.DisplayName())),
-                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dcipi) => query.Where(x => x.Criteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dcipi.DisplayName())),
+                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dcexa) => query.Where(x => x.DecisiveCriteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dcexa.DisplayName())),
+                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dcexb) => query.Where(x => x.DecisiveCriteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dcexb.DisplayName())),
+                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dcipab) => query.Where(x => DeciciveCriteria.DecisiveCriteriaEnum.dcipab.DisplayName().Any(y => x.DecisiveCriteria.Contains(y))),
+                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dcipc) => query.Where(x => x.DecisiveCriteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dcipc.DisplayName())),
+                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dceed) => query.Where(x => x.DecisiveCriteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dceed.DisplayName())),
+                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dcipe) => query.Where(x => x.DecisiveCriteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dcipe.DisplayName())),
+                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dceef) => query.Where(x => x.DecisiveCriteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dceef.DisplayName())),
+                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dcipg) => query.Where(x => x.DecisiveCriteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dcipg.DisplayName())),
+                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dceeh) => query.Where(x => x.DecisiveCriteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dceeh.DisplayName())),
+                    nameof(DeciciveCriteria.DecisiveCriteriaEnum.dcipi) => query.Where(x => x.DecisiveCriteria.Contains(DeciciveCriteria.DecisiveCriteriaEnum.dcipi.DisplayName())),
                     _ => null
                 };
                 if (assessments != null)

--- a/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023Extensions.cs
+++ b/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023Extensions.cs
@@ -1,0 +1,111 @@
+﻿using Assessments.Mapping.AlienSpecies.Model;
+using Assessments.Mapping.AlienSpecies.Model.Enums;
+
+namespace Assessments.Mapping.AlienSpecies.Helpers
+{
+    public static class AlienSpeciesAssessment2023Extensions
+    {
+        public static string Description(this AlienSpeciesAssessment2023Criterion criterion)
+        {
+            var description = string.Empty;
+
+            switch (criterion.CriteriaLetter)
+            {
+                case AlienSpeciesAssessment2023CriteriaLetter.A:
+                    description = criterion.Value switch
+                    {
+                        1 => "mindre enn 10 år",
+                        2 => "mellom 10 og 59 år",
+                        3 => "mellom 60 og 649 år",
+                        4 => "minimum 650 år",
+                        _ => description
+                    };
+                    break;
+                case AlienSpeciesAssessment2023CriteriaLetter.B:
+                    description = criterion.Value switch
+                    {
+                        1 => "mindre enn 50 m/år",
+                        2 => "mellom 50 og 159 m/år",
+                        3 => "mellom 160 og 499 m/år",
+                        4 => "minimum 500 m/år",
+                        _ => description
+                    };
+                    break;
+                case AlienSpeciesAssessment2023CriteriaLetter.C:
+                    description = criterion.Value switch
+                    {
+                        1 => "mindre enn 5%",
+                        2 => "minimum 5%",
+                        3 => "minimum 10%",
+                        4 => "minimum 20%",
+                        _ => description
+                    };
+                    break;
+                case AlienSpeciesAssessment2023CriteriaLetter.D:
+                    description = criterion.Value switch
+                    {
+                        1 => "fraværende",
+                        2 => "svak styrke og begrenset omfang",
+                        3 => "svak styrke og storskala omfang ELLER moderat styrke og begrenset omfang",
+                        4 => "moderat styrke og storskala omfang ELLER fortrengning",
+                        _ => description
+                    };
+                    break;
+                case AlienSpeciesAssessment2023CriteriaLetter.E:
+                    description = criterion.Value switch
+                    {
+                        1 => "svak styrke ELLER moderat styrke og begrenset omfang",
+                        2 => "moderat styrke og storskala omfang",
+                        3 => "fortrengning i begrenset omfang",
+                        4 => "fortrengning i storskala omfang",
+                        _ => description
+                    };
+                    break;
+                case AlienSpeciesAssessment2023CriteriaLetter.F:
+                    description = criterion.Value switch
+                    {
+                        1 => "0%",
+                        2 => "over 0%",
+                        3 => "minimum 2%",
+                        4 => "minimum 5%",
+                        _ => description
+                    };
+                    break;
+                case AlienSpeciesAssessment2023CriteriaLetter.G:
+                    description = criterion.Value switch
+                    {
+                        1 => "mindre enn 5%",
+                        2 => "minimum 5%",
+                        3 => "minimum 10%",
+                        4 => "minimum 20%",
+                        _ => description
+                    };
+                    break;
+                case AlienSpeciesAssessment2023CriteriaLetter.H:
+                    description = criterion.Value switch
+                    {
+                        1 => "ingen overføring",
+                        2 => "begrenset til rødlistevurdert art",
+                        3 => "storskala til rødlistevurdert art ELLER begrenset til truet art eller nøkkelart",
+                        4 => "storskala til truet art eller nøkkelart",
+                        _ => description
+                    };
+                    break;
+                case AlienSpeciesAssessment2023CriteriaLetter.I:
+                    description = criterion.Value switch
+                    {
+                        1 => "ingen overføring ELLER begrenset til art som allerede er vert for denne parasitten",
+                        2 => "storskala til art som allerede er vert for denne parasitten ELLER begrenset til ny vert",
+                        3 => "storskala av eksisterende parasitt til ny vert ELLER begrenset til ny truet vert",
+                        4 => "storskala av eksisterende parasitt til ny truet vert ELLER storskala eller begrenset av en fremmed parasitt",
+                        _ => description
+                    };
+                    break;
+                default:
+                    return description;
+            }
+
+            return description;
+        }
+    }
+}

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
@@ -30,16 +30,21 @@ namespace Assessments.Mapping.AlienSpecies.Model
         /// Explanation for why an earlier believed alien species is no longer considered alien. Free text field.
         /// </summary>
         public string ChangedFromAlienDescription { get; set; }
-
-        /// <summary>
-        /// Decisive criteria according to GEIAAS method
-        /// </summary>
-        public string Criteria { get; set; }
-
+        
         /// <summary>
         /// Explanation for why the taxon is evaluated at another taxonomic rank. Free text field.
         /// </summary>
         public string ConnectedToHigherLowerTaxonDescription { get; set; }
+        
+        /// <summary>
+        /// TODO: documentation
+        /// </summary>
+        public List<AlienSpeciesAssessment2023Criterion> Criteria { get; set; }
+
+        /// <summary>
+        /// Decisive criteria according to GEIAAS method
+        /// </summary>
+        public string DecisiveCriteria { get; set; }
 
         /// <summary>
         /// Establishment category in Norway today. The alien species may not be in Norway, be represented in Norway by sporadic, ephemeral occurrences, or by populations that are locally self-sustaining or strongly expanding
@@ -295,6 +300,5 @@ namespace Assessments.Mapping.AlienSpecies.Model
         /// Number of introductions (minus one) during a 10 years period (high estimate). Used to estimate future AOO for doorknockers. 
         /// </summary>
         public int? RiskAssessmentIntroductionsHigh { get; set; }
-
     }
 }

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023Criterion.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023Criterion.cs
@@ -3,12 +3,24 @@ using Assessments.Mapping.AlienSpecies.Model.Enums;
 
 namespace Assessments.Mapping.AlienSpecies.Model
 {
+    /// <summary>
+    /// TODO: documentation
+    /// </summary>
     public class AlienSpeciesAssessment2023Criterion
     {
+        /// <summary>
+        /// TODO: documentation
+        /// </summary>
         public AlienSpeciesAssessment2023CriteriaLetter CriteriaLetter { get; set; }
 
+        /// <summary>
+        /// TODO: documentation
+        /// </summary>
         public int Value { get; set; }
 
+        /// <summary>
+        /// TODO: documentation
+        /// </summary>
         public List<int> UncertaintyValues { get; set; }
     }
 }

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023Criterion.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023Criterion.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Assessments.Mapping.AlienSpecies.Model.Enums;
+
+namespace Assessments.Mapping.AlienSpecies.Model
+{
+    public class AlienSpeciesAssessment2023Criterion
+    {
+        public AlienSpeciesAssessment2023CriteriaLetter CriteriaLetter { get; set; }
+
+        public int Value { get; set; }
+
+        public List<int> UncertaintyValues { get; set; }
+    }
+}

--- a/Assessments.Mapping/AlienSpecies/Model/Enums/AlienSpeciesAssessment2023CriteriaLetter.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/Enums/AlienSpeciesAssessment2023CriteriaLetter.cs
@@ -1,0 +1,34 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Assessments.Mapping.AlienSpecies.Model.Enums
+{
+    public enum AlienSpeciesAssessment2023CriteriaLetter
+    {
+        [Display(Name = "Median levetid i Norge (A-kriteriet)")]
+        A,
+
+        [Display(Name = "Ekspansjonshastighet (B-kriteriet)")]
+        B,
+
+        [Display(Name = "Kolonisert naturtypeareal (C-kriteriet)")]
+        C,
+
+        [Display(Name = "Effekter på truede arter eller nøkkelarter (D-kriteriet)")]
+        D,
+
+        [Display(Name = "Effekter på øvrige rødlistevurderte arter (E-kriteriet)")]
+        E,
+
+        [Display(Name = "Effekter på truede eller sjeldne naturtyper (F-kriteriet)")]
+        F,
+
+        [Display(Name = "Effekter på øvrige naturtyper (G-kriteriet)")]
+        G,
+
+        [Display(Name = "Overføring av genetisk materiale (H-kriteriet)")]
+        H,
+
+        [Display(Name = "Overføring av parasitter eller patogener (I-kriteriet)")]
+        I
+    }
+}

--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
@@ -1,4 +1,5 @@
-﻿using Assessments.Mapping.AlienSpecies.Helpers;
+﻿using System.Linq;
+using Assessments.Mapping.AlienSpecies.Helpers;
 using Assessments.Mapping.AlienSpecies.Model;
 using Assessments.Mapping.AlienSpecies.Source;
 using Assessments.Shared.Helpers;
@@ -113,11 +114,17 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                       opt.PreCondition(src => src.AssessmentConclusion == "AssessedDoorknocker");
                       opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.IntroductionsHigh(src.RiskAssessment));
                   })
+                .ForMember(dest => dest.DecisiveCriteria, opt => opt.MapFrom(src => src.Criteria))
+                .ForMember(dest => dest.Criteria, opt => opt.MapFrom(src => src.RiskAssessment.Criteria))
 
                 .AfterMap((_, dest) => dest.PreviousAssessments = AlienSpeciesAssessment2023ProfileHelper.GetPreviousAssessments(dest.PreviousAssessments))
                 ;
 
             CreateMap<FA4.PreviousAssessment, AlienSpeciesAssessment2023PreviousAssessment>(MemberList.None);
+           
+            CreateMap<RiskAssessment.Criterion, AlienSpeciesAssessment2023Criterion>(MemberList.None)
+                .ForMember(dest => dest.Value, opt => opt.MapFrom(src => src.Value + 1))
+                .ForMember(dest => dest.UncertaintyValues, opt => opt.MapFrom(src => src.UncertaintyValues.OrderBy(x => x).Select(x => x + 1)));
         }
     }
 }


### PR DESCRIPTION
Utvidelse av modell for kriterier

- gjort om navn fra Criteria til DecisiveCriteria
- Criteria som ny type "AlienSpeciesAssessment2023Criterion", med enum
- mapping og transformering av verdier (skala på verdier)
- hjelpemetode for beregning av beskrivelse 

det mangler dokumentasjon på de nye feltene, håper på litt hjelp med det :)
- har lagt til kommentarer med "TODO: documentation" i AlienSpeciesAssessment2023.cs og AlienSpeciesAssessment2023Criterion.cs

det er ikke lagt inn bruk av beregningen noen plasser, men man kan hente "beregning"(?) på en enkel måte ved å bruke utvidelsen - f.eks:

```
foreach (var criterion in assessment.Criteria)
{
    var descriotion = criterion.Description();
}
```

Mulig metoden bør hete noe annet enn "Description"?

Close #732 