### PR TITLE
Risikomatrise utseende

### DIFF
--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
@@ -275,7 +275,7 @@
                     <li class="risk-level lo @className(3, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-13"><span>LO</span></li>
                     <li class="risk-level ph @className(4, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-14"><span>PH</span></li>
                 </ul>
-                <ul>
+                <ul class="bottom-legend">
                     <li class="description"></li>
                     <li class="description"><span>1</span> lite</li>
                     <li class="description"><span>2</span> begrensa</li>

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
@@ -6,15 +6,15 @@
     /* Risk Matrix 2023
      * 
    Filled line - Criteria value
-   -> Determines risk category
+   -> Determines risk risk-levelegory
 
    Dashed/Dotted Line - Uncertainty
-   -> one step up/down from risk category
+   -> one step up/down from risk risk-levelegory
     x-axis: A-C criteria. 
     y-axis: D-I criteria
     */
 
-    // Risk category placement
+    // Risk risk-levelegory placement
     int x = Model.Assessment.ScoreInvasionPotential.Value;
     int y = Model.Assessment.ScoreEcologicalEffect.Value;
     List<AlienSpeciesAssessment2023Criterion> yAxisCriteriaList = new List<AlienSpeciesAssessment2023Criterion>();    
@@ -86,15 +86,15 @@
 	        {"1", 0},
 	        {"1>", 1},
             {"2", 2},
-            {"<2", 3},
+            {"><2", 3},
 	        {"2>", 4},
-            {"<2>", 5},
+            {"><2>", 5},
             {"3", 6},
-            {"<3", 7},
+            {"><3", 7},
 	        {"3>", 8},
-            {"<3>", 9},
+            {"><3>", 9},
             {"4", 10},
-            {"<4", 11},
+            {"><4", 11},
         };
 
     // Reverse lookup of stringToUNumberDictionary
