### PR TITLE
Add and consolidate "hearing" configurationsettings

### DIFF
--- a/Assessments.Frontend.Web/Controllers/AlienSpeciesController.cs
+++ b/Assessments.Frontend.Web/Controllers/AlienSpeciesController.cs
@@ -92,7 +92,7 @@ namespace Assessments.Frontend.Web.Controllers
 
         private IActionResult GetExport(IEnumerable<AlienSpeciesAssessment2023> query)
         {
-            if (!_alienSpecies2023Options.EnableExport)
+            if (_alienSpecies2023Options.IsHearing)
                 return NotFound();
 
             var assessmentsForExport = Mapper.Map<IEnumerable<AlienSpeciesAssessment2023Export>>(query.ToList());

--- a/Assessments.Frontend.Web/Models/PartialViewModels.cs
+++ b/Assessments.Frontend.Web/Models/PartialViewModels.cs
@@ -71,6 +71,8 @@ namespace Assessments.Frontend.Web.Models
         public string View { get; set; }
 
         public int ItemCount { get; set; }
+
+        public bool EnableStatistics { get; set; } = true;
     }
 
     public class CriteriaExplanationViewModel

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesDetail.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesDetail.cshtml
@@ -8,8 +8,6 @@
 @inject IOptions<ApplicationOptions> Options
 
 @{
-    var enableCitation = Options.Value.AlienSpecies2023.EnableCitation;
-
     var assessment = Model.Assessment;
     ViewData["Title"] = assessment.ScientificName.ScientificName + " - Fremmedartslista 2023 innsyn"; // TODO: change after innsight process
 
@@ -96,8 +94,8 @@
     var showImpactedNatureTypes = !isNr && !isEvaluatedAtAnotherLevel;
     var showReference = assessment.References != null && assessment.References.Count() > 0;
     var showSpreadWays = !isNr && !isEvaluatedAtAnotherLevel;
-    var showCitationForAssessment = enableCitation && !string.IsNullOrEmpty(Model.ExpertGroupMembers.Select(x => $"{x.LastName} {x.FirstNameInitials}").JoinAnd(", ", " og "));
-    var showFeedback = true;
+    var showCitationForAssessment = Model.ExpertGroupMembers.Any() && !Options.Value.AlienSpecies2023.IsHearing;
+    var showFeedback = Options.Value.AlienSpecies2023.IsHearing;
 
     var tableOfContentsViewModel = new TableOfContentsViewModel
     {
@@ -243,7 +241,7 @@
                 <div class="page-section" is-visible="showCitationForAssessment">
                     <partial name="/Views/Shared/_CitationForAssessment.cshtml" model="citationViewModel" />
                 </div>
-                <div class="page-section" id="Feedback">
+                <div class="page-section" id="Feedback" is-visible="@showFeedback">
                     <partial name="/Views/Shared/_Feedback.cshtml" model="new FeedbackFormViewModel { Year = 2023, AssessmentId = assessment.Id, ExpertGroup = assessment.ExpertGroup, Type = FeedbackType.AlienSpecies, HasBackToTopLink = true }" />
                 </div>
             </div>

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesIndex.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AlienSpeciesIndex.cshtml
@@ -31,7 +31,7 @@
 
     ViewData["Title"] = "Fremmedartslista 2023 - innsyn"; // TODO: change after innsight process
 
-    var enableCitation = Options.Value.AlienSpecies2023.EnableCitation;
+    var enableCitation = !Options.Value.AlienSpecies2023.IsHearing;
 }
 
 <div class="pagecontainer">

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/ListPartials/_Filters.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/ListPartials/_Filters.cshtml
@@ -7,7 +7,7 @@
 @inject IOptions<ApplicationOptions> Options
 
 @{
-    ViewData["EnableExport"] = Options.Value.AlienSpecies2023.EnableExport;
+    ViewData["EnableExport"] = !Options.Value.AlienSpecies2023.IsHearing;
 
     var AllAreas = Areas.AlienSpecies2023Areas;
     var AllCategories = Categories.AlienSpecies2023Categories;
@@ -27,6 +27,7 @@
     {
         View = Model.View,
         ItemCount = Model.Results.TotalItemCount,
+        EnableStatistics = !Options.Value.AlienSpecies2023.IsHearing
     };
 }
 

--- a/Assessments.Frontend.Web/Views/Shared/_ControlButtons.cshtml
+++ b/Assessments.Frontend.Web/Views/Shared/_ControlButtons.cshtml
@@ -18,9 +18,13 @@
     <button @GetViewClass(Model.View, "grid") type="submit" @ViewCheck("View", Model.View, "grid") class="hideonmobile">
         <span class="material-icons">grid_on</span> Grid
     </button>*@
-<button id="stat_view_button" @GetViewClass(Model.View, "stat") type="submit" name="View" value="stat">
-    <span class="material-icons">bar_chart</span> Statistikk
-</button>
+
+@if (Model.EnableStatistics)
+{
+    <button id="stat_view_button" @GetViewClass(Model.View, "stat") type="submit" name="View" value="stat">
+        <span class="material-icons">bar_chart</span> Statistikk
+    </button>
+}
 
 <span class="num_of_resutls desktop_hide">@Model.ItemCount treff</span>
 

--- a/Assessments.Frontend.Web/appsettings.Development.json
+++ b/Assessments.Frontend.Web/appsettings.Development.json
@@ -10,8 +10,7 @@
   "ApplicationOptions": {
     "AlienSpecies2023": {
       "Enabled": true,
-      "EnableExport": true,
-      "EnableCitation": false,
+      "IsHearing": true,
       "TransformAssessments": true
     },
     "Species2021": {

--- a/Assessments.Frontend.Web/appsettings.Staging.json
+++ b/Assessments.Frontend.Web/appsettings.Staging.json
@@ -10,8 +10,7 @@
   "ApplicationOptions": {
     "AlienSpecies2023": {
       "Enabled": true,
-      "EnableCitation": false,
-      "EnableExport": true,
+      "IsHearing": true,
       "TransformAssessments": true
     },
     "Species2021": {

--- a/Assessments.Frontend.Web/appsettings.json
+++ b/Assessments.Frontend.Web/appsettings.json
@@ -16,8 +16,7 @@
   "ApplicationOptions": {
     "AlienSpecies2023": {
       "Enabled": false, // toogle alien species 2003 views and links
-      "EnableCitation": false, // toogle citation
-      "EnableExport": false, // toogle export (button and excel)
+      "IsHearing": true, // toggles feedback (enabled if true) and export/citation/statistics (disabled if true) during "innsynet"
       "TransformAssessments": true
     },
     "Species2021": {      

--- a/Assessments.Shared/Options/ApplicationOptions.cs
+++ b/Assessments.Shared/Options/ApplicationOptions.cs
@@ -11,9 +11,7 @@
     {
         public bool Enabled { get; set; }
 
-        public bool EnableExport { get; set; }
-
-        public bool EnableCitation { get; set; }
+        public bool IsHearing { get; set; }
 
         public bool TransformAssessments { get; set; }
     }


### PR DESCRIPTION
Close #1004

samler alle innstillinger for innsynet i en innstilling "IsHearing" som styrer om eksport, sitering, tilbakemeldinger og statistikk vises

`  "IsHearing": true, // toggles feedback (enabled if true) and export/citation/statistics (disabled if true) during "innsynet"`