### PR TITLE
Add dataprotection, attempt to fix antiforgery issues

### DIFF
--- a/Assessments.Data/Assessments.Data.csproj
+++ b/Assessments.Data/Assessments.Data.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="ClosedXML" Version="0.100.3" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="6.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.14">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Assessments.Data/AssessmentsDbContext.cs
+++ b/Assessments.Data/AssessmentsDbContext.cs
@@ -1,10 +1,11 @@
 ﻿using System.Reflection;
 using Assessments.Data.Models;
+using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace Assessments.Data
 {
-    public class AssessmentsDbContext : DbContext
+    public class AssessmentsDbContext : DbContext, IDataProtectionKeyContext
     {
         public DbSet<Feedback> Feedbacks { get; set; }
 
@@ -13,6 +14,8 @@ namespace Assessments.Data
         public DbSet<EmailValidation> EmailValidations { get; set; }
 
         public DbSet<Log> Logs { get; set; }
+
+        public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
 
         public AssessmentsDbContext(DbContextOptions<AssessmentsDbContext> options) : base(options) { }
 

--- a/Assessments.Data/Migrations/20230222090549_AddDataProtectionKeys.Designer.cs
+++ b/Assessments.Data/Migrations/20230222090549_AddDataProtectionKeys.Designer.cs
@@ -4,6 +4,7 @@ using Assessments.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Assessments.Data.Migrations
 {
     [DbContext(typeof(AssessmentsDbContext))]
-    partial class AssessmentsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230222090549_AddDataProtectionKeys")]
+    partial class AddDataProtectionKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Assessments.Data/Migrations/20230222090549_AddDataProtectionKeys.cs
+++ b/Assessments.Data/Migrations/20230222090549_AddDataProtectionKeys.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Assessments.Data.Migrations
+{
+    public partial class AddDataProtectionKeys : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DataProtectionKeys",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    FriendlyName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Xml = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataProtectionKeys", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DataProtectionKeys");
+        }
+    }
+}

--- a/Assessments.Frontend.Web/Assessments.Frontend.Web.csproj
+++ b/Assessments.Frontend.Web/Assessments.Frontend.Web.csproj
@@ -11,6 +11,7 @@
 	
 	<ItemGroup>
 		<PackageReference Include="ClosedXML" Version="0.100.3" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="6.0.14" />
 		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.14" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.14" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.14">

--- a/Assessments.Frontend.Web/Program.cs
+++ b/Assessments.Frontend.Web/Program.cs
@@ -10,6 +10,7 @@ using Assessments.Frontend.Web.Infrastructure.Services;
 using Assessments.Shared.Options;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.CookiePolicy;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
@@ -58,6 +59,8 @@ builder.Services.AddResponseCompression();
 builder.Services.AddSendGrid(options => { options.ApiKey = builder.Configuration["SendGridApiKey"]; });
 
 builder.Services.Configure<ApplicationOptions>(builder.Configuration.GetSection(nameof(ApplicationOptions)));
+
+builder.Services.AddDataProtection().SetApplicationName("Assessments").PersistKeysToDbContext<AssessmentsDbContext>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
det logges mange feil av typen "Microsoft.AspNetCore.Antiforgery.AntiforgeryValidationException: The antiforgery token could not be decrypted." regner med det er pga lastbalanseringen i drift

forsøker løsning med konfigurering av "Data Protection":  https://learn.microsoft.com/en-us/aspnet/core/security/data-protection/configuration/overview?view=aspnetcore-6.0