### PR TITLE
Feature/notfound error pages

### DIFF
--- a/Assessments.Frontend.Web/Controllers/Api/BaseApiController.cs
+++ b/Assessments.Frontend.Web/Controllers/Api/BaseApiController.cs
@@ -7,7 +7,7 @@ namespace Assessments.Frontend.Web.Controllers.Api
 {
     [NotReadyForProduction]
     [ApiController, Produces("application/json")]
-    public abstract class BaseApiController<T> : Controller where T : BaseApiController<T>
+    public abstract class BaseApiController<T> : ControllerBase where T : BaseApiController<T>
     {
         private IWebHostEnvironment _environment;
 

--- a/Assessments.Frontend.Web/Controllers/Api/TestController.cs
+++ b/Assessments.Frontend.Web/Controllers/Api/TestController.cs
@@ -8,7 +8,7 @@ namespace Assessments.Frontend.Web.Controllers.Api;
 
 [ApiController]
 [Route("api/[controller]")]
-public class TestController : Controller
+public class TestController : ControllerBase
 {
     private readonly IWebHostEnvironment _environment;
     private readonly IConfiguration _configuration;

--- a/Assessments.Frontend.Web/Controllers/ErrorController.cs
+++ b/Assessments.Frontend.Web/Controllers/ErrorController.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace Assessments.Frontend.Web.Controllers;
+
+[Route("Error")]
+[ApiExplorerSettings(IgnoreApi = true)]
+[ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
+public class ErrorController : Controller
+{
+    [Route("{code:int}")]
+    public IActionResult Error(int code) => code == 404 ? View("ErrorNotFound") : View();
+
+    public IActionResult Error() => View();
+}

--- a/Assessments.Frontend.Web/Program.cs
+++ b/Assessments.Frontend.Web/Program.cs
@@ -62,7 +62,11 @@ builder.Services.Configure<ApplicationOptions>(builder.Configuration.GetSection(
 var app = builder.Build();
 
 if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseStatusCodePagesWithReExecute("/Error/{0}");
     app.UseHsts();
+}
 
 app.UseHttpsRedirection();
 

--- a/Assessments.Frontend.Web/Views/Error/Error.cshtml
+++ b/Assessments.Frontend.Web/Views/Error/Error.cshtml
@@ -1,0 +1,11 @@
+﻿@{
+    ViewData["Title"] = "En feil oppstod";
+}
+
+<div class="pagecontainer">
+    <div class="mid-content">
+        <div class="page-header">
+            <h3>Beklager, en feil oppstod på denne siden.</h3>
+        </div>
+    </div>
+</div>

--- a/Assessments.Frontend.Web/Views/Error/ErrorNotFound.cshtml
+++ b/Assessments.Frontend.Web/Views/Error/ErrorNotFound.cshtml
@@ -1,0 +1,14 @@
+﻿@{
+    ViewData["Title"] = "Kan ikke finne siden";
+}
+
+<div class="pagecontainer">
+    <partial name="/Views/Shared/_PageMenuHistorical.cshtml" />
+    <div class="content-placer bigmid">
+        <div class="mid-content">
+            <div class="page-header">
+                <h3>@ViewData["Title"]</h3>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Håndtering av feil og sider som ikke finnes

- nye sider i Views-> Error -> "[Error.cshtml](https://github.com/Artsdatabanken/assessments-frontend/blob/c851a224f77648ee6f74f38671d5fe2e9d044113/Assessments.Frontend.Web/Views/Error/Error.cshtml)" (for feil i kode eller på server) og "[ErrorNotFound.cshtml](https://github.com/Artsdatabanken/assessments-frontend/blob/c851a224f77648ee6f74f38671d5fe2e9d044113/Assessments.Frontend.Web/Views/Error/ErrorNotFound.cshtml)" (når side/ressurs ikkke finnes)
- endret samtidig til anbefalt baseklasse i api'et

**Feilsidene vises ikke i "Development" miljø** 

Man kan teste dette ved å endre miljø til "Staging" eller "Production" i Properties -> launchSettings.json 
https://github.com/Artsdatabanken/assessments-frontend/blob/d9c219f37ad789489659a46096d3bdf508f0d911/Assessments.Frontend.Web/Properties/launchSettings.json#L23

.. og så forsøke å åpne en side/url som ikke finnes, eller trigge en feil i koden f.eks slik:

![image](https://user-images.githubusercontent.com/69149042/213692278-1a82b93d-b7ca-4259-acec-71716563ee34.png)

**Trenger nok mere og bedre tekster, formatering og styling..**

Error.cshtml bør ha så enkelt innhold som mulig (slik at man er sikker på at den vises, i tilfelle det er feil i en meny eller noe)

Close #881 