### PR TITLE
Mapping: invasjonspotensial - A-kriteriet

### DIFF
--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
@@ -355,12 +355,45 @@ namespace Assessments.Mapping.AlienSpecies.Model
         /// Arguments for not accepting the median population lifetime that was automatically estimated based on estimation method "simplified estimation". Applies when IsAcceptedSimplifiedEstimate == false 
         /// </summary>
         public string MedianLifetimeSimplifiedEstimationAdjustScoreReason { get; set; }
-
-        public long MedianLifetimeNumericalEstimationPopulationSize { get; set; } 
-        public double MedianLifetimeNumericalEstimationGrowthRate { get; set; } 
-        public double MedianLifetimeNumericalEstimationEnvironmentalVariance { get; set; } 
-        public double MedianLifetimeNumericalEstimationDemographicVariance { get; set; } 
-        public long MedianLifetimeNumericalEstimationCarryingCapacity { get; set; } 
-        public int MedianLifetimeNumericalEstimationExtinctionThreshold { get; set; }
+        ///<summary>
+        /// The population size used to estimate population viability with estimation method "numerical estimation"
+        /// </summary>
+        public long MedianLifetimeNumericalEstimationPopulationSize { get; set; }
+        ///<summary>
+        /// The growth rate used to estimate population viability with estimation method "numerical estimation"
+        /// </summary>
+        public double MedianLifetimeNumericalEstimationGrowthRate { get; set; }
+        ///<summary>
+        /// The environmental variance used to estimate population viability with estimation method "numerical estimation". Optional.
+        /// </summary>
+        public double? MedianLifetimeNumericalEstimationEnvironmentalVariance { get; set; }
+        ///<summary>
+        /// The demographic variance used to estimate population viability with estimation method "numerical estimation". Optional.
+        /// </summary>
+        public double? MedianLifetimeNumericalEstimationDemographicVariance { get; set; }
+        ///<summary>
+        /// The carrying capacity (in number of individuals) used to estimate population viability with estimation method "numerical estimation". Optional.
+        /// </summary>
+        public long? MedianLifetimeNumericalEstimationCarryingCapacity { get; set; }
+        ///<summary>
+        /// The quazi-extinction threashold (in number of individuals) used to estimate population viability with estimation method "numerical estimation". Optional.
+        /// </summary>
+        public int? MedianLifetimeNumericalEstimationExtinctionThreshold { get; set; }
+        ///<summary>
+        /// The estimated median lifetime (in years) of the species in Norway. Obligatory for estimation methods "numerical estimation" and "viability analysis". 
+        /// </summary>
+        public long MedianLifetimeBestEstimate { get; set; }
+        ///<summary>
+        /// The estimated low quantile of median lifetime (in years) of the species in Norway. Obligatory for estimation method "viability analysis". 
+        /// </summary>
+        public long MedianLifetimeLowEstimate { get; set; }
+        ///<summary>
+        /// The estimated high quantile of median lifetime (in years) of the species in Norway. Obligatory for estimation method "viability analysis". 
+        /// </summary>
+        public long MedianLifetimeHighEstimate { get; set; }
+        ///<summary>
+        /// Desciption of the Population Viability Analysis model used. Used for estimation method "viability analysis". 
+        /// </summary>
+        public string MedianLifetimeViabilityAnalysisDescription { get; set; }
     }
 }

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
@@ -340,5 +340,27 @@ namespace Assessments.Mapping.AlienSpecies.Model
         /// The default, estimated score on criterion A (median lifetime) when using estimation method "simplified estimation"
         /// </summary>
         public int MedianLifetimeSimplifiedEstimationDefaultScore { get; set; }
