### PR TITLE
site does not crash if an assessment has no species group

### DIFF
--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesDetail.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesDetail.cshtml
@@ -14,7 +14,7 @@
     ViewBag.Title = assessment.ScientificName + " - Fremmedartslista";
 
     var speciesGroup = AlienSpeciesHelpers.GetSpeciesGroup(SpeciesGroups.AlienSpecies2023SpeciesGroups.Filters, assessment.SpeciesGroup);
-    var speciesGroupImageUrl = speciesGroup.ImageUrl;
+    var speciesGroupImageUrl = speciesGroup?.ImageUrl;
 
     var assessmentPageHeaderViewModel = new AssessmentPageHeaderViewModel()
     {


### PR DESCRIPTION
Fixes #979 
Grunnen til krasjen er at artsgruppen mangler på vurderingen. Jeg legger inn så det tillates i koden. 