### PR TITLE
Feature/citation url feedback anchor

### DIFF
--- a/Assessments.Frontend.Web/Controllers/FeedbackController.cs
+++ b/Assessments.Frontend.Web/Controllers/FeedbackController.cs
@@ -221,7 +221,7 @@ namespace Assessments.Frontend.Web.Controllers
 
             TempData["feedback"] = $"Du vil bli tilsendt en e-post (til {viewModel.Email}) med lenke for tilbakemelding.";
 
-            return Url.IsLocalUrl(returnUrl) ? Redirect(returnUrl) : BadRequest();
+            return Url.IsLocalUrl(returnUrl) ? Redirect($"{returnUrl}#feedback") : BadRequest();
         }
 
         public IActionResult Terms() => View();

--- a/Assessments.Frontend.Web/Views/Shared/_CitationForAssessment.cshtml
+++ b/Assessments.Frontend.Web/Views/Shared/_CitationForAssessment.cshtml
@@ -20,6 +20,6 @@
         (@date).
         @Html.Raw(Model.AssessmentName)
         @Model.PublicationText
-        @Context.Request.GetEncodedUrl()
+        @Context.Request.GetDisplayUrl().Split('?')[0]
     </p>
 }


### PR DESCRIPTION
- fjerner querystring fra siteringsurl (den fikk med "guid" parameter når bruker validerer e-postadresse)
- går til #feedback anker når man registerer e-postadresse for validering