+
+        ///<summary>
+        /// The default, low estimate / low uncertainty quantile of the score on criterion A (median lifetime) when using estimation method "simplified estimation"
+        /// </summary>
+        public int MedianLifetimeSimplifiedEstimationDefaultScoreLow { get; set; }
+
+        ///<summary>
+        /// The default, high estimate / high uncertainty quantile of the score on criterion A (median lifetime) when using estimation method "simplified estimation"
+        /// </summary>
+        public int MedianLifetimeSimplifiedEstimationDefaultScoreHigh { get; set; }
+
+        /// <summary>
+        /// Arguments for not accepting the median population lifetime that was automatically estimated based on estimation method "simplified estimation". Applies when IsAcceptedSimplifiedEstimate == false 
+        /// </summary>
+        public string MedianLifetimeSimplifiedEstimationAdjustScoreReason { get; set; }
+
+        public long MedianLifetimeNumericalEstimationPopulationSize { get; set; } 
+        public double MedianLifetimeNumericalEstimationGrowthRate { get; set; } 
+        public double MedianLifetimeNumericalEstimationEnvironmentalVariance { get; set; } 
+        public double MedianLifetimeNumericalEstimationDemographicVariance { get; set; } 
+        public long MedianLifetimeNumericalEstimationCarryingCapacity { get; set; } 
+        public int MedianLifetimeNumericalEstimationExtinctionThreshold { get; set; }
     }
 }

--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
@@ -157,7 +157,22 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                 .ForMember(dest => dest.MedianLifetimeNumericalEstimationDemographicVariance, opt => opt.MapFrom(src => src.RiskAssessment.DemVariance))
                 .ForMember(dest => dest.MedianLifetimeNumericalEstimationCarryingCapacity, opt => opt.MapFrom(src => src.RiskAssessment.CarryingCapacity))
                 .ForMember(dest => dest.MedianLifetimeNumericalEstimationExtinctionThreshold, opt => opt.MapFrom(src => src.RiskAssessment.ExtinctionThreshold))
-
+                .ForMember(dest => dest.MedianLifetimeBestEstimate, opt =>
+                {
+                    opt.PreCondition(src => new[] { "SpreadRscriptEstimatedSpeciesLongevity", "ViableAnalysis" }.Any(x => src.RiskAssessment.ChosenSpreadMedanLifespan.Contains(x)));
+                    opt.MapFrom(src => src.RiskAssessment.MedianLifetimeInput);
+                })
+                .ForMember(dest => dest.MedianLifetimeLowEstimate, opt =>
+                {
+                    opt.PreCondition(src => src.RiskAssessment.ChosenSpreadMedanLifespan == "ViableAnalysis");
+                    opt.MapFrom(src => src.RiskAssessment.LifetimeLowerQInput);
+                })
+                .ForMember(dest => dest.MedianLifetimeHighEstimate, opt =>
+                {
+                    opt.PreCondition(src => src.RiskAssessment.ChosenSpreadMedanLifespan == "ViableAnalysis");
+                    opt.MapFrom(src => src.RiskAssessment.LifetimeUpperQInput);
+                })
+                .ForMember(dest => dest.MedianLifetimeViabilityAnalysisDescription, opt => opt.MapFrom(src => src.RiskAssessment.SpreadPVAAnalysis.StripUnwantedHtml()))
 
                 .AfterMap((_, dest) => dest.PreviousAssessments = AlienSpeciesAssessment2023ProfileHelper.GetPreviousAssessments(dest.PreviousAssessments));
 

--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
@@ -19,7 +19,7 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                 .ForMember(dest => dest.VernacularName, opt => opt.MapFrom(src => src.EvaluatedVernacularName))
                 .ForMember(dest => dest.AlienSpeciesCategory, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAlienSpeciesCategory(src.AlienSpeciesCategory, src.ExpertGroup)))
                 .ForMember(dest => dest.ExpertGroup, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetExpertGroup(src.ExpertGroup).Trim()))
