### PR TITLE
Exclude certain livestock breeds

### DIFF
--- a/Assessments.Transformation/TransformAlienSpecies.cs
+++ b/Assessments.Transformation/TransformAlienSpecies.cs
@@ -194,6 +194,13 @@ namespace Assessments.Transformation
                 return true;
             }
 
+            // ekskluderer vurderinger med pattedyr som er husdyrraser
+            if (new[]{ 4937, 4963, 4964, 4965, 5217 }.Contains(fa4.Id))
+            {
+                Progress.ProgressBar.Tick();
+                return true;
+            }
+
             return false;
         }
 


### PR DESCRIPTION
close #1024

eksluderer vurderinger med id 4937, 4963, 4964, 4965, 5217 (husdyrraser)

4937	Capra aegagrus subsp. hircus f. 'kystgeit'
4963	Ovis aries 'gammelnorsk sau'
4964	Bos taurus 'skotsk høylandsfe'
4965	Equus caballus 'shetlandsponni'
5217	Sus scrofa subsp. domesticus f. 'ullgris'

hardkodede id'er siden det ikke er mulig å få til en spørring akkurat nå (pga en feil i "NameHiearchy" på en av vurderingene)..