### PR TITLE
Fjern termen RiskAssessment fra alle felter på datamodellen

### DIFF
--- a/Assessments.Frontend.Web/Models/AlienSpeciesDetailViewModel.cs
+++ b/Assessments.Frontend.Web/Models/AlienSpeciesDetailViewModel.cs
@@ -28,11 +28,11 @@ namespace Assessments.Frontend.Web.Models
                 Category = assessment.Category,
                 ChangedFromAlienDescription = assessment.ChangedFromAlienDescription,
                 ConnectedToHigherLowerTaxonDescription = assessment.ConnectedToHigherLowerTaxonDescription,
-                CriteriaDocumentation = assessment.RiskAssessmentCriteriaDocumentation,
-                CriteriaDocumentationDomesticSpread = assessment.RiskAssessmentCriteriaDocumentationDomesticSpread,
-                CriteriaDocumentationEcoEffect = assessment.RiskAssessmentCriteriaDocumentationEcoEffect,
-                CriteriaDocumentationInvasionPotential = assessment.RiskAssessmentCriteriaDocumentationInvasionPotential,
-                CriteriaDocumentationSpeciesStatus = assessment.RiskAssessmentCriteriaDocumentationSpeciesStatus,
+                CriteriaDocumentation = assessment.CriteriaDocumentation,
+                CriteriaDocumentationDomesticSpread = assessment.CriteriaDocumentationDomesticSpread,
+                CriteriaDocumentationEcoEffect = assessment.CriteriaDocumentationEcoEffect,
+                CriteriaDocumentationInvasionPotential = assessment.CriteriaDocumentationInvasionPotential,
+                CriteriaDocumentationSpeciesStatus = assessment.CriteriaDocumentationSpeciesStatus,
                 ChangedFromAlien = assessment.ChangedFromAlien,
                 Environment = assessment.Environment,
                 EvaluationContext = assessment.EvaluationContext,
@@ -78,8 +78,8 @@ namespace Assessments.Frontend.Web.Models
             {
                 AlienSpeciesCategory = assessment.AlienSpeciesCategory,
                 AreaOfOccupancyFutureBest = assessment.AOOfutureBest,
-                AreaOfOccupancyFutureHigh = assessment.RiskAssessmentAOOfutureHigh,
-                AreaOfOccupancyFutureLow = assessment.RiskAssessmentAOOfutureLow,
+                AreaOfOccupancyFutureHigh = assessment.AOOfutureHigh,
+                AreaOfOccupancyFutureLow = assessment.AOOfutureLow,
                 AreaOfOccupancyInStronglyAlteredEcosystems = assessment.AreaOfOccupancyInStronglyAlteredEcosystems,
                 AreaOfOccupancyKnown = assessment.AOOknown,
                 AreaOfOccupancyTotalBest = assessment.AOOtotalBest,
@@ -91,12 +91,12 @@ namespace Assessments.Frontend.Web.Models
                 NameRank = assessment.ScientificName.ScientificNameRank,
                 RegionOccurrences = assessment.RegionOccurrences,
                 FreshWaterRegionModel = assessment.FreshWaterRegionModel,
-                RiskAssessmentIntroductionsLow = assessment.RiskAssessmentIntroductionsLow,
-                RiskAssessmentIntroductionsBest = assessment.RiskAssessmentIntroductionsBest,
-                RiskAssessmentIntroductionsHigh = assessment.RiskAssessmentIntroductionsHigh,
-                RiskAssessmentOccurrences1Low = assessment.RiskAssessmentOccurrences1Low,
-                RiskAssessmentOccurrences1Best = assessment.RiskAssessmentOccurrences1Best,
-                RiskAssessmentOccurrences1High = assessment.RiskAssessmentOccurrences1High
+                RiskAssessmentIntroductionsLow = assessment.IntroductionsLow,
+                RiskAssessmentIntroductionsBest = assessment.IntroductionsBest,
+                RiskAssessmentIntroductionsHigh = assessment.IntroductionsHigh,
+                RiskAssessmentOccurrences1Low = assessment.Occurrences1Low,
+                RiskAssessmentOccurrences1Best = assessment.Occurrences1Best,
+                RiskAssessmentOccurrences1High = assessment.Occurrences1High
             };
 
             SideBarContentViewModel = new SideBarContentViewModel

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_CriteriaExplanation.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_CriteriaExplanation.cshtml
@@ -396,9 +396,9 @@
                     
                     <span is-visible="showSimplifiedEstimateAcceptedDoorKnockerOrEffectWithoutReproduction || showSimplifiedEstimateNotAcceptedDoorKnockerOrEffectWithoutReproduction">
                         @Constants.basedOnEstimatesSingular
