### PR TITLE
Diverse mapping - nytt listeelement på naturtyper til filtermeny

### DIFF
--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023Export.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023Export.cs
@@ -165,5 +165,9 @@ namespace Assessments.Mapping.AlienSpecies.Model
         [DisplayName("Kom til vurderingsområdet fra")]
         [Description("Angir hvorfra arten ankom vurderingsområdet")]
         public string ArrivedCountryFrom { get; set; }
+
+        [DisplayName("Naturtyper")]
+        [Description("Naturtyper arten koloniserer eller påvirker i dag, eller forventes å kolonisere/påvirke i løpet av vurderingsperioden")]
+        public string Ecosystems { get; set; }
     }
 }

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023ImpactedNatureTypes.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023ImpactedNatureTypes.cs
@@ -5,7 +5,7 @@ namespace Assessments.Mapping.AlienSpecies.Model
 {
     public class AlienSpeciesAssessment2023ImpactedNatureTypes
     {
-        /// </summary>
+        /// <summary>
         /// Name of the ecosystem's major type group in Norwegian
         /// </summary>
         public string MajorTypeGroup { get; set; }
@@ -24,10 +24,12 @@ namespace Assessments.Mapping.AlienSpecies.Model
         /// Time horizon of effect. I.e. whether the impact of the alien species is happening now or assumed in the futre
         /// </summary>
         public AlienSpeciesAssessment2023TimeHorizon TimeHorizon { get; set; }
+        
         /// <summary>
         /// The proportion of the total area of the ecosystem(s) affected that will contain occurrences of the alien species within 50 years
         /// </summary>
         public string ColonizedArea { get; set; }
+        
         /// <summary>
         /// The variables that the alien species brings about a substantial state change in
         /// </summary>

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023ImpactedNatureTypes.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023ImpactedNatureTypes.cs
@@ -5,6 +5,11 @@ namespace Assessments.Mapping.AlienSpecies.Model
 {
     public class AlienSpeciesAssessment2023ImpactedNatureTypes
     {
+        /// </summary>
+        /// Name of the ecosystem's major type group in Norwegian
+        /// </summary>
+        public string MajorTypeGroup { get; set; }
+
         /// <summary>
         /// Name of the ecosystem in Norwegian
         /// </summary>

--- a/Assessments.Mapping/AlienSpecies/Model/Enums/AlienSpeciesAssessment2023AreaOfOccupancyInStronglyAlteredEcosystems.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/Enums/AlienSpeciesAssessment2023AreaOfOccupancyInStronglyAlteredEcosystems.cs
@@ -4,9 +4,6 @@ namespace Assessments.Mapping.AlienSpecies.Model.Enums
 {
     public enum AlienSpeciesAssessment2023AreaOfOccupancyInStronglyAlteredEcosystems
     {
-        [Display(Name = "")]
-        NotChosen,
-
         [Display(Name = "under 5 %")]
         Value0,
 

--- a/Assessments.Mapping/AlienSpecies/Model/Enums/AlienSpeciesAssessment2023SpeciesStatus.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/Enums/AlienSpeciesAssessment2023SpeciesStatus.cs
@@ -5,10 +5,6 @@ namespace Assessments.Mapping.AlienSpecies.Model.Enums
 {
     public enum AlienSpeciesAssessment2023SpeciesStatus
     {
-        [Display(Name = "Ikke relevant")]
-        [Description("er ikke relevant")]
-        Empty,
-
         [Display(Name = "Ikke i Norge")]
         [Description("ikke forekommer i Norge")]
         A,

--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023ExportProfile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023ExportProfile.cs
@@ -29,6 +29,7 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                 .ForMember(dest => dest.ScientificNameId, opt => opt.MapFrom(src => src.ScientificName.ScientificNameId))
                 .ForMember(dest => dest.ScientificNameAuthor, opt => opt.MapFrom(src => src.ScientificName.ScientificNameAuthor))
                 .ForMember(dest => dest.TaxonHierarcy, opt => opt.MapFrom(src => string.Join("\\", src.NameHiearchy.Select(x=>x.ScientificName).ToArray())))
+                .ForMember(dest => dest.Ecosystems, opt => opt.MapFrom(src => string.Join("; ", src.ImpactedNatureTypes.DefaultIfEmpty().Select(x => x.Name).Distinct().ToArray())))
                 ;
         }
     }

--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
@@ -66,24 +66,9 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                     opt.MapFrom(src => src.RiskAssessment.AOOtotalHighInput);
                 })
                 .ForMember(dest => dest.AlienSpeciesDescription, opt => opt.MapFrom(src => src.IsAlien.StripUnwantedHtml()))
-                .ForMember(dest => dest.RiskAssessmentAOOfutureLow, opt =>
-                {
-                    //TODO: remove precondition when all assessments are finished (before innsynet)
-                    opt.PreCondition(src => src.EvaluationStatus == "finished");
-                    opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAOOfuture(src, src.RiskAssessment, "low"));
-                })
-                .ForMember(dest => dest.AOOfutureBest, opt =>
-                {
-                    //TODO: remove precondition when all assessments are finished (before innsynet)
-                    opt.PreCondition(src => src.EvaluationStatus == "finished");
-                    opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAOOfuture(src, src.RiskAssessment, "best"));
-                })
-                .ForMember(dest => dest.RiskAssessmentAOOfutureHigh, opt =>
-                {
-                    //TODO: remove precondition when all assessments are finished (before innsynet)
-                    opt.PreCondition(src => src.EvaluationStatus == "finished");
-                    opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAOOfuture(src, src.RiskAssessment, "high"));
-                })
+                .ForMember(dest => dest.RiskAssessmentAOOfutureLow, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAOOfuture(src, src.RiskAssessment, "low")))
+                .ForMember(dest => dest.AOOfutureBest, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAOOfuture(src, src.RiskAssessment, "best")))
+                .ForMember(dest => dest.RiskAssessmentAOOfutureHigh, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAOOfuture(src, src.RiskAssessment, "high")))
                 .ForMember(dest => dest.CurrentPresenceComment, opt => opt.MapFrom(src => src.CurrentPresenceComment.StripUnwantedHtml()))
                 .ForMember(dest => dest.RiskAssessmentOccurrences1Low, opt =>
                 {
@@ -199,17 +184,17 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                 .ForMember(dest => dest.ExpansionSpeedEstimatedIncreaseInAOODescription, opt => opt.MapFrom(src => src.RiskAssessment.CommentOrDescription.StripUnwantedHtml()))
                 .ForMember(dest => dest.ExpansionSpeedLowEstimate, opt =>
                 {
-                    opt.PreCondition(src => src.Category != "NR" && src.EvaluationStatus == "finished" && src.AlienSpeciesCategory != "TaxonEvaluatedAtAnotherLevel");
+                    opt.PreCondition(src => src.Category != "NR" && src.AlienSpeciesCategory != "TaxonEvaluatedAtAnotherLevel");
                     opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetExpansionSpeedEstimates(src.RiskAssessment, "low", src.AssessmentConclusion));
                 })
                 .ForMember(dest => dest.ExpansionSpeedBestEstimate, opt =>
                 {
-                    opt.PreCondition(src => src.Category != "NR" && src.EvaluationStatus == "finished" && src.AlienSpeciesCategory != "TaxonEvaluatedAtAnotherLevel");
+                    opt.PreCondition(src => src.Category != "NR" && src.AlienSpeciesCategory != "TaxonEvaluatedAtAnotherLevel");
                     opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetExpansionSpeedEstimates(src.RiskAssessment, "best", src.AssessmentConclusion));
                 })
                 .ForMember(dest => dest.ExpansionSpeedHighEstimate, opt =>
                 {
-                    opt.PreCondition(src => src.Category != "NR" && src.EvaluationStatus == "finished" && src.AlienSpeciesCategory != "TaxonEvaluatedAtAnotherLevel");
+                    opt.PreCondition(src => src.Category != "NR" && src.AlienSpeciesCategory != "TaxonEvaluatedAtAnotherLevel");
                     opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetExpansionSpeedEstimates(src.RiskAssessment, "high", src.AssessmentConclusion));
                 })
                 .ForMember(dest => dest.Attachments, opt => opt.MapFrom(src => src.Attachmemnts))