@@ -125,7 +125,7 @@
     // Obtain Uncertainty Lookup number by criterion. 
     static int uncertaintyConversion( AlienSpeciesAssessment2023Criterion criterion,Dictionary<string, int> stringToUNumber){
         string key = "";
-        if(criterion.UncertaintyValues.AsQueryable().Min() < criterion.Value){ key += "<"; };
+        if(criterion.UncertaintyValues.AsQueryable().Min() < criterion.Value){ key += "><"; };
         key += criterion.Value;
         if(criterion.UncertaintyValues.AsQueryable().Max() > criterion.Value){ key += ">"; };
         return stringToUNumber[key];
@@ -150,10 +150,10 @@
     // Follow rules for conclusion strings, as given by Ane :)        
     if(deciciveAB && deciciveC) // both AB & C are decisive criteria
     {
-        bool cUP = C_conclusion.Contains("<");
-        bool cDown = C_conclusion.Contains("<");
-        bool abUP = AB_conclusion.Contains("<");
-        bool abDown = AB_conclusion.Contains("<");
+        bool cUP = C_conclusion.Contains("><");
+        bool cDown = C_conclusion.Contains("><");
+        bool abUP = AB_conclusion.Contains("><");
+        bool abDown = AB_conclusion.Contains("><");
         bool cHasUV = cUP || cDown; // C has any uncertainty
         bool abHasUV = abUP || abDown; // AB has any uncertainty
 
@@ -166,10 +166,10 @@
         }else {                
             if(cUP && abUP && cDown && abDown) // Both have up and down
             {                    
-                x_conclusion = "<" + x + ">";
+                x_conclusion = "><" + x + ">";
             }else if(cDown && abDown) // Down if both have down
             {                    
-                x_conclusion = "<" + x;
+                x_conclusion = "><" + x;
             }else if(cUP && abUP) // Up if both have up
             {
                 x_conclusion += ">";
@@ -185,7 +185,7 @@
 
     // Final interpretation of conclusion-string 
     int xHigherUncertainty = x_conclusion.Contains(">")?x+1:x; 
-    int xLowerUncertainty =  x_conclusion.Contains("<")?x-1:x;
+    int xLowerUncertainty =  x_conclusion.Contains("><")?x-1:x;
 }
 
 @functions{
@@ -201,7 +201,7 @@
             if (current_y <= highestUncertainty_y && current_y > place_y)
             {
                 // y value smaller than the highest cap
-                // higher than the category value
+                // higher than the risk-levelegory value
                 classN = "uncertain " + highestUncertainty_y + " " +current_y + " " + place_y;               
             }
 
@@ -209,7 +209,7 @@
             if (current_y >= lowestUncertainty_y && current_y < place_y)
             {
                 // y value higher than the lowest cap
-                // lower than the category value
+                // lower than the risk-levelegory value
                 classN = "uncertain " + lowestUncertainty_y + " " +current_y + " " + place_y;               
             }
         }
@@ -227,7 +227,7 @@
             if (current_x >= lowestUncertainty_x && current_x < place_x)
             {
                 // y value higher than the lowest cap
-                // lower than the category value
+                // lower than the risk-levelegory value
                 classN = "uncertain " + lowestUncertainty_x + " " +current_x + " " + place_x;               
             }
         }
@@ -242,53 +242,49 @@
 
 <div>
     <h2>@Constants.HeadingsNo.RiskMatrix</h2>
+
+
     <figure class="risk-level-matrix">
-        <table>
-            <tbody>
-                <tr>
-                    <td rowspan="4" class="legend legend-v"><span>@yAxisLabel</span></td>
-                    <td class="description"><span>4</span> stor</td>
-                    <td class="cat-ph @className(1, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-41">14</td>
-                    <td class="cat-hi @className(2, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-42">24</td>
-                    <td class="cat-se @className(3, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-43">34</td>
-                    <td class="cat-se @className(4, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-44">44</td>
-                </tr>
-                <tr>
-                    <td class="description"><span>3</span> middels</td>
-                    <td class="cat-lo @className(1, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-31">13</td>
-                    <td class="cat-hi @className(2, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-32">23</td>
-                    <td class="cat-hi @className(3, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-33">33</td>
-                    <td class="cat-se @className(4, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-34">43</td>
-                </tr>
-                <tr>
-                    <td class="description"><span>2</span> liten</td>
-                    <td class="cat-lo @className(1, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-21">12</td>
-                    <td class="cat-lo @className(2, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-22">22</td>
-                    <td class="cat-lo @className(3, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-23">32</td>
-                    <td class="cat-hi @className(4, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-24">42</td>
-                </tr>
-                <tr>
-                    <td class="description"><span>1</span> ingen kjent</td>
-                    <td class="cat-nk @className(1, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-11">11</td>
-                    <td class="cat-lo @className(2, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-12">21</td>
-                    <td class="cat-lo @className(3, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-13">31</td>
-                    <td class="cat-ph @className(4, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-14">41</td>
-                </tr>
-                <tr>
-                    <td class="description"></td>
-                    <td class="description"></td>
-                    <td class="description"><span>1</span> lite</td>
-                    <td class="description"><span>2</span> begrensa</td>
-                    <td class="description"><span>3</span> moderat</td>
-                    <td class="description"><span>4</span> stor</td>
-                </tr>
-            <tr>
-                <td class="legend"></td>
-                <td></td>
-                <td colspan="4" class="legend">@xAxisLabel</td>
-            </tr>
-            </tbody>
-        </table>
+        <span class="legend rotate-legend">@yAxisLabel</span>
+        <div class="risk-matrix">
+                <ul>                    
+                    <li class="description"><span>4</span> stor</li>
+                    <li class="risk-level ph @className(1, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-41"><span>PH</span></li>
+                    <li class="risk-level hi @className(2, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-42"><span>HI</span></li>
+                    <li class="risk-level se @className(3, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-43"><span>SE</span></li>
+                    <li class="risk-level se @className(4, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-44"><span>SE</span></li>
+                </ul>
+                <ul>
+                    <li class="description"><span>3</span> middels</li>
+                    <li class="risk-level lo @className(1, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-31"><span>LO</span></li>
+                    <li class="risk-level hi @className(2, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-32"><span>HI</span></li>
+                    <li class="risk-level hi @className(3, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-33"><span>HI</span></li>
+                    <li class="risk-level se @className(4, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-34"><span>SE</span></li>
+                </ul>
+                <ul>
+                    <li class="description"><span>2</span> liten</li>
+                    <li class="risk-level lo @className(1, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-21"><span>LO</span></li>
+                    <li class="risk-level lo @className(2, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-22"><span>LO</span></li>
+                    <li class="risk-level lo @className(3, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-23"><span>LO</span></li>
+                    <li class="risk-level hi @className(4, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-24"><span>HI</span></li>
+                </ul>
+                <ul class="bottom-border">
+                    <li class="description"><span>1</span> ingen kjent</li>
+                    <li class="risk-level nk @className(1, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-11"><span>NK</span></li>
+                    <li class="risk-level lo @className(2, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-12"><span>LO</span></li>
+                    <li class="risk-level lo @className(3, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-13"><span>LO</span></li>
+                    <li class="risk-level ph @className(4, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-14"><span>PH</span></li>
+                </ul>
+                <ul>
+                    <li class="description"></li>
+                    <li class="description"><span>1</span> lite</li>
+                    <li class="description"><span>2</span> begrensa</li>
+                    <li class="description"><span>3</span> moderat</li>
+                    <li class="description"><span>4</span> stor</li>
+                </ul>
+        </div>
+        <span></span>
+        <span class="legend">@xAxisLabel</span>
         <!--  <a class="info-link" href="/pages/239659" target="_blank">Forklaring på risikomatrisen</a>-->
     </figure>
 </div>

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
@@ -245,38 +245,38 @@
 
 
     <figure class="risk-level-matrix">
-        <span class="legend rotate-legend">@yAxisLabel</span>
+        <span class="legend rotate-legend">@yAxisLabel<span class="non-css-only"> (1-4)</span></span>
         <div class="risk-matrix">
                 <ul>                    
-                    <li class="description"><span>4</span> stor</li>
-                    <li class="risk-level ph @className(1, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-41"><span>PH</span></li>
-                    <li class="risk-level hi @className(2, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-42"><span>HI</span></li>
-                    <li class="risk-level se @className(3, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-43"><span>SE</span></li>
-                    <li class="risk-level se @className(4, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-44"><span>SE</span></li>
+                    <li class="description"><span>4</span> stor<span class="non-css-only"> @yAxisLabel:</span></li>
+                    <li class="risk-level ph @className(1, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-41"><span class="non-css-only">1 @xAxisLabel: </span><span>PH</span><span class="non-css-only"> @className(1, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level hi @className(2, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-42"><span class="non-css-only">2 @xAxisLabel:  </span><span>HI</span><span class="non-css-only"> @className(2, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level se @className(3, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-43"><span class="non-css-only">3 @xAxisLabel:  </span><span>SE</span><span class="non-css-only"> @className(3, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level se @className(4, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-44"><span class="non-css-only">4 @xAxisLabel:  </span><span>SE</span><span class="non-css-only"> @className(4, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
                 </ul>
                 <ul>
-                    <li class="description"><span>3</span> middels</li>
-                    <li class="risk-level lo @className(1, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-31"><span>LO</span></li>
-                    <li class="risk-level hi @className(2, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-32"><span>HI</span></li>
-                    <li class="risk-level hi @className(3, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-33"><span>HI</span></li>
-                    <li class="risk-level se @className(4, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-34"><span>SE</span></li>
+                    <li class="description"><span>3</span> middels<span class="non-css-only"> @yAxisLabel:</span></li>
+                    <li class="risk-level lo @className(1, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-31"><span class="non-css-only">1 @xAxisLabel:  </span><span>LO</span><span class="non-css-only"> @className(1, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level hi @className(2, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-32"><span class="non-css-only">2 @xAxisLabel:  </span><span>HI</span><span class="non-css-only"> @className(2, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level hi @className(3, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-33"><span class="non-css-only">3 @xAxisLabel:  </span><span>HI</span><span class="non-css-only"> @className(3, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level se @className(4, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-34"><span class="non-css-only">4 @xAxisLabel:  </span><span>SE</span><span class="non-css-only"> @className(4, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
                 </ul>
                 <ul>
-                    <li class="description"><span>2</span> liten</li>
-                    <li class="risk-level lo @className(1, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-21"><span>LO</span></li>
-                    <li class="risk-level lo @className(2, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-22"><span>LO</span></li>
-                    <li class="risk-level lo @className(3, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-23"><span>LO</span></li>
-                    <li class="risk-level hi @className(4, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-24"><span>HI</span></li>
+                    <li class="description"><span>2</span> liten<span class="non-css-only"> @yAxisLabel:</span></li>
+                    <li class="risk-level lo @className(1, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-21"><span class="non-css-only">1 @xAxisLabel:  </span><span>LO</span><span class="non-css-only"> @className(1, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level lo @className(2, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-22"><span class="non-css-only">2 @xAxisLabel:  </span><span>LO</span><span class="non-css-only"> @className(2, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level lo @className(3, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-23"><span class="non-css-only">3 @xAxisLabel:  </span><span>LO</span><span class="non-css-only"> @className(3, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level hi @className(4, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-24"><span class="non-css-only">4 @xAxisLabel:  </span><span>HI</span><span class="non-css-only"> @className(4, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
                 </ul>
                 <ul class="bottom-border">
-                    <li class="description"><span>1</span> ingen kjent</li>
-                    <li class="risk-level nk @className(1, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-11"><span>NK</span></li>
-                    <li class="risk-level lo @className(2, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-12"><span>LO</span></li>
-                    <li class="risk-level lo @className(3, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-13"><span>LO</span></li>
-                    <li class="risk-level ph @className(4, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-14"><span>PH</span></li>
+                    <li class="description"><span>1</span> ingen kjent<span class="non-css-only"> @yAxisLabel:</span></li>
+                    <li class="risk-level nk @className(1, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-11"><span class="non-css-only">1 @xAxisLabel:  </span><span>NK</span><span class="non-css-only"> @className(1, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level lo @className(2, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-12"><span class="non-css-only">2 @xAxisLabel:  </span><span>LO</span><span class="non-css-only"> @className(2, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level lo @className(3, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-13"><span class="non-css-only">3 @xAxisLabel:  </span><span>LO</span><span class="non-css-only"> @className(3, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level ph @className(4, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-14"><span class="non-css-only">4 @xAxisLabel:  </span><span>PH</span><span class="non-css-only"> @className(4, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
                 </ul>
                 <ul class="bottom-legend">
-                    <li class="description"></li>
+                    <li class="description"><span class="non-css-only">Tallforklaring</span></li>
                     <li class="description"><span>1</span> lite</li>
                     <li class="description"><span>2</span> begrensa</li>
                     <li class="description"><span>3</span> moderat</li>

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
@@ -302,7 +302,7 @@
                     <li class="risk-level lo @className(3, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-13"><span class="non-css-only">For @xAxisLabel (x-aksen) = 3: kategori </span><span>LO</span><span class="non-css-only"> er verdien: @findStatus(3, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
                     <li class="risk-level ph @className(4, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-14"><span class="non-css-only">For @xAxisLabel (x-aksen) = 4: kategori </span><span>PH</span><span class="non-css-only"> er verdien: @findStatus(4, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
                 </ul>
-                <b class="non-css-only"><br />Tallforklaring:</b>
+                <b class="non-css-only"><br />Tallforklaring for x-aksen:</b>
                 <ul class="bottom-legend">
                     <span></span>
                     <li class="description"><span>1</span> lite</li>

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
@@ -202,7 +202,7 @@
             {
                 // y value smaller than the highest cap
                 // higher than the risk-levelegory value
-                classN = "uncertain " + highestUncertainty_y + " " +current_y + " " + place_y;               
+                classN = "uncertain";              
             }
 
             // Add DOWNWARDS uncertainty to the y-axis only for the current column on the x-axis.
@@ -210,17 +210,17 @@
             {
                 // y value higher than the lowest cap
                 // lower than the risk-levelegory value
-                classN = "uncertain " + lowestUncertainty_y + " " +current_y + " " + place_y;               
+                classN = "uncertain";       
             }
         }
 
-         if(current_y == place_y)
+        if(current_y == place_y)
         {
             // Add UPWARDS uncertainty to the x-axis only for the current column on the x-axis.
             if (current_x <= highestUncertainty_x && current_x > place_x)
             {
-               
-                classN = "uncertain " + highestUncertainty_x + " " +current_x + " " + place_x;               
+
+                classN = "uncertain";
             }
 
             // Add DOWNWARDS uncertainty to the y-axis only for the current column on the x-axis.
@@ -228,7 +228,7 @@
             {
                 // y value higher than the lowest cap
                 // lower than the risk-levelegory value
-                classN = "uncertain " + lowestUncertainty_x + " " +current_x + " " + place_x;               
+                classN = "uncertain";
             }
         }
 
@@ -240,43 +240,71 @@
     }
 }
 
+@functions{
+    string findStatus(int current_x, int current_y, int place_x, int place_y,int highestUncertainty_y, int lowestUncertainty_y,int highestUncertainty_x, int lowestUncertainty_x){
+
+        string name = className(current_x, current_y, place_x, place_y, highestUncertainty_y, lowestUncertainty_y, highestUncertainty_x, lowestUncertainty_x);
+        if(name == "active")
+        {
+            return "gjeldende";
+        }else if(name == "uncertain")
+        {
+            return "har usikkerhet";
+        }
+        else
+        {
+            return "ikke gjeldende";
+        }
+    }
+}
+
 <div>
     <h2>@Constants.HeadingsNo.RiskMatrix</h2>
-
+    <!-- 
+        Used the class non-css-only to make the matrix readable for users with css disabled.
+        This was not an issue with tables, but would be for grid view with many lists.
+        All info given in the non-css-only fields would be easily seen when css is added without these 
+        texts which then gets a display:none.
+    -->
 
     <figure class="risk-level-matrix">
-        <span class="legend rotate-legend">@yAxisLabel<span class="non-css-only"> (1-4)</span></span>
+        <span class="legend rotate-legend">@yAxisLabel<span class="non-css-only"> (y-aksen)</span></span>
         <div class="risk-matrix">
+            <b class="non-css-only"><br />y = 4</b>
                 <ul>                    
-                    <li class="description"><span>4</span> stor<span class="non-css-only"> @yAxisLabel:</span></li>
-                    <li class="risk-level ph @className(1, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-41"><span class="non-css-only">1 @xAxisLabel: </span><span>PH</span><span class="non-css-only"> @className(1, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
-                    <li class="risk-level hi @className(2, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-42"><span class="non-css-only">2 @xAxisLabel:  </span><span>HI</span><span class="non-css-only"> @className(2, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
-                    <li class="risk-level se @className(3, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-43"><span class="non-css-only">3 @xAxisLabel:  </span><span>SE</span><span class="non-css-only"> @className(3, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
-                    <li class="risk-level se @className(4, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-44"><span class="non-css-only">4 @xAxisLabel:  </span><span>SE</span><span class="non-css-only"> @className(4, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="description"><span class="non-css-only">@yAxisLabel: </span><span>4</span> stor</li>
+                    <li class="risk-level ph @className(1, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-41"><span class="non-css-only">For @xAxisLabel (x-aksen) = 1: kategori </span><span>PH</span><span class="non-css-only"> er verdien: @findStatus(1, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level hi @className(2, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-42"><span class="non-css-only">For @xAxisLabel (x-aksen) = 2: kategori </span><span>HI</span><span class="non-css-only"> er verdien: @findStatus(2, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level se @className(3, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-43"><span class="non-css-only">For @xAxisLabel (x-aksen) = 3: kategori </span><span>SE</span><span class="non-css-only"> er verdien: @findStatus(3, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level se @className(4, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )"  id="risk-44"><span class="non-css-only">For @xAxisLabel (x-aksen) = 4: kategori </span><span>SE</span><span class="non-css-only"> er verdien: @findStatus(4, 4, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
                 </ul>
+                <b class="non-css-only"><br />y = 3</b>
                 <ul>
-                    <li class="description"><span>3</span> middels<span class="non-css-only"> @yAxisLabel:</span></li>
-                    <li class="risk-level lo @className(1, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-31"><span class="non-css-only">1 @xAxisLabel:  </span><span>LO</span><span class="non-css-only"> @className(1, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
-                    <li class="risk-level hi @className(2, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-32"><span class="non-css-only">2 @xAxisLabel:  </span><span>HI</span><span class="non-css-only"> @className(2, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
-                    <li class="risk-level hi @className(3, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-33"><span class="non-css-only">3 @xAxisLabel:  </span><span>HI</span><span class="non-css-only"> @className(3, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
-                    <li class="risk-level se @className(4, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-34"><span class="non-css-only">4 @xAxisLabel:  </span><span>SE</span><span class="non-css-only"> @className(4, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="description"><span class="non-css-only">@yAxisLabel: </span><span>3</span> middels</li>
+                    <li class="risk-level lo @className(1, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-31"><span class="non-css-only">For @xAxisLabel (x-aksen) = 1: kategori </span><span>LO</span><span class="non-css-only"> er verdien: @findStatus(1, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level hi @className(2, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-32"><span class="non-css-only">For @xAxisLabel (x-aksen) = 2: kategori </span><span>HI</span><span class="non-css-only"> er verdien: @findStatus(2, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level hi @className(3, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-33"><span class="non-css-only">For @xAxisLabel (x-aksen) = 3: kategori </span><span>HI</span><span class="non-css-only"> er verdien: @findStatus(3, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level se @className(4, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-34"><span class="non-css-only">For @xAxisLabel (x-aksen) = 4: kategori </span><span>SE</span><span class="non-css-only"> er verdien: @findStatus(4, 3, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
                 </ul>
+                <b class="non-css-only"><br />y = 2</b>
                 <ul>
-                    <li class="description"><span>2</span> liten<span class="non-css-only"> @yAxisLabel:</span></li>
-                    <li class="risk-level lo @className(1, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-21"><span class="non-css-only">1 @xAxisLabel:  </span><span>LO</span><span class="non-css-only"> @className(1, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
-                    <li class="risk-level lo @className(2, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-22"><span class="non-css-only">2 @xAxisLabel:  </span><span>LO</span><span class="non-css-only"> @className(2, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
-                    <li class="risk-level lo @className(3, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-23"><span class="non-css-only">3 @xAxisLabel:  </span><span>LO</span><span class="non-css-only"> @className(3, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
-                    <li class="risk-level hi @className(4, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-24"><span class="non-css-only">4 @xAxisLabel:  </span><span>HI</span><span class="non-css-only"> @className(4, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="description"><span class="non-css-only">@yAxisLabel: </span><span>2</span> liten</li>
+                    <li class="risk-level lo @className(1, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-21"><span class="non-css-only">For @xAxisLabel (x-aksen) = 1: kategori </span><span>LO</span><span class="non-css-only"> er verdien: @findStatus(1, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level lo @className(2, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-22"><span class="non-css-only">For @xAxisLabel (x-aksen) = 2: kategori </span><span>LO</span><span class="non-css-only"> er verdien: @findStatus(2, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level lo @className(3, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-23"><span class="non-css-only">For @xAxisLabel (x-aksen) = 3: kategori </span><span>LO</span><span class="non-css-only"> er verdien: @findStatus(3, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level hi @className(4, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-24"><span class="non-css-only">For @xAxisLabel (x-aksen) = 4: kategori </span><span>HI</span><span class="non-css-only"> er verdien: @findStatus(4, 2, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
                 </ul>
+                <b class="non-css-only"><br />y = 1</b>
                 <ul class="bottom-border">
-                    <li class="description"><span>1</span> ingen kjent<span class="non-css-only"> @yAxisLabel:</span></li>
-                    <li class="risk-level nk @className(1, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-11"><span class="non-css-only">1 @xAxisLabel:  </span><span>NK</span><span class="non-css-only"> @className(1, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
-                    <li class="risk-level lo @className(2, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-12"><span class="non-css-only">2 @xAxisLabel:  </span><span>LO</span><span class="non-css-only"> @className(2, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
-                    <li class="risk-level lo @className(3, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-13"><span class="non-css-only">3 @xAxisLabel:  </span><span>LO</span><span class="non-css-only"> @className(3, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
-                    <li class="risk-level ph @className(4, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-14"><span class="non-css-only">4 @xAxisLabel:  </span><span>PH</span><span class="non-css-only"> @className(4, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="description"><span class="non-css-only">@yAxisLabel: </span><span>1</span> ingen kjent</li>
+                    <li class="risk-level nk @className(1, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-11"><span class="non-css-only">For @xAxisLabel (x-aksen) = 1: kategori </span><span>NK</span><span class="non-css-only"> er verdien: @findStatus(1, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level lo @className(2, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-12"><span class="non-css-only">For @xAxisLabel (x-aksen) = 2: kategori </span><span>LO</span><span class="non-css-only"> er verdien: @findStatus(2, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level lo @className(3, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-13"><span class="non-css-only">For @xAxisLabel (x-aksen) = 3: kategori </span><span>LO</span><span class="non-css-only"> er verdien: @findStatus(3, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
+                    <li class="risk-level ph @className(4, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty )" id="risk-14"><span class="non-css-only">For @xAxisLabel (x-aksen) = 4: kategori </span><span>PH</span><span class="non-css-only"> er verdien: @findStatus(4, 1, x, y, yHigherUncertainty, yLowerUncertainty, xHigherUncertainty, xLowerUncertainty ) </span></li>
                 </ul>
+                <b class="non-css-only"><br />Tallforklaring:</b>
                 <ul class="bottom-legend">
-                    <li class="description"><span class="non-css-only">Tallforklaring</span></li>
+                    <span></span>
                     <li class="description"><span>1</span> lite</li>
                     <li class="description"><span>2</span> begrensa</li>
                     <li class="description"><span>3</span> moderat</li>
@@ -284,7 +312,7 @@
                 </ul>
         </div>
         <span></span>
-        <span class="legend">@xAxisLabel</span>
+        <span class="legend">@xAxisLabel<span class="non-css-only">: @x, @yAxisLabel: @y </span></span>
         <!--  <a class="info-link" href="/pages/239659" target="_blank">Forklaring på risikomatrisen</a>-->
     </figure>
 </div>

--- a/Assessments.Frontend.Web/wwwroot/css/riskMatrix.css
+++ b/Assessments.Frontend.Web/wwwroot/css/riskMatrix.css
@@ -4,7 +4,9 @@
 .risk-level-matrix {
     display: inline-grid;
     grid-template-columns: 20px 1fr;
-    margin:0
+    margin:0;
+    overflow-x:auto;
+        max-width:100%;
 }
 
 .risk-matrix {
@@ -73,7 +75,7 @@
 }
 
 .rotate-legend {
-    writing-mode: vertical-lr;
+    writing-mode: vertical-rl;
     transform: scale(-1, -1);
 }
 
@@ -106,4 +108,31 @@
 .risk-matrix .se span {
     background: #5e3063;
     color: white;
+}
+
+
+@media only screen and (max-width: 355px) {
+
+    .risk-matrix ul {
+        grid-template-columns: 60px repeat(4, 40px);
+    }
+
+    .risk-matrix li {
+        height: 40px;
+        line-height: 38px;
+        width:40px
+    }
+
+    .risk-matrix li.active span,
+    .risk-matrix li.uncertain span {
+        line-height: 34px;
+    }
+
+    .bottom-legend .description {
+        writing-mode: vertical-rl;
+        transform: scale(-1, -1);
+        height: 80px;
+        text-align: right
+    }
+    
 }

--- a/Assessments.Frontend.Web/wwwroot/css/riskMatrix.css
+++ b/Assessments.Frontend.Web/wwwroot/css/riskMatrix.css
@@ -1,129 +1,109 @@
-/* DIRECT COPY FROM 2018 */
+
+/* remaking risk matrix to grid*/
 
 .risk-level-matrix {
-    margin: 20px -20px;
+    display: inline-grid;
+    grid-template-columns: 20px 1fr;
+    margin:0
 }
 
-figure.risk-level-matrix table {
-    border: none;
-    border-collapse: separate;
-    border-spacing: 1px;
-    width: 360px;
-    height: 300px;
+.risk-matrix {
+    display: inline-flex;
+    flex-direction: column;
 }
 
-@media print {
-    figure.risk-level-matrix table {
-        border-collapse: collapse;
-        border-spacing: inherit;
-    }
-
-    figure.risk-level-matrix table td.cat-nk,
-    figure.risk-level-matrix table td.cat-lo,
-    figure.risk-level-matrix table td.cat-ph,
-    figure.risk-level-matrix table td.cat-hi,
-    figure.risk-level-matrix table td.cat-se {
-        border-color: #000000;
-        color: #000000;
-    }
+.risk-matrix ul {
+    display: inline-grid;
+    grid-template-columns: repeat(5, 60px);
+    list-style: none;
 }
 
-figure.risk-level-matrix table td:not(.description) {
-    width: 44px;
-    height: 44px;
-    border: 2px solid transparent;
+
+/* element containers */
+.risk-matrix li {
+    height: 60px;
+    line-height: 60px;
     text-align: center;
-    font-weight: bold;
-    padding: 0;
-    color: transparent;
-}
-figure.risk-level-matrix table .description {
-   color: black;
 }
 
-.darktheme figure.risk-level-matrix table .description {
-    color: white;
+.risk-level {
+    background: black;
+    border: 1px solid black;
+    border-bottom-width: 0px;
 }
 
-
-figure.risk-level-matrix table td[colspan],
-figure.risk-level-matrix table td[rowspan] {
-    color: #000000;
+.risk-level:not(:last-child) {
+    border-right: none
 }
 
-
-.darktheme figure.risk-level-matrix table td[colspan],
-.darktheme figure.risk-level-matrix table td[rowspan] {
-    color: white;
+.bottom-border .risk-level {
+    border-width: 1px
 }
 
-figure.risk-level-matrix table .cat-nk {
-    background: #9ba963;
-    border-color: #9ba963;
-}
-
-figure.risk-level-matrix table .cat-lo {
-    background: #5ea4a1;
-    border-color: #5ea4a1;
-}
-
-figure.risk-level-matrix table .cat-ph {
-    background: #185a6c;
-    border-color: #185a6c;
-}
-
-figure.risk-level-matrix table .cat-hi {
-    background: #1b386f;
-    border-color: #1b386f;
-}
-
-figure.risk-level-matrix table .cat-se {
-    background: #5e3063;
-    border-color: #5e3063;
-}
-
-figure.risk-level-matrix table td.active {
-    border-color: #FFF;
-}
-
-figure.risk-level-matrix table .active > b {
+.risk-level span {
     display: block;
-    width: 100%;
     height: 100%;
-    border: medium solid #FFF;
 }
 
-figure.risk-level-matrix table td.uncertain {
-    border-color: #FFF;
-    border-style:dashed;
+.risk-matrix li.active span {
+    font-weight: bold;
+    text-decoration: underline;
 }
 
-figure.risk-level-matrix table td.legend {
-    font-weight: normal;
-    text-align: center;
+.risk-matrix li.active span,
+.risk-matrix li.uncertain span {
+    border: 2px solid white;
+    font-size: 20px;
+    line-height: 54px;
 }
 
-figure.risk-level-matrix table td.legend-v {
-    position: relative;
+.risk-matrix li.uncertain span {
+    border-style: dashed;
 }
 
-figure.risk-level-matrix table td.legend-v span {
-    position: absolute;
-    transform: rotate(-90deg);
-    display: block;
-    width: 1rem;
-    white-space: nowrap;
-    line-height: 1rem;
-    top: 50%;
-    right: -2em;
-    text-align: center;
-    bottom: 0;
+.risk-matrix li.description {
+    line-height: initial;
+    padding: 8px;
+    font-size: small;
+    border: none;
 }
 
-.description{
-    font-size:small
+.risk-matrix li.description span {
+    display: block
 }
 
-.description span {
-    display: block;
+.rotate-legend {
+    writing-mode: vertical-lr;
+    transform: scale(-1, -1);
+}
+
+.legend {
+    text-align: center
+}
+
+
+/* colours */
+.risk-matrix .nk span {
+    background: #9ba963;
+    color: #201f1f
+}
+
+.risk-matrix .lo span {
+    background: #5ea4a1;
+    color: #201f1f
+}
+
+.risk-matrix .ph span {
+    background: #185a6c;
+    color: white;
+}
+
+.risk-matrix .hi span {
+    background: #1b386f;
+    color: white;
+}
+
+.risk-matrix .se span {
+    background: #5e3063;
+    color: white;
 }

--- a/Assessments.Frontend.Web/wwwroot/css/riskMatrix.css
+++ b/Assessments.Frontend.Web/wwwroot/css/riskMatrix.css
@@ -1,6 +1,10 @@
 
 /* remaking risk matrix to grid*/
 
+.non-css-only {
+    display: none!important;
+}
+
 .risk-level-matrix {
     display: inline-grid;
     grid-template-columns: 20px 1fr;


### PR DESCRIPTION
Fikses #922

- La inn en mindre størrelse for bitte-bitte små vinduer (under 355px) bare fordi jeg ikke liker at ting ikke ser bra ut alltid
- For mikroskopiske skjermer satte jeg på scrollbar for x-retning. Får være grenser ;)
- endra fra tabell til grid
- satte på kategorinavnene på hvert felt, slik at det er lesbart også om fargene strippes vekk
- sort border rundt alle elementene for å øke kontrast for ikke-darktheme mot det hvite. Det var vanskelig å finne en god border-farge som var tydelig nok uten ramme. Med sort omriss kan vi gå for hvit, som har høy kontrast mot det meste.
- Har også uthevet usikker og gjeldende kategori for å nå krav om å vise på andre måter enn bare farge
- Har av samme grunn lagt på underline på gjeldende.
- Har lagt til en del felter som vises for brukere med avskrudd css for å gi mer mening til teksten i matrisa.

![bilde](https://user-images.githubusercontent.com/17450081/216324568-64c7b4b1-80ef-40fe-a317-6fb9f919fa19.png)
--
![bilde](https://user-images.githubusercontent.com/17450081/216340577-64c79d90-70b0-4b8f-9c44-80280fb15cf4.png)