### PR TITLE
Add not found when attachment is missing in blobstorage

### DIFF
--- a/Assessments.Frontend.Web/Controllers/AlienSpeciesController.cs
+++ b/Assessments.Frontend.Web/Controllers/AlienSpeciesController.cs
@@ -79,8 +79,10 @@ namespace Assessments.Frontend.Web.Controllers
 
             var attachment = assessment.Attachments.Single(x => x.Id == attachmentId);
 
-            var stream = await _attachmentRepository.GetFileStream(
-                DataFilenames.CalculateAlienSpecies2023AttachmentFilePath(attachmentId, attachment.FileName));
+            var stream = await _attachmentRepository.GetFileStream(DataFilenames.CalculateAlienSpecies2023AttachmentFilePath(attachmentId, attachment.FileName));
+
+            if (stream == null)
+                return NotFound();
             
             return new FileStreamResult(stream, attachment.MimeType)
             {

--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/AttachmentRepository.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/AttachmentRepository.cs
@@ -4,6 +4,7 @@ using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
 {
@@ -11,6 +12,7 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
     {
         private readonly IConfiguration _configuration;
         private BlobContainerClient _containerClient;
+        private readonly ILogger<AttachmentRepository> _logger;
 
         private BlobContainerClient ContainerClient
         {
@@ -25,8 +27,9 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
             }
         }
 
-        public AttachmentRepository(IConfiguration configuration)
+        public AttachmentRepository(IConfiguration configuration, ILogger<AttachmentRepository> logger)
         {
+            _logger = logger;
             _configuration = configuration;
         }
         
@@ -42,6 +45,8 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
             }
             catch (RequestFailedException ex) when (ex.ErrorCode == BlobErrorCode.BlobNotFound)
             {
+                _logger.LogWarning("{Message}", ex.Message);
+               
                 return null;
             }
         }


### PR DESCRIPTION
vises 404 side i stedet for en feilside når et filvedlegg mangler i azure storage