--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
@@ -241,9 +241,10 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                 .ForMember(dest => dest.GenerationTime, opt => opt.MapFrom(src => src.ReproductionGenerationTime))
                 .ForMember(dest => dest.ArrivedCountryFrom, opt => opt.PreCondition(src => src.ArrivedCountryFrom is not null && src.ArrivedCountryFrom.Count > 0))
                 .ForMember(dest => dest.ArrivedCountryFromDetails, opt => opt.MapFrom(src => src.ArrivedCountryFromDetails.StripUnwantedHtml()))
-                .ForMember(dest => dest.AreaOfOccupancyInStronglyAlteredEcosystems, opt => opt.MapFrom(src => src.RiskAssessment.SpreadHistoryDomesticAreaInStronglyChangedNatureTypes.HasValue ? "Value" + src.RiskAssessment.SpreadHistoryDomesticAreaInStronglyChangedNatureTypes.ToString() : "NotChosen"))
+                .ForMember(dest => dest.AreaOfOccupancyInStronglyAlteredEcosystems, opt => opt.MapFrom(src => src.RiskAssessment.SpreadHistoryDomesticAreaInStronglyChangedNatureTypes.HasValue ? "Value" + src.RiskAssessment.SpreadHistoryDomesticAreaInStronglyChangedNatureTypes.ToString() : "Value0"))
                 .ForMember(dest => dest.AllSubTaxaAssessedSeparatelyDescription, opt => opt.MapFrom(src => src.AllSubTaxaAssessedSeparatelyDescription.StripUnwantedHtml()))
                 .ForMember(dest => dest.HybridWithoutOwnRiskAssessmentDescription, opt => opt.MapFrom(src => src.IsHybridWithoutOwnRiskAssessmentDescription.StripUnwantedHtml()))
