### PR TITLE
mapping og gjenskaping av metoder for estimater på ekspansjonshastighet. 

### DIFF
--- a/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
+++ b/Assessments.Mapping/AlienSpecies/Helpers/AlienSpeciesAssessment2023ProfileHelper.cs
@@ -557,5 +557,99 @@ namespace Assessments.Mapping.AlienSpecies.Helpers
             else return "NotRelevant";
       
         }
+
+        static private long GetExpansionSpeedAOOSelfReproducing(RiskAssessment riskAssessment, long areaOfOccurrenceToday, long areaOfOccurrenceIn50Years)
+        {
+            bool chosenSubMethod = riskAssessment.AOOfirstOccurenceLessThan10Years == "yes";
+            long? firstYear = riskAssessment.AOOyear1;
+            long? lastYear = riskAssessment.AOOyear2;
+            long? firstYearArea = riskAssessment.AOO1;
+            long? lastYearArea = riskAssessment.AOO2;
+            long? areaOfOccurrenceTodayBest = riskAssessment.AOOtotalBestInput;
+            long? knownAreaToday = riskAssessment.AOOknownInput;
+
+            decimal result;
+            if (chosenSubMethod)
+            {
+                result = (firstYear == null || lastYear == null || (lastYear - firstYear) < 10 || firstYearArea <= 0 || lastYearArea <= 0) ?
+                0
+                : Math.Truncate((decimal)(Math.Sqrt((double)(areaOfOccurrenceToday / knownAreaToday)) * 2000 * (Math.Sqrt(Math.Ceiling((double)(lastYearArea / 4))) - Math.Sqrt(Math.Ceiling((double)(firstYearArea / 4)))) / ((lastYear - firstYear) * Math.Sqrt(Math.PI))));
+            }
+
+            else
+            {
+                result = (decimal)Math.Truncate(20 * (Math.Sqrt((double)areaOfOccurrenceIn50Years) - Math.Sqrt((double)areaOfOccurrenceTodayBest)) / Math.Sqrt(Math.PI));
+            }
+
+            return (long)Math.Round(result,0);
+        }
+
+        internal static long GetExpansionSpeedEstimates(RiskAssessment riskAssessment, string estimateQuantile, string assessmentConclusion)
+        {
+            var mainMethodA = riskAssessment.ChosenSpreadYearlyIncrease is "a";
+            var mainMethodB = riskAssessment.ChosenSpreadYearlyIncrease is "b";
+            var assessedDoorKnocker = assessmentConclusion is "AssessedDoorknocker";
+
+            if (mainMethodA)
+            {
+                return (long)(estimateQuantile is "best" ? riskAssessment.ExpansionSpeedInput
+                    : estimateQuantile is "low" ? riskAssessment.ExpansionLowerQInput
+                    : riskAssessment.ExpansionUpperQInput);
+            }
+
+            if (mainMethodB && assessedDoorKnocker)
+            {
+                long? numberOfOccurrences;
+                long? numberOfIntroductions;
+                long areaAfterTenYearsEstimate;
+
+                if (estimateQuantile == "low")
+                {
+                    numberOfOccurrences = riskAssessment.Occurrences1Low ?? 0;
+                    numberOfIntroductions = IntroductionsLow(riskAssessment);
+
+                }
+                else if (estimateQuantile == "best")
+                {
+                    numberOfOccurrences = riskAssessment.Occurrences1Best ?? 0;
+                    numberOfIntroductions = (int?)riskAssessment.IntroductionsBest ?? 0;
+                }
+                else
+                {
+                    numberOfOccurrences = riskAssessment.Occurrences1High ?? 0;
+                    numberOfIntroductions = IntroductionsHigh(riskAssessment);
+                }
+
+                areaAfterTenYearsEstimate = AOO10yr(numberOfOccurrences, numberOfIntroductions) ?? 0;
+
+                return (long)Math.Round(Math.Truncate(200 * (Math.Sqrt((double)(areaAfterTenYearsEstimate / 4)) - 1) / Math.Sqrt(Math.PI)),0);
+            }
+
+            else //mainMethodB and assessed as self-reproducing
+            {
+                long areaOfOccurrenceToday;
+                long areaOfOccurrenceIn50Years;
+                if (estimateQuantile == "low")
+                {
+                    areaOfOccurrenceToday = riskAssessment.AOOtotalLowInput ?? 0;
+                    areaOfOccurrenceIn50Years = riskAssessment.AOO50yrLowInput ?? 0;
+                }
+
+                else if (estimateQuantile == "best")
+                {
+                    areaOfOccurrenceToday = riskAssessment.AOOtotalBestInput ?? 0;
+                    areaOfOccurrenceIn50Years = riskAssessment.AOO50yrBestInput ?? 0;
+                }
+
+                else
+                {
+                    areaOfOccurrenceToday = riskAssessment.AOOtotalHighInput ?? 0;
+                    areaOfOccurrenceIn50Years = riskAssessment.AOO50yrHighInput ?? 0;
+                }
+
+                return GetExpansionSpeedAOOSelfReproducing(riskAssessment, areaOfOccurrenceToday, areaOfOccurrenceIn50Years);
+            }
+
+        }
     }
 }

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
@@ -460,5 +460,20 @@ namespace Assessments.Mapping.AlienSpecies.Model
         /// Comment or description related to the estimation of expansion speed. Used for method EstimatedIncreaseInAOO.
         /// </summary>
         public string ExpansionSpeedEstimatedIncreaseInAOODescription { get; set; }
