### PR TITLE
disable ReasonsForChangeOfCategoryDescription

### DIFF
--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_CategoryChange.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_CategoryChange.cshtml
@@ -19,7 +19,7 @@
     var showChangedCriteria = Model.Assessment.ReasonForChangeOfCategory.Contains("changedCriteria");
     var showChangedCriteriaInterpretation = Model.Assessment.ReasonForChangeOfCategory.Contains("changedCriteriaInterpretation");
     var showChangedStatus = Model.Assessment.ReasonForChangeOfCategory.Contains("changedStatus");
-    var showReasonsForChangeDescription = !wasNr2018 && !showSameAs2018 && !string.IsNullOrEmpty(Model.Assessment.ReasonsForChangeOfCategoryDescription);
+    var showReasonsForChangeDescription = (!wasNr2018 && !showSameAs2018 && !string.IsNullOrEmpty(Model.Assessment.ReasonsForChangeOfCategoryDescription) && false); // this is disabled as for now.
 }
 
 <div id="@nameof(Constants.HeadingsNo.CategoryChange)">


### PR DESCRIPTION
Fjerner begrunnelsen for endring av kategori fra 2018 inntil den slås på igjen.