### PR TITLE
Fiks matrisebug #935

### DIFF
--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
@@ -33,7 +33,7 @@
         var letter = criterion.CriteriaLetter;
         var xAxis = (letter == AlienSpeciesAssessment2023CriteriaLetter.A || letter == AlienSpeciesAssessment2023CriteriaLetter.B || letter == AlienSpeciesAssessment2023CriteriaLetter.C);
         if (!xAxis){
-            if (criterion.UncertaintyValues.Count > 1 && criterion.Value > 0 && criterion.Value == y)
+            if (criterion.Value > 0 && criterion.Value == y) //criterion.UncertaintyValues.Count > 1 && 
             {
                 yAxisCriteriaList.Add(criterion);
             }
@@ -42,27 +42,34 @@
 
     // 2. Obtain higher and lower uncertainties
     List<int> lowestYList = new List<int>();
-    foreach (var criterion in yAxisCriteriaList) 
-    {            
-        int criteriaLowestY = y;
-        foreach (var uncertainty in criterion.UncertaintyValues)
-        {                
-            if(uncertainty > yHigherUncertainty) // Always use highest uncertainty 
-            {
-                yHigherUncertainty = uncertainty;
-            }                
-            if(uncertainty < y)
-            {
-                lowestYList.Add(uncertainty); // dump alllower uncertainties into one comparison-list
-            }
-        }   
-    }        
-
-    // 3. set lower uncertainty if all lower uncertainty values are the same
-    if(lowestYList.Distinct().Count() == 1)
+    
+    if (yAxisCriteriaList.Count == 1 || yAxisCriteriaList.All(x => x.UncertaintyValues.Count == 1)) //Accounts for those with only one decisive criteria and those with no decisive criteria on the y-axis (e.g. "2A,1") or no uncertainty in any decisive criteria)
     {
-        yLowerUncertainty = lowestYList[0];
+        yHigherUncertainty = yAxisCriteriaList[0].UncertaintyValues.Max();
+        yLowerUncertainty = yAxisCriteriaList[0].UncertaintyValues.Min();
     }
+    if (yAxisCriteriaList.Count > 1 && !yAxisCriteriaList.All(x => x.UncertaintyValues.Count == 1))
+    {
+        foreach (var criterion in yAxisCriteriaList) 
+        {     
+            lowestYList.Add(criterion.UncertaintyValues.Min()); // dump alllower uncertainties into one comparison-list
+            foreach (var uncertainty in criterion.UncertaintyValues)
+            {                
+                if(uncertainty > yHigherUncertainty) // Always use highest uncertainty 
+                {
+                    yHigherUncertainty = uncertainty;
+                }                
+              
+            }   
+        }
+        
+        // 3. set lower uncertainty if all lower uncertainty values are the same
+        if (lowestYList.Distinct().Count() == 1)
+        {
+            yLowerUncertainty = lowestYList[0];
+        }
+    }
+    
 
     // ~*~ x Uncertainty - Invation Potential ~*~
 

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
@@ -33,7 +33,7 @@
         var letter = criterion.CriteriaLetter;
         var xAxis = (letter == AlienSpeciesAssessment2023CriteriaLetter.A || letter == AlienSpeciesAssessment2023CriteriaLetter.B || letter == AlienSpeciesAssessment2023CriteriaLetter.C);
         if (!xAxis){
-            if (criterion.Value > 0 && criterion.Value == y) //criterion.UncertaintyValues.Count > 1 && 
+            if (criterion.Value > 0 && criterion.Value == y) 
             {
                 yAxisCriteriaList.Add(criterion);
             }

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RiskMatrix.cshtml
@@ -42,25 +42,18 @@
 
     // 2. Obtain higher and lower uncertainties
     List<int> lowestYList = new List<int>();
-    
-    if (yAxisCriteriaList.Count == 1 || yAxisCriteriaList.All(x => x.UncertaintyValues.Count == 1)) //Accounts for those with only one decisive criteria and those with no decisive criteria on the y-axis (e.g. "2A,1") or no uncertainty in any decisive criteria)
+
+    if (yAxisCriteriaList.Count == 1)
     {
         yHigherUncertainty = yAxisCriteriaList[0].UncertaintyValues.Max();
         yLowerUncertainty = yAxisCriteriaList[0].UncertaintyValues.Min();
     }
-    if (yAxisCriteriaList.Count > 1 && !yAxisCriteriaList.All(x => x.UncertaintyValues.Count == 1))
+    if (yAxisCriteriaList.Count > 1 && !yAxisCriteriaList.All(x => x.UncertaintyValues.Count == 1)) //More than one decisive criteria and at least one has uncertainty
     {
+        yHigherUncertainty = yAxisCriteriaList.Select(x => x.UncertaintyValues.Max()).Max(); // Always use highest uncertainty 
         foreach (var criterion in yAxisCriteriaList) 
         {     
-            lowestYList.Add(criterion.UncertaintyValues.Min()); // dump alllower uncertainties into one comparison-list
-            foreach (var uncertainty in criterion.UncertaintyValues)
-            {                
-                if(uncertainty > yHigherUncertainty) // Always use highest uncertainty 
-                {
-                    yHigherUncertainty = uncertainty;
-                }                
-              
-            }   
+            lowestYList.Add(criterion.UncertaintyValues.Min()); // dump alllower uncertainties into one comparison-list  
         }
         
         // 3. set lower uncertainty if all lower uncertainty values are the same


### PR DESCRIPTION
Fix #935 

- Tidligere viste matrisa usikkerhet ned selv om ikke alle utslagsgivende kriterier på y-aksen hadde usikkerhet ned. Feilen var 2-delt: (1) kun utslagsgivende kriterier _med_ usikkerhet ble sammenlignet, men alle må sammenlignes _og_ (2) lista som la til nedre usikkerhet hadde kun med verdier for de kriteriene som faktisk hadde usikkerhet ned. Begge disse bugene er nå fikset.
- Tok meg samtidig friheten til å korte ned litt på koden for usikkerhet oppover - og med det ble koden nøyaktig like lang som før :D