### PR TITLE
#711

### DIFF
--- a/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
+++ b/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
@@ -216,9 +216,28 @@ namespace Assessments.Mapping.AlienSpecies.Helpers
                 }
                 else
                 {
-                    // TODO: legg til 2012 når formel for utregning er på plass #711
-                    previousAssessment.Category = AlienSpeciesAssessment2023Category.NR;
-                    previousAssessment.Url = "https://artsdatabanken.no/fremmedartslista2018";
+                    if (previousAssessment.MainSubCategory == "noRiskAssessment")
+                    {
+                        previousAssessment.Category = AlienSpeciesAssessment2023Category.NR;
+                    }
+                    else
+                    {
+                        previousAssessment.Category = previousAssessment.RiskLevel switch
+                        {
+                            0 => AlienSpeciesAssessment2023Category.NK,
+                            1 => AlienSpeciesAssessment2023Category.LO,
+                            2 => AlienSpeciesAssessment2023Category.PH,
+                            3 => AlienSpeciesAssessment2023Category.HI,
+                            4 => AlienSpeciesAssessment2023Category.SE,
+                            _ => AlienSpeciesAssessment2023Category.NR
+                        };
+                    }
+
+                    previousAssessment.Url = !previousAssessment.AssessmentId.Contains(":") 
+                        ? "https://artsdatabanken.no/fremmedartslista2018" 
+                        : $"https://databank.artsdatabanken.no/FremmedArt2012/{previousAssessment.AssessmentId.Split(":")[1]}";
+
+
                 }
             }
 

--- a/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
+++ b/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
@@ -234,7 +234,7 @@ namespace Assessments.Mapping.AlienSpecies.Helpers
                     }
 
                     previousAssessment.Url = !previousAssessment.AssessmentId.Contains(":") 
-                        ? "https://artsdatabanken.no/fremmedartslista2018" 
+                        ? "https://databank.artsdatabanken.no/FremmedArt2012" 
                         : $"https://databank.artsdatabanken.no/FremmedArt2012/{previousAssessment.AssessmentId.Split(":")[1]}";
 
 


### PR DESCRIPTION
Produksjonsbasen er patchet med oppdatert info på 2012 vurderingene, både justert ID - slik at vi kan lenke til eldre visning, men også oppdatert de andre previousassessment parametrene - selv om ikke alle brukes. Logikken på 2012 vurdering er tilpasset metoden fra 2012.

Data republisert til storageaccount.

2012 data ser typisk slik ut - der parametrene er hentet fra resultatdata og id representeter (produksjonsdatabase):(resultatvisning)
```json
		{
			"RevisionYear": 2012,
			"AssessmentId": "540:N63780",
			"RiskLevel": 1,
			"SpreadRiskLevel": 3,
			"EcologicalRiskLevel": 1,
			"MainCategory": "AlienSpecie",
			"MainSubCategory": "RiskAssessed",
			"DecisiveCriteria": "3A,1"
		}
```