### PR TITLE
Toppen av vurderingssiden

### DIFF
--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/FilterItemHelpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/FilterItemHelpers.cs
@@ -1118,28 +1118,28 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
         {
             new()
             {
-                Name = "Overlever vinteren utendørs",
-                NameShort = "C1"
+                Name = AlienSpeciesAssessment2023SpeciesStatus.c1.DisplayName(),
+                NameShort = nameof(AlienSpeciesAssessment2023SpeciesStatus.c1)
             },
             new()
             {
-                Name = "Observert i norsk natur",
-                NameShort = "C0"
+                Name = AlienSpeciesAssessment2023SpeciesStatus.c0.DisplayName(),
+                NameShort = nameof(AlienSpeciesAssessment2023SpeciesStatus.c0)
             },
             new()
             {
-                Name = "Utendørs i eget produksjonsareal",
-                NameShort = "B2"
+                Name = AlienSpeciesAssessment2023SpeciesStatus.b2.DisplayName(),
+                NameShort = nameof(AlienSpeciesAssessment2023SpeciesStatus.b2)
             },
             new()
             {
-                Name = "Innendørs",
-                NameShort = "B1"
+                Name = AlienSpeciesAssessment2023SpeciesStatus.b1.DisplayName(),
+                NameShort = nameof(AlienSpeciesAssessment2023SpeciesStatus.b1)
             },
             new()
             {
-                Name = "Ikke i Norge",
-                NameShort = "A"
+                Name = AlienSpeciesAssessment2023SpeciesStatus.a.DisplayName(),
+                NameShort = nameof(AlienSpeciesAssessment2023SpeciesStatus.a)
             }
         };
 
@@ -1147,13 +1147,13 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
         {
             new()
             {
-                Name = "Etablert",
-                NameShort = "C3"
+                Name = AlienSpeciesAssessment2023SpeciesStatus.c3.DisplayName(),
+                NameShort = nameof(AlienSpeciesAssessment2023SpeciesStatus.c3)
             },
             new()
             {
-                Name = "Selvstendig reproduserende",
-                NameShort = "C2"
+                Name = AlienSpeciesAssessment2023SpeciesStatus.c2.DisplayName(),
+                NameShort = nameof(AlienSpeciesAssessment2023SpeciesStatus.c2)
             },
             new()
             {

--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
@@ -128,7 +128,7 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
         {
             const string doorKnockerShort = "eda";
 
-            return query.Where(x => speciesStatus.Contains(x.SpeciesStatus) ||
+            return query.Where(x => speciesStatus.Contains(x.SpeciesStatus.ToString()) ||
                                     (speciesStatus.Contains(doorKnockerShort) && (x.AlienSpeciesCategory == AlienSpeciecAssessment2023AlienSpeciesCategory.DoorKnocker || x.AlienSpeciesCategory == AlienSpeciecAssessment2023AlienSpeciesCategory.EffectWithoutReproduction)));
         }
 

--- a/Assessments.Frontend.Web/Models/PartialViewModels.cs
+++ b/Assessments.Frontend.Web/Models/PartialViewModels.cs
@@ -110,7 +110,11 @@ namespace Assessments.Frontend.Web.Models
 
         public AlienSpeciesAssessment2023Category Category { get; set; }
 
+        public AlienSpeciecAssessment2023AlienSpeciesCategory AlienSpeciesCategory { get; set; }
+
         public string ListName { get; set; }
+
+        public AlienSpeciesAssessment2023SpeciesStatus SpeciesStatus { get; set; }
 
         public string Status { get; set; }
 

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesDetail.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesDetail.cshtml
@@ -60,7 +60,9 @@
         Category = assessment.Category,
         Environment = assessment.Environment,
         ListName = Constants.AlienSpecies2023PageMenuHeaderText,
+        SpeciesStatus = assessment.SpeciesStatus,
         Status = assessment.EstablishmentCategory + assessment.AlienSpeciesCategory,
+        AlienSpeciesCategory = assessment.AlienSpeciesCategory,
         TaxonRank = assessment.ScientificNameRank
     };
 

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesDetail.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesDetail.cshtml
@@ -57,12 +57,12 @@
 
     var ingressViewModel = new IngressViewModel()
     {
+        AlienSpeciesCategory = assessment.AlienSpeciesCategory,
         Category = assessment.Category,
         Environment = assessment.Environment,
         ListName = Constants.AlienSpecies2023PageMenuHeaderText,
         SpeciesStatus = assessment.SpeciesStatus,
         Status = assessment.EstablishmentCategory + assessment.AlienSpeciesCategory,
-        AlienSpeciesCategory = assessment.AlienSpeciesCategory,
         TaxonRank = assessment.ScientificNameRank
     };
 

--- a/Assessments.Frontend.Web/Views/Shared/_Ingress.cshtml
+++ b/Assessments.Frontend.Web/Views/Shared/_Ingress.cshtml
@@ -12,7 +12,7 @@
 }
 
 <div class="page_section">
-    <p>Livsmiljø: @Model.Environment.DisplayName()</p>
+    <p is-visible="!isNr">Livsmiljø: @Model.Environment.DisplayName()</p>
     <p is-visible="isEvaluatedAtAnotherLevel">
         @Helpers.FixSpeciesLevel("{Art}en", (int)Model.TaxonRank) er @Model.AlienSpeciesCategory.DisplayName().ToLowerInvariant() (les vurderingen <a href="">her</a>).
     </p>

--- a/Assessments.Frontend.Web/Views/Shared/_Ingress.cshtml
+++ b/Assessments.Frontend.Web/Views/Shared/_Ingress.cshtml
@@ -2,26 +2,34 @@
 @using Assessments.Mapping.AlienSpecies.Model.Enums
 
 @{
-    var riskCategoryPreText = Model.Category == AlienSpeciesAssessment2023Category.NR ?
-        $"{@Helpers.FixSpeciesLevel("{Art}en", (int)Model.TaxonRank)} er " :
-        $"{@Helpers.FixSpeciesLevel("{Art}en", (int)Model.TaxonRank)} er vurdert til ";
+    var isNr = Model.Category == AlienSpeciesAssessment2023Category.NR;
+    var isEvaluatedAtAnotherLevel = Model.AlienSpeciesCategory == AlienSpeciecAssessment2023AlienSpeciesCategory.TaxonEvaluatedAtAnotherLevel;
 
-    var andOrComma = string.Empty;
-    if (Model.Environment == AlienSpeciesAssessment2023Environment.Limnisk)
-        andOrComma = " og";
-    else if (Model.Environment == AlienSpeciesAssessment2023Environment.Marint)
-        andOrComma = " og";
-    else if (Model.Environment == AlienSpeciesAssessment2023Environment.Terrestrisk)
-        andOrComma = " og";
-    else
-        andOrComma = ",";
+    var isDoorKnocker = Model.AlienSpeciesCategory == AlienSpeciecAssessment2023AlienSpeciesCategory.DoorKnocker;
+    var hasEffectWithoutReproduction = Model.AlienSpeciesCategory == AlienSpeciecAssessment2023AlienSpeciesCategory.EffectWithoutReproduction;
+    var isRegionallyAlien = Model.AlienSpeciesCategory == AlienSpeciecAssessment2023AlienSpeciesCategory.RegionallyAlien;
+    var isNoneOfTheAbove = !isNr && !isEvaluatedAtAnotherLevel && !isDoorKnocker && !hasEffectWithoutReproduction && !isRegionallyAlien;
 }
 
 <div class="page_section">
-    <p>
-        @Helpers.FixSpeciesLevel("{Art}en", (int)Model.TaxonRank) er @Model.Status@andOrComma @Model.Environment.DisplayName().
+    <p>Livsmiljø: @Model.Environment.DisplayName()</p>
+    <p is-visible="isEvaluatedAtAnotherLevel">
+        @Helpers.FixSpeciesLevel("{Art}en", (int)Model.TaxonRank) er @Model.AlienSpeciesCategory.DisplayName().ToLowerInvariant() (les vurderingen <a href="">her</a>).
     </p>
-    <p>
-        @riskCategoryPreText <i>@Model.Category.DisplayName()</i> - @Model.Category i @Model.ListName.
+    <p is-visible="isNr && !isEvaluatedAtAnotherLevel">
+        @Helpers.FixSpeciesLevel("{Art}en", (int)Model.TaxonRank) er @Model.AlienSpeciesCategory.DisplayName().ToLowerInvariant().
+    </p>
+
+    <p is-visible="!isNr && !isEvaluatedAtAnotherLevel && isDoorKnocker">
+        @Helpers.FixSpeciesLevel("{Art}en", (int)Model.TaxonRank) er en dørstokkart som @Model.SpeciesStatus.Description().
+    </p>
+    <p is-visible="!isNr && !isEvaluatedAtAnotherLevel && hasEffectWithoutReproduction">
+        @Helpers.FixSpeciesLevel("{Art}en", (int)Model.TaxonRank) har @Model.AlienSpeciesCategory.DisplayName().ToLowerInvariant() som @Model.SpeciesStatus.Description().
+    </p>
+    <p is-visible="!isNr && !isEvaluatedAtAnotherLevel && isRegionallyAlien">
+        @Helpers.FixSpeciesLevel("{Art}en", (int)Model.TaxonRank) er en regionalt fremmed @Helpers.FixSpeciesLevel("{art}", (int)Model.TaxonRank) som @Model.SpeciesStatus.Description().
+    </p>
+    <p is-visible="isNoneOfTheAbove">
+        @Helpers.FixSpeciesLevel("{Art}en", (int)Model.TaxonRank) @Model.SpeciesStatus.Description().
     </p>
 </div>

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
@@ -30,12 +30,12 @@ namespace Assessments.Mapping.AlienSpecies.Model
         /// Explanation for why an earlier believed alien species is no longer considered alien. Free text field.
         /// </summary>
         public string ChangedFromAlienDescription { get; set; }
-        
+
         /// <summary>
         /// Explanation for why the taxon is evaluated at another taxonomic rank. Free text field.
         /// </summary>
         public string ConnectedToHigherLowerTaxonDescription { get; set; }
-        
+
         /// <summary>
         /// List including all criteria (A-I), their score and uncertainty
         /// </summary>
@@ -139,7 +139,7 @@ namespace Assessments.Mapping.AlienSpecies.Model
         /// <summary>
         /// Establishment category in Norway today from A-C3. The alien species may not be in Norway, be represented in Norway by sporadic, ephemeral occurrences, or by populations that are established
         /// </summary>
-        public string SpeciesStatus { get; set; }
+        public AlienSpeciesAssessment2023SpeciesStatus SpeciesStatus { get; set; }
 
         /// <summary>
         /// Further information about the taxons' secondary spread (i.e. spread within Norwegian nature)

--- a/Assessments.Mapping/AlienSpecies/Model/Enums/AlienSpeciesAssessment2023SpeciesStatus.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/Enums/AlienSpeciesAssessment2023SpeciesStatus.cs
@@ -1,0 +1,40 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace Assessments.Mapping.AlienSpecies.Model.Enums
+{
+    public enum AlienSpeciesAssessment2023SpeciesStatus
+    {
+        [Display(Name = "Ikke relevant")]
+        [Description("er ikke relevant")]
+        empty,
+
+        [Display(Name = "Ikke i Norge")]
+        [Description("ikke forekommer i Norge")]
+        a,
+
+        [Display(Name = "Innendørs")]
+        [Description("forekommer innendørs eller i lukkede installasjoner")]
+        b1,
+
+        [Display(Name = "Utendørs i eget produksjonsareal")]
+        [Description("forekommer utendørs i eget produksjonsareal")]
+        b2,
+
+        [Display(Name = "Observert i norsk natur")]
+        [Description("er dokumentert fra norsk natur")]
+        c0,
+
+        [Display(Name = "Overlever vinteren utendørs")]
+        [Description("kan overleve vinteren utendørs og uten hjelp")]
+        c1,
+
+        [Display(Name = "Selvstendig reproduserende")]
+        [Description("er selvstendig reproduserende")]
+        c2,
+
+        [Display(Name = "Etablert")]
+        [Description("er etablert")]
+        c3
+    }
+}


### PR DESCRIPTION
Fixes #797 
Fixes #712 (Dette er det samme som #797 @AneMarlene?
Endrer SpeciesStatus fra string til enum.
Håndterer ulike kombinasjoner av mivsmiljø og statuser for artene som vises frem som vist på bildet: 
![image](https://user-images.githubusercontent.com/15391193/210562998-8cd674bc-402d-4f4f-86d5-3e386d9475b8.png)
Teksten er fikset opp i etter bildet ble tatt.