+                .ForMember(dest => dest.SpeciesStatus, opt => opt.PreCondition(src => src.SpeciesStatus is not null))
                 .AfterMap((_, dest) => dest.PreviousAssessments = AlienSpeciesAssessment2023ProfileHelper.GetPreviousAssessments(dest.PreviousAssessments));
 
             CreateMap<FA4.PreviousAssessment, AlienSpeciesAssessment2023PreviousAssessment>(MemberList.None);

--- a/Assessments.Mapping/AlienSpecies/Source/FA4Vurdering.cs
+++ b/Assessments.Mapping/AlienSpecies/Source/FA4Vurdering.cs
@@ -1664,6 +1664,7 @@ namespace Assessments.Mapping.AlienSpecies.Source
 
         public class ImpactedNatureType
         {
+            public string MajorTypeGroup { get; set; }
             public string NiNCode { get; set; }
             public string Name { get; set; }
             public List<string> NiNVariation { get; set; } = new List<string>();


### PR DESCRIPTION
Har gjort diverse småting i mapping-prosjektet. Spesielt:

1. La til nytt listeelement i ImpactedNatureTypes (MajorTypeGroup). Dette skal brukes i filtreringen (#1118), og måtte også legges til i kildefilen (FA4). 
2. Ryddet i et par enumer som hadde upresise/feil defaultverdier
3. Fjernet PreConditions i profilen som sjekka om en vurdering var ferdigstilt eller ikke (relevant før innsynet, men ikke nå lengre)
4. La til naturtyper i eksporten. 