### PR TITLE
Add nullsubsitute to decisivecriteria

### DIFF
--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
@@ -119,6 +119,7 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                 .ForMember(dest => dest.DecisiveCriteria, opt => opt.MapFrom(src => src.Criteria))
                 .ForMember(dest => dest.Criteria, opt => opt.MapFrom(src => src.RiskAssessment.Criteria))
                 .ForMember(dest => dest.DecisiveCriteria, opt => opt.MapFrom(src => src.Criteria))
+                .ForMember(dest => dest.DecisiveCriteria, opt => opt.NullSubstitute(string.Empty))
                 .ForMember(dest => dest.Criteria, opt => opt.MapFrom(src => src.RiskAssessment.Criteria))
                 .ForMember(dest => dest.RegionOccurrences, opt =>
                 {


### PR DESCRIPTION
erstatter null verdier med tom tekst på "DecisiveCriteria"
fikser spørringen når man bruker filter for Invasjonspotensial