### PR TITLE
Feature/disable export option

### DIFF
--- a/Assessments.Frontend.Web/Controllers/AlienSpeciesController.cs
+++ b/Assessments.Frontend.Web/Controllers/AlienSpeciesController.cs
@@ -6,9 +6,10 @@ using Assessments.Frontend.Web.Infrastructure.AlienSpecies;
 using Assessments.Frontend.Web.Models;
 using Assessments.Mapping.AlienSpecies.Model;
 using Assessments.Shared.Helpers;
+using Assessments.Shared.Options;
 using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using X.PagedList;
 
 namespace Assessments.Frontend.Web.Controllers
@@ -17,9 +18,14 @@ namespace Assessments.Frontend.Web.Controllers
     [Route("fremmedartslista")]
     public class AlienSpeciesController : BaseController<AlienSpeciesController>
     {
-        private AttachmentRepository _attachmentRepository;
+        private readonly AttachmentRepository _attachmentRepository;
+        private readonly AlienSpeciesOptions _alienSpeciesOptions;
 
-        protected AttachmentRepository AttachmentRepository => _attachmentRepository ??= HttpContext.RequestServices.GetService<AttachmentRepository>();
+        public AlienSpeciesController(IOptions<ApplicationOptions> options, AttachmentRepository attachmentRepository)
+        {
+            _alienSpeciesOptions = options.Value.AlienSpecies;
+            _attachmentRepository = attachmentRepository;
+        }
 
         public IActionResult Home() => View("AlienSpeciesHome");
 
@@ -67,20 +73,26 @@ namespace Assessments.Frontend.Web.Controllers
         {
             var data = await DataRepository.GetAlienSpeciesAssessments();
             var assessment = data.FirstOrDefault(x => x.Attachments.Any(y => y.Id == attachmentId));
+
+            if (assessment == null)
+                return NotFound();
+
             var attachment = assessment.Attachments.Single(x => x.Id == attachmentId);
 
-            var stream = await AttachmentRepository.GetFileStream(
+            var stream = await _attachmentRepository.GetFileStream(
                 DataFilenames.CalculateAlienSpecies2023AttachmentFilePath(attachmentId, attachment.FileName));
             
             return new FileStreamResult(stream, attachment.MimeType)
             {
                 FileDownloadName = attachment.FileName
             };
-
         }
 
         private IActionResult GetExport(IEnumerable<AlienSpeciesAssessment2023> query)
         {
+            if (_alienSpeciesOptions.DisableExport)
+                return NotFound();
+
             var assessmentsForExport = Mapper.Map<IEnumerable<AlienSpeciesAssessment2023Export>>(query.ToList());
 
             return new FileStreamResult(ExportHelper.GenerateAlienSpeciesAssessment2023Export(assessmentsForExport, Request.GetDisplayUrl()), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")

--- a/Assessments.Frontend.Web/Program.cs
+++ b/Assessments.Frontend.Web/Program.cs
@@ -7,6 +7,7 @@ using Assessments.Frontend.Web.Infrastructure;
 using Assessments.Frontend.Web.Infrastructure.AlienSpecies;
 using Assessments.Frontend.Web.Infrastructure.Api;
 using Assessments.Frontend.Web.Infrastructure.Services;
+using Assessments.Shared.Options;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.CookiePolicy;
 using Microsoft.AspNetCore.Http;
@@ -47,6 +48,8 @@ builder.Services.AddSwagger();
 builder.Services.AddResponseCompression();
 
 builder.Services.AddSendGrid(options => { options.ApiKey = builder.Configuration["SendGridApiKey"]; });
+
+builder.Services.Configure<ApplicationOptions>(builder.Configuration.GetSection(nameof(ApplicationOptions)));
 
 var app = builder.Build();
 

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesIndex.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesIndex.cshtml
@@ -47,14 +47,6 @@
                 <partial name="/Views/AlienSpecies/2023/ListPartials/_Filters.cshtml" />
             </form>
 
-            <div is-visible="@Model.Results.Any()">
-                <form>
-                    <button type="submit" name="Export" value="true" formtarget="_blank">
-                        <span class="material-icons">file_download</span> Eksporter
-                    </button>
-                </form>
-            </div>
-
             <partial name="/Views/Shared/_CitationForList.cshtml" model="citationViewModel"/>
         </div>
     </div>

--- a/Assessments.Frontend.Web/Views/Shared/_FilterMobileButtons.cshtml
+++ b/Assessments.Frontend.Web/Views/Shared/_FilterMobileButtons.cshtml
@@ -1,9 +1,18 @@
+@using Assessments.Shared.Options
+@using Microsoft.Extensions.Options
+
+@inject IOptions<ApplicationOptions> Options
+
+@{
+    var disableExport = Options.Value.AlienSpecies.DisableExport;
+}
+
 <div class="filters_bottom">
     <button class="close_filters" name="Lukk filtre" type="button" onclick="closeFilters()">
         Avslutt
         <span class="material-icons">close</span>
     </button>
-    <button class="hideonmobile tertiary" type="submit" name="Export" value="true" formtarget="_blank">
+    <button is-visible="!disableExport" class="hideonmobile tertiary" type="submit" name="Export" value="true" formtarget="_blank">
         <span class="material-icons">file_download</span> Eksporter
     </button>
     <button id="submit_filters" name="Påfør filter" type="submit" class="submit_filters primary">

--- a/Assessments.Frontend.Web/appsettings.Development.json
+++ b/Assessments.Frontend.Web/appsettings.Development.json
@@ -14,5 +14,10 @@
     "AlienSpecies": {
       "TransformAssessments": true
     }
+  },
+  "ApplicationOptions": {
+    "AlienSpecies": {
+      "DisableExport": false
+    }
   }
 }

--- a/Assessments.Frontend.Web/appsettings.Staging.json
+++ b/Assessments.Frontend.Web/appsettings.Staging.json
@@ -1,23 +1,23 @@
 {
-	"Logging": {
-		"LogLevel": {
-			"Default": "Information",
-			"Microsoft": "Warning",
-			"Microsoft.Hosting.Lifetime": "Information",
-			"Assessments.*": "Debug"
-		}
-	},
-	"Mapping": {
-		"Species": {
-			"TransformAssessments": false
-		},
-		"AlienSpecies": {
-			"TransformAssessments": true
-		}
-	},
-	"ApplicationOptions": {
-		"AlienSpecies": {
-			"DisableExport": false
-		}
-	}
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Assessments.*": "Debug"
+    }
+  },
+  "Mapping": {
+    "Species": {
+      "TransformAssessments": false
+    },
+    "AlienSpecies": {
+      "TransformAssessments": true
+    }
+  },
+  "ApplicationOptions": {
+    "AlienSpecies": {
+      "DisableExport": false
+    }
+  }
 }

