### PR TITLE
database migrations in startup, disable database info

### DIFF
--- a/Assessments.Frontend.Web/Controllers/Api/TestController.cs
+++ b/Assessments.Frontend.Web/Controllers/Api/TestController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 
 namespace Assessments.Frontend.Web.Controllers.Api;
 
@@ -25,6 +26,9 @@ public class TestController : Controller
     [HttpGet("database")]
     public IActionResult DatabaseInfo()
     {
+        if (_environment.IsProduction())
+            return NotFound();
+
         var connectionString = _configuration.GetConnectionString("Default");
         var sqlConnectionStringBuilder = new SqlConnectionStringBuilder(connectionString);
         

--- a/Assessments.Frontend.Web/Program.cs
+++ b/Assessments.Frontend.Web/Program.cs
@@ -86,11 +86,11 @@ app.MapDefaultControllerRoute();
 
 ExportHelper.Setup();
 
-//if (!app.Environment.IsDevelopment())
-//{
-//    using var scope = app.Services.CreateScope();
-//    var dataContext = scope.ServiceProvider.GetRequiredService<AssessmentsDbContext>();
-//    dataContext.Database.Migrate();
-//}
+if (!app.Environment.IsDevelopment())
+{
+    using var scope = app.Services.CreateScope();
+    var dataContext = scope.ServiceProvider.GetRequiredService<AssessmentsDbContext>();
+    dataContext.Database.Migrate();
+}
 
 app.Run();


### PR DESCRIPTION
kjører database migrasjon på oppstart (igjen)
skjuler databaseinfo (via api'et) i produksjon