### PR TITLE
Fix mapping species status

### DIFF
--- a/Assessments.Frontend.Web/Assessments.Frontend.Web.csproj
+++ b/Assessments.Frontend.Web/Assessments.Frontend.Web.csproj
@@ -38,5 +38,9 @@
 	  <ProjectReference Include="..\Assessments.Mapping\Assessments.Mapping.csproj" />
 	  <ProjectReference Include="..\Assessments.Shared\Assessments.Shared.csproj" />
 	</ItemGroup>
+
+	<ItemGroup>
+	  <Folder Include="Cache\" />
+	</ItemGroup>
 	
 </Project>

--- a/Assessments.Frontend.Web/Assessments.Frontend.Web.csproj
+++ b/Assessments.Frontend.Web/Assessments.Frontend.Web.csproj
@@ -38,9 +38,5 @@
 	  <ProjectReference Include="..\Assessments.Mapping\Assessments.Mapping.csproj" />
 	  <ProjectReference Include="..\Assessments.Shared\Assessments.Shared.csproj" />
 	</ItemGroup>
-
-	<ItemGroup>
-	  <Folder Include="Cache\" />
-	</ItemGroup>
 	
 </Project>

--- a/Assessments.Mapping/AlienSpecies/Model/Enums/AlienSpeciesAssessment2023SpeciesStatus.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/Enums/AlienSpeciesAssessment2023SpeciesStatus.cs
@@ -5,6 +5,10 @@ namespace Assessments.Mapping.AlienSpecies.Model.Enums
 {
     public enum AlienSpeciesAssessment2023SpeciesStatus
     {
+        [Display(Name = "Ikke angitt")]
+        [Description("")]
+        NotIndicated,
+
         [Display(Name = "Ikke i Norge")]
         [Description("ikke forekommer i Norge")]
         A,


### PR DESCRIPTION
Lagt til ny default verdi på etableringsklasse. Dette er en default verdi som kun angår arter som ikke har angitt etableringsklasse, og er altså en verdi som aldri skal vises (se også #1113).