-                        @assessment.RiskAssessmentOccurrences1Best?.ToString("N0")
+                        @assessment.Occurrences1Best?.ToString("N0")
                         @Constants.basedOnArea10years @Constants.and
-                        @assessment.RiskAssessmentIntroductionsBest?.ToString("N0")
+                        @assessment.IntroductionsBest?.ToString("N0")
                         @Constants.moreIntroductions                       
                     </span>
 
@@ -572,8 +572,8 @@
                     </p>
                 </div>
                 <p is-visible="isEstimatedIncreaseInAOODoorKnockers">                   
-                    @Constants.basedOnEstimatesSingular  @assessment.RiskAssessmentOccurrences1Best?.ToString("N0") 
-                    @Constants.basedOnArea10years @Constants.and @assessment.RiskAssessmentIntroductionsBest?.ToString("N0") 
+                    @Constants.basedOnEstimatesSingular  @assessment.Occurrences1Best?.ToString("N0") 
+                    @Constants.basedOnArea10years @Constants.and @assessment.IntroductionsBest?.ToString("N0") 
                     @Constants.moreIntroductions @Constants.bCriteriaScoredAs @uncertaintyB.Value (@Constants.withUuncertainty
                     @AlienSpeciesHelpers.GetUncertaintyValueMinMax(uncertaintyB.Value, AlienSpeciesHelpers.GetUncertaintyLow(uncertaintyB))
                     – 

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023.cs
@@ -187,27 +187,27 @@ namespace Assessments.Mapping.AlienSpecies.Model
         /// <summary>
         /// Short conclusion/summary of the impact assessment. Free text field
         /// </summary>
-        public string RiskAssessmentCriteriaDocumentation { get; set; }
+        public string CriteriaDocumentation { get; set; }
 
         /// <summary>
         /// Description of the species' distribution in Norway. Free text field
         /// </summary>
-        public string RiskAssessmentCriteriaDocumentationDomesticSpread { get; set; }
+        public string CriteriaDocumentationDomesticSpread { get; set; }
 
         /// <summary>
         /// Description and documentation of the species' ecological effects. Free text field
         /// </summary>
-        public string RiskAssessmentCriteriaDocumentationEcoEffect { get; set; }
+        public string CriteriaDocumentationEcoEffect { get; set; }
 
         /// <summary>
         /// Description and documentation of the species' invasion potential. Free text field
         /// </summary>
-        public string RiskAssessmentCriteriaDocumentationInvasionPotential { get; set; }
+        public string CriteriaDocumentationInvasionPotential { get; set; }
 
         /// <summary>
         /// Description of relevant aspects of taxonomy, the species life history and ecology. Free text field
         /// </summary>
-        public string RiskAssessmentCriteriaDocumentationSpeciesStatus { get; set; }
+        public string CriteriaDocumentationSpeciesStatus { get; set; }
 
         /// <summary>
         /// Wether the species' score on the invation axis would be lower in the absence of current or future climate changes 
@@ -267,7 +267,7 @@ namespace Assessments.Mapping.AlienSpecies.Model
         /// <summary>
         /// Low estimate of area of occupancy (AOO) in  10 (doorknockers) to 50 (alien species that reproduce unaided now) years from now. 
         /// </summary>
-        public int RiskAssessmentAOOfutureLow { get; set; }
+        public int AOOfutureLow { get; set; }
 
         /// <summary>
         /// Best estimate of area of occupancy (AOO) in  10 (doorknockers) to 50 (alien species that reproduce unaided now) years from now. 
@@ -277,7 +277,7 @@ namespace Assessments.Mapping.AlienSpecies.Model
         /// <summary>
         /// High estimate of area of occupancy (AOO) in  10 (doorknockers) to 50 (alien species that reproduce unaided now) years from now. 
         /// </summary>
-        public int RiskAssessmentAOOfutureHigh { get; set; }
+        public int AOOfutureHigh { get; set; }
 
         /// <summary>
         /// The reasoning or assumptions behind future area of occupancy and regional distribution. 
@@ -287,32 +287,32 @@ namespace Assessments.Mapping.AlienSpecies.Model
         /// <summary>
         /// Number of occurrences stemming from a single introduction event 10 years after the introduction took place (low estimate). Used to estimate future AOO for doorknockers. 
         /// </summary>
-        public int? RiskAssessmentOccurrences1Low { get; set; }
+        public int? Occurrences1Low { get; set; }
 
         /// <summary>
         /// Number of occurrences stemming from a single introduction event 10 years after the introduction took place (best estimate). Used to estimate future AOO for doorknockers. 
         /// </summary>
-        public int? RiskAssessmentOccurrences1Best { get; set; }
+        public int? Occurrences1Best { get; set; }
 
         /// <summary>
         /// Number of occurrences stemming from a single introduction event 10 years after the introduction took place (high estimate). Used to estimate future AOO for doorknockers. 
         /// </summary>
-        public int? RiskAssessmentOccurrences1High { get; set; }
+        public int? Occurrences1High { get; set; }
 
         /// <summary>
         /// Number of introductions (minus one) during a 10 years period (low estimate). Used to estimate future AOO for doorknockers. 
         /// </summary>
-        public int? RiskAssessmentIntroductionsLow { get; set; }
+        public int? IntroductionsLow { get; set; }
 
         /// <summary>
         /// Number of introductions (minus one) during a 10 years period (best estimate). Used to estimate future AOO for doorknockers. 
         /// </summary>
-        public int? RiskAssessmentIntroductionsBest { get; set; }
+        public int? IntroductionsBest { get; set; }
 
         /// <summary>
         /// Number of introductions (minus one) during a 10 years period (high estimate). Used to estimate future AOO for doorknockers. 
         /// </summary>
-        public int? RiskAssessmentIntroductionsHigh { get; set; }
+        public int? IntroductionsHigh { get; set; }
 
         /// <summary>
         /// The available methods to estimate the population lifetime of a species (or its likelihood of extinction) in Norway.

--- a/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023Export.cs
+++ b/Assessments.Mapping/AlienSpecies/Model/AlienSpeciesAssessment2023Export.cs
@@ -128,7 +128,7 @@ namespace Assessments.Mapping.AlienSpecies.Model
         //TODO: skill felt mellom dørstokkarter og selvstendig reproduserende for fremtidige forekomstareal?
         [DisplayName("Fremtidig forekomstareal lavt anslag")]
         [Description("Artens antatte forekomstareal (lavt anslag) ti år etter første introduksjon (dørstokkarter) eller om 50 år (selvstendig reproduserende arter)")]
-        public int? RiskAssessmentAOOfutureLow { get; set; }
+        public int? AOOfutureLow { get; set; }
 
         [DisplayName("Fremtidig forekomstareal beste anslag")]
         [Description("Artens antatte forekomstareal (beste anslag) ti år etter første introduksjon (dørstokkarter) eller om 50 år (selvstendig reproduserende arter)")]
@@ -136,31 +136,31 @@ namespace Assessments.Mapping.AlienSpecies.Model
 
         [DisplayName("Fremtidig forekomstareal høyt anslag")]
         [Description("Artens antatte forekomstareal (beste anslag) ti år etter første introduksjon (dørstokkarter) eller om 50 år (selvstendig reproduserende arter)")]
-        public int? RiskAssessmentAOOfutureHigh { get; set; }
+        public int? AOOfutureHigh { get; set; }
 
         [DisplayName("Ant. forekomster fra én introduksjon lavt anslag")]
         [Description("Antallet forekomster (2 km x 2 km-ruter) dørstokkarten kan kolonisere i løpet av en 10 års-periode basert på én introduksjon til norsk natur (lavt anslag)")]
-        public int? RiskAssessmentOccurrences1Low { get; set; }
+        public int? Occurrences1Low { get; set; }
 
         [DisplayName("Ant. forekomster fra én introduksjon beste anslag")]
         [Description("Antallet forekomster (2 km x 2 km-ruter) dørstokkarten kan kolonisere i løpet av en 10 års-periode basert på én introduksjon til norsk natur (beste anslag)")]
-        public int? RiskAssessmentOccurrences1Best { get; set; }
+        public int? Occurrences1Best { get; set; }
 
         [DisplayName("Ant. forekomster fra én introduksjon høyt anslag")]
         [Description("Antallet forekomster (2 km x 2 km-ruter) dørstokkarten kan kolonisere i løpet av en 10 års-periode basert på én introduksjon til norsk natur (høyt anslag)")]
-        public int? RiskAssessmentOccurrences1High { get; set; }
+        public int? Occurrences1High { get; set; }
 
         [DisplayName("Ant. ytterligere introduksjoner lavt anslag")]
         [Description("Antallet ytterligere introduksjoner til norsk natur dørstokkarten antas å få i løpet av en 10 års-periode (lavt anslag)")]
-        public int? RiskAssessmentIntroductionsLow { get; set; }
+        public int? IntroductionsLow { get; set; }
 
         [DisplayName("Ant. ytterligere introduksjoner beste anslag")]
         [Description("Antallet ytterligere introduksjoner til norsk natur dørstokkarten antas å få i løpet av en 10 års-periode (beste anslag)")]
-        public int? RiskAssessmentIntroductionsBest { get; set; }
+        public int? IntroductionsBest { get; set; }
 
         [DisplayName("Ant. ytterligere introduksjoner høyt anslag")]
         [Description("Antallet ytterligere introduksjoner til norsk natur dørstokkarten antas å få i løpet av en 10 års-periode (høyt anslag)")]
-        public int? RiskAssessmentIntroductionsHigh { get; set; }
+        public int? IntroductionsHigh { get; set; }
 
         [DisplayName("Kom til vurderingsområdet fra")]
         [Description("Angir hvorfra arten ankom vurderingsområdet")]

--- a/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
+++ b/Assessments.Mapping/AlienSpecies/Profiles/AlienSpeciesAssessment2023Profile.cs
@@ -30,11 +30,11 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                 .ForMember(dest => dest.ClimateEffectsEcoEffect, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetClimateEffects(src.Category, src.Criteria, "eco", src.RiskAssessment)))
                 .ForMember(dest => dest.ClimateEffectsDocumentation, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetClimateEffectsDoc(src.Category, src.Criteria, src.RiskAssessment, src.RiskAssessment.ClimateEffectsDocumentation)))
                 .ForMember(dest => dest.SpeciesGroup, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetSpeciesGroup(src.TaxonHierarcy)))
