### PR TITLE
Enable alienspecies

### DIFF
--- a/Assessments.Frontend.Web/appsettings.json
+++ b/Assessments.Frontend.Web/appsettings.json
@@ -15,7 +15,7 @@
   "SendGridApiKey": "", // from configuration or user secrets
   "ApplicationOptions": {
     "AlienSpecies2023": {
-      "Enabled": false, // toogle alien species 2003 views and links
+      "Enabled": true, // toogle alien species 2003 views and links
       "IsHearing": true, // toggles feedback (enabled if true) and export/citation/statistics (disabled if true) during "innsynet"
       "TransformAssessments": true
     },


### PR DESCRIPTION
oppdaterer konfigurasjonen (som det er gjort kun i master akkurat nå)

gjør at fremmedartslista 2023 vises i produksjon (slik den skal under innsynet)