-                .ForMember(dest => dest.EstablishmentCategory, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetEstablishmentCategory(src.SpeciesEstablishmentCategory, src.SpeciesStatus)))
+                .ForMember(dest => dest.EstablishmentCategory, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetEstablishmentCategory(src.SpeciesEstablishmentCategory, src.SpeciesStatus, src.AlienSpeciesCategory)))
                 .ForMember(dest => dest.ScoreInvasionPotential, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetScores(src.Category, src.Criteria, "inv")))
                 .ForMember(dest => dest.ScoreEcologicalEffect, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetScores(src.Category, src.Criteria, "eco")))
                 .ForMember(dest => dest.RiskAssessmentGeographicVariationInCategory, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetGeographicVarInCat(src.Category, src.RiskAssessment.PossibleLowerCategory)))
@@ -140,6 +140,23 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                     opt.PreCondition(src => src.Category != "NR");
                     opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetMedianLifetimeSimplifiedEstimationDefaultScoreBest(src.AssessmentConclusion, src.RiskAssessment));
                 })
+                .ForMember(dest => dest.MedianLifetimeSimplifiedEstimationDefaultScoreLow, opt =>
+                {
+                    opt.PreCondition(src => src.Category != "NR");
+                    opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetMedianLifetimeSimplifiedEstimationDefaultScoreUncertainty(src.AssessmentConclusion, src.RiskAssessment, "Low"));
+                })
+                .ForMember(dest => dest.MedianLifetimeSimplifiedEstimationDefaultScoreHigh, opt =>
+                {
+                    opt.PreCondition(src => src.Category != "NR");
+                    opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetMedianLifetimeSimplifiedEstimationDefaultScoreUncertainty(src.AssessmentConclusion, src.RiskAssessment, "High"));
+                })
+                .ForMember(dest => dest.MedianLifetimeSimplifiedEstimationAdjustScoreReason, opt => opt.MapFrom(src => src.RiskAssessment.ReasonForAdjustmentCritA.StripUnwantedHtml()))
+                .ForMember(dest => dest.MedianLifetimeNumericalEstimationPopulationSize, opt => opt.MapFrom(src => src.RiskAssessment.PopulationSize))
+                .ForMember(dest => dest.MedianLifetimeNumericalEstimationGrowthRate, opt => opt.MapFrom(src => src.RiskAssessment.GrowthRate))
+                .ForMember(dest => dest.MedianLifetimeNumericalEstimationEnvironmentalVariance, opt => opt.MapFrom(src => src.RiskAssessment.EnvVariance))
+                .ForMember(dest => dest.MedianLifetimeNumericalEstimationDemographicVariance, opt => opt.MapFrom(src => src.RiskAssessment.DemVariance))
+                .ForMember(dest => dest.MedianLifetimeNumericalEstimationCarryingCapacity, opt => opt.MapFrom(src => src.RiskAssessment.CarryingCapacity))
+                .ForMember(dest => dest.MedianLifetimeNumericalEstimationExtinctionThreshold, opt => opt.MapFrom(src => src.RiskAssessment.ExtinctionThreshold))
 
 
                 .AfterMap((_, dest) => dest.PreviousAssessments = AlienSpeciesAssessment2023ProfileHelper.GetPreviousAssessments(dest.PreviousAssessments));


### PR DESCRIPTION
Følgende er gjort: 
1. Lagt til metode/funksjon for å finne automatisk utregnet 'range' på skår på A-kriteriet (ble ikke lagret på datamodellen i FAB). Her er resultatet avhengig av om det er lav kvantil eller høy kvantil som skal estimeres, samt om arten er risikovurdert som en dørstokkart eller som en selvstendig reproduserende. 
2. Lagt til en linje som manglet i metoden for automatisk utregnet beste anslag for skår på A-kriteriet (den hadde sluppet unna forrige runde..)
3. Mapping av alle felt som er direkte knyttet til A-kriteriet. Jeg har endret navn til samtlige av disse. Jeg har lagt alle på hovedmodellen, men det kan kanskje vurderes om alt med A-kriteriet, eller kanskje alt som har med invasjonsaksen (A, B og C-kriteriet) burde ut i en egen "undermodell"/fil..(?)