-                .ForMember(dest => dest.RiskAssessmentCriteriaDocumentation, opt => opt.MapFrom(src => src.RiskAssessment.CriteriaDocumentation.StripUnwantedHtml()))
-                .ForMember(dest => dest.RiskAssessmentCriteriaDocumentationSpeciesStatus, opt => opt.MapFrom(src => src.RiskAssessment.CriteriaDocumentationSpeciesStatus.StripUnwantedHtml()))
-                .ForMember(dest => dest.RiskAssessmentCriteriaDocumentationDomesticSpread, opt => opt.MapFrom(src => src.RiskAssessment.CriteriaDocumentationDomesticSpread.StripUnwantedHtml()))
-                .ForMember(dest => dest.RiskAssessmentCriteriaDocumentationEcoEffect, opt => opt.MapFrom(src => src.RiskAssessment.CriteriaDocumentationEcoEffect.StripUnwantedHtml()))
-                .ForMember(dest => dest.RiskAssessmentCriteriaDocumentationInvasionPotential, opt => opt.MapFrom(src => src.RiskAssessment.CriteriaDocumentationInvationPotential.StripUnwantedHtml()))
+                .ForMember(dest => dest.CriteriaDocumentation, opt => opt.MapFrom(src => src.RiskAssessment.CriteriaDocumentation.StripUnwantedHtml()))
+                .ForMember(dest => dest.CriteriaDocumentationSpeciesStatus, opt => opt.MapFrom(src => src.RiskAssessment.CriteriaDocumentationSpeciesStatus.StripUnwantedHtml()))
+                .ForMember(dest => dest.CriteriaDocumentationDomesticSpread, opt => opt.MapFrom(src => src.RiskAssessment.CriteriaDocumentationDomesticSpread.StripUnwantedHtml()))
+                .ForMember(dest => dest.CriteriaDocumentationEcoEffect, opt => opt.MapFrom(src => src.RiskAssessment.CriteriaDocumentationEcoEffect.StripUnwantedHtml()))
+                .ForMember(dest => dest.CriteriaDocumentationInvasionPotential, opt => opt.MapFrom(src => src.RiskAssessment.CriteriaDocumentationInvationPotential.StripUnwantedHtml()))
                 .ForMember(dest => dest.UncertaintyStatusDescription, opt => opt.MapFrom(src => src.UncertainityStatusDescription.StripUnwantedHtml()))
                 .ForMember(dest => dest.HasIndoorProduction, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetHasIndoorProduction(src.IndoorProduktion)))
                 .ForMember(dest => dest.SpreadIndoorFurtherInfo, opt => opt.MapFrom(src => src.SpreadIndoorFurtherInfo.StripUnwantedHtml()))