+
+        ///<summary>
+        /// The estimated expansion speed (low quantile) of the species in Norway.  
+        /// </summary>
+        public long ExpansionSpeedLowEstimate { get; set; }
+
+        ///<summary>
+        /// The estimated expansion speed (median/best estimate) of the species in Norway. 
+        /// </summary>
+        public long ExpansionSpeedBestEstimate { get; set; }
+
+        ///<summary>
+        /// The estimated expansion speed (high estimate) of the species in Norway. 
+        /// </summary>
+        public long ExpansionSpeedHighEstimate { get; set; }
     }
 }

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023Export.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023Export.cs
@@ -69,6 +69,18 @@ namespace Assessments.Mapping.AlienSpecies.Model
         [Description("Valgt estimeringsmetode for B-kriteriet, artens ekspansjonshastighet i norsk natur")]
         public string ExpansionSpeedEstimationMethod { get; set; }
 
+        [DisplayName("Ekspansjonshastighet (lavt anslag)")]
+        [Description("Artens ekspansjonshastighet i norsk natur (lavt anslag)")]
+        public long ExpansionSpeedLowEstimate { get; set; }
+
+        [DisplayName("Ekspansjonshastighet (beste anslag)")]
+        [Description("Artens ekspansjonshastighet i norsk natur (beste anslag)")]
+        public long ExpansionSpeedBestEstimate { get; set; }
+
+        [DisplayName("Ekspansjonshastighet (høyt anslag)")]
+        [Description("Artens ekspansjonshastighet i norsk natur (høyt anslag)")]
+        public long ExpansionSpeedHighEstimate { get; set; }
+
         [DisplayName("Geografisk variasjon i risiko")]
         [Description("Arter med en viss utstrekning i forekomstarealet kan, som en respons på ulike miljøbetingelser, ha ulik påvirkning i naturen. Spørsmålet viser til om arten kunne fått en lavere risikokategori i deler av sitt potensielle forekomstareal")]
         public bool? RiskAssessmentGeographicVariationInCategory { get; set; }

--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
@@ -196,7 +196,21 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                 .ForMember(dest => dest.ExpansionSpeedEstimatedIncreaseInAOOFirstAOOCorr, opt => opt.MapFrom(src => src.RiskAssessment.AOO1))
                 .ForMember(dest => dest.ExpansionSpeedEstimatedIncreaseInAOOLastAOOCorr, opt => opt.MapFrom(src => src.RiskAssessment.AOO2))
                 .ForMember(dest => dest.ExpansionSpeedEstimatedIncreaseInAOODescription, opt => opt.MapFrom(src => src.RiskAssessment.CommentOrDescription.StripUnwantedHtml()))
-
+                .ForMember(dest => dest.ExpansionSpeedLowEstimate, opt =>
+                {
+                    opt.PreCondition(src => src.Category != "NR" && src.EvaluationStatus == "finished");
+                    opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetExpansionSpeedEstimates(src.RiskAssessment, "low", src.AssessmentConclusion));
+                })
+                .ForMember(dest => dest.ExpansionSpeedBestEstimate, opt =>
+                {
+                    opt.PreCondition(src => src.Category != "NR" && src.EvaluationStatus == "finished");
+                    opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetExpansionSpeedEstimates(src.RiskAssessment, "best", src.AssessmentConclusion));
+                })
+                .ForMember(dest => dest.ExpansionSpeedHighEstimate, opt =>
+                {
+                    opt.PreCondition(src => src.Category != "NR" && src.EvaluationStatus == "finished");
+                    opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetExpansionSpeedEstimates(src.RiskAssessment, "high", src.AssessmentConclusion));
+                })
 
                 .AfterMap((_, dest) => dest.PreviousAssessments = AlienSpeciesAssessment2023ProfileHelper.GetPreviousAssessments(dest.PreviousAssessments));
 


### PR DESCRIPTION
fix #765

Estimatene på ekspansjonshastighet (estimatene som bestemmer artens skår på B-kriteriet) var kun lagret på datamodellen i FAB for én av estimeringsmetodene (feltene med "Input", f.eks. ExpansionSpeedInput). De øvrige estimatene ble utregnet i frontend i FAB. Jeg har her gjenskapt funksjonene for å estimere ekspansjonshastighet (lavt anslag, beste anslag og høyt anslag). 

Estimatene er også lagt til i eksporten. 