--- a/Assessments.Frontend.Web/appsettings.Staging.json
+++ b/Assessments.Frontend.Web/appsettings.Staging.json
@@ -1,0 +1,23 @@
+{
+	"Logging": {
+		"LogLevel": {
+			"Default": "Information",
+			"Microsoft": "Warning",
+			"Microsoft.Hosting.Lifetime": "Information",
+			"Assessments.*": "Debug"
+		}
+	},
+	"Mapping": {
+		"Species": {
+			"TransformAssessments": false
+		},
+		"AlienSpecies": {
+			"TransformAssessments": true
+		}
+	},
+	"ApplicationOptions": {
+		"AlienSpecies": {
+			"DisableExport": false
+		}
+	}
+}

--- a/Assessments.Frontend.Web/appsettings.json
+++ b/Assessments.Frontend.Web/appsettings.json
@@ -19,5 +19,10 @@
     "Default": "Server=localhost;Database=Assessments;Trusted_Connection=True;Integrated Security=SSPI"
   },
   "FeedbackSecret": "", // from configuration or user secrets
-  "SendGridApiKey": "" // from configuration or user secrets
+  "SendGridApiKey": "", // from configuration or user secrets,
+  "ApplicationOptions": {
+    "AlienSpecies": {
+      "DisableExport": true // toogle export button visibility
+    }
+  }
 }

--- a/Assessments.Shared/Options/AlienSpeciesOptions.cs
+++ b/Assessments.Shared/Options/AlienSpeciesOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace Assessments.Shared.Options
+{
+    public class ApplicationOptions
+    {
+        public AlienSpeciesOptions AlienSpecies { get; set; }
+    }
+
+    public class AlienSpeciesOptions
+    {
+        public bool DisableExport { get; set; }
+    }
+}


### PR DESCRIPTION
La til innstillinger (via [Options pattern](https://learn.microsoft.com/en-us/dotnet/core/extensions/options)) for å kunne slå av eksport

innstillingen ligger i appsettings: ApplicationOptions -> AlienSpecies -> DisableExport (true/false), og kan gjøres per miljø
skal være avslått i "Production" under innsynet (slik innstillingen er satt nå)

man må bygge på nytt for at endring skal tas i bruk

Close #880 