@@ -68,36 +68,36 @@ namespace Assessments.Mapping.AlienSpecies.Profiles
                     opt.MapFrom(src => src.RiskAssessment.AOOtotalHighInput);
                 })
                 .ForMember(dest => dest.AlienSpeciesDescription, opt => opt.MapFrom(src => src.IsAlien.StripUnwantedHtml()))
-                .ForMember(dest => dest.RiskAssessmentAOOfutureLow, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAOOfuture(src, src.RiskAssessment, "low")))
+                .ForMember(dest => dest.AOOfutureLow, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAOOfuture(src, src.RiskAssessment, "low")))
                 .ForMember(dest => dest.AOOfutureBest, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAOOfuture(src, src.RiskAssessment, "best")))
-                .ForMember(dest => dest.RiskAssessmentAOOfutureHigh, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAOOfuture(src, src.RiskAssessment, "high")))
+                .ForMember(dest => dest.AOOfutureHigh, opt => opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.GetAOOfuture(src, src.RiskAssessment, "high")))
                 .ForMember(dest => dest.CurrentPresenceComment, opt => opt.MapFrom(src => src.CurrentPresenceComment.StripUnwantedHtml()))
-                .ForMember(dest => dest.RiskAssessmentOccurrences1Low, opt =>
+                .ForMember(dest => dest.Occurrences1Low, opt =>
                 {
                     opt.PreCondition(src => src.AssessmentConclusion == "AssessedDoorknocker");
                     opt.MapFrom(src => src.RiskAssessment.Occurrences1Low);
                 })
-                .ForMember(dest => dest.RiskAssessmentOccurrences1Best, opt =>
+                .ForMember(dest => dest.Occurrences1Best, opt =>
                 {
                     opt.PreCondition(src => src.AssessmentConclusion == "AssessedDoorknocker");
                     opt.MapFrom(src => src.RiskAssessment.Occurrences1Best);
                 })
-                .ForMember(dest => dest.RiskAssessmentOccurrences1High, opt =>
+                .ForMember(dest => dest.Occurrences1High, opt =>
                 {
                     opt.PreCondition(src => src.AssessmentConclusion == "AssessedDoorknocker");
                     opt.MapFrom(src => src.RiskAssessment.Occurrences1High);
                 })
-                .ForMember(dest => dest.RiskAssessmentIntroductionsLow, opt =>
+                .ForMember(dest => dest.IntroductionsLow, opt =>
                 {
                     opt.PreCondition(src => src.AssessmentConclusion == "AssessedDoorknocker");
                     opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.IntroductionsLow(src.RiskAssessment));
                 })
-                .ForMember(dest => dest.RiskAssessmentIntroductionsBest, opt =>
+                .ForMember(dest => dest.IntroductionsBest, opt =>
                 {
                     opt.PreCondition(src => src.AssessmentConclusion == "AssessedDoorknocker");
                     opt.MapFrom(src => src.RiskAssessment.IntroductionsBest);
                 })
-                .ForMember(dest => dest.RiskAssessmentIntroductionsHigh, opt =>
+                .ForMember(dest => dest.IntroductionsHigh, opt =>
                 {
                     opt.PreCondition(src => src.AssessmentConclusion == "AssessedDoorknocker");
                     opt.MapFrom(src => AlienSpeciesAssessment2023ProfileHelper.IntroductionsHigh(src.RiskAssessment));


### PR DESCRIPTION
Jeg har gått gjennom alle felt på datamodellen og fjernet termen "RiskAssessment" fra navnene. 

Fix #749 