### PR TITLE
Feature/search

### DIFF
--- a/Assessments.Frontend.Web/Controllers/AlienSpeciesController.cs
+++ b/Assessments.Frontend.Web/Controllers/AlienSpeciesController.cs
@@ -126,7 +126,7 @@ namespace Assessments.Frontend.Web.Controllers
                                                     query.Any(y => y.ScientificName.ScientificNameId == x.ScientificNameId)).ToList();                // or match on scientific name id: exact match on species/subsp./var.
 
             // Add assessments if they are in alien species list, but not in artskart. "Subsp." and "var." are not included in scientific names in artskart.
-            var alienSpeciesHits = query.Where(x => x.ScientificName.ScientificName.Trim().ToLower().Contains(name)).ToArray();
+            var alienSpeciesHits = QueryHelpers.ApplySearch(search, query);
 
             foreach (var hit in alienSpeciesHits)
             {
@@ -137,10 +137,7 @@ namespace Assessments.Frontend.Web.Controllers
                     PopularName = hit.VernacularName,
                     MatchedName = hit.ScientificName.ScientificName,
                     ScientificName = hit.ScientificName.ScientificName,
-                    TaxonCategory = hit.ScientificName.ScientificNameRank.DisplayName() == nameof(Constants.TaxonCategoriesEn.Species) ? Constants.TaxonCategoriesEn.Species :
-                                    hit.ScientificName.ScientificNameRank.DisplayName() == nameof(Constants.TaxonCategoriesEn.SubSpecies) ? Constants.TaxonCategoriesEn.SubSpecies :
-                                    hit.ScientificName.ScientificNameRank.DisplayName() == nameof(Constants.TaxonCategoriesEn.Variety) ? Constants.TaxonCategoriesEn.Variety :
-                                    hit.ScientificName.ScientificNameRank.DisplayName() == nameof(Constants.TaxonCategoriesEn.Form) ? Constants.TaxonCategoriesEn.Form : 0
+                    TaxonCategory = (int)hit.ScientificName.ScientificNameRank
                 });
             }
 

--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
@@ -89,7 +89,7 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
                 rank = searchString.Substring(rankIndexAt + 1, rankIndexEnd - 1 - rankIndexAt);
                 if (rank.Length > 2)
                 {
-                    rank = rank[0].ToString().ToUpperInvariant() + rank.Substring(1).ToLowerInvariant();
+                    rank = rank[0].ToString().ToUpperInvariant() + rank[1..].ToLowerInvariant();
                 }
                 searchString = searchString[..rankIndexAt].Trim().ToLowerInvariant();
             }
@@ -97,8 +97,7 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
             // If taxonomic rank is not valid, the normal search will be used instead
             if (!string.IsNullOrEmpty(rank))
             {
-                string rankValue;
-                if (Constants.TaxonCategoriesNbToEn.TryGetValue(rank, out rankValue))
+                if (Constants.TaxonCategoriesNbToEn.TryGetValue(rank, out string rankValue))
                 {
                     if (Enum.TryParse(typeof(AlienSpeciesAssessment2023ScientificNameRank), rankValue, true, out var newRank))
                     {

--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
@@ -78,19 +78,49 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
             return query;
         }
 
-        private static IQueryable<AlienSpeciesAssessment2023> ApplySearch(string searchString, IQueryable<AlienSpeciesAssessment2023> query)
+        public static IQueryable<AlienSpeciesAssessment2023> ApplySearch(string searchString, IQueryable<AlienSpeciesAssessment2023> query)
         {
+            // Searching for a specific taxonomic rank
+            var rankIndexAt = searchString.IndexOf('(');
+            var rankIndexEnd = searchString.IndexOf(')');
+            var rank = String.Empty;
+            if (rankIndexAt > 0 && rankIndexEnd > 0)
+            {
+                rank = searchString.Substring(rankIndexAt + 1, rankIndexEnd - 1 - rankIndexAt);
+                if (rank.Length > 2)
+                {
+                    rank = rank[0].ToString().ToUpperInvariant() + rank.Substring(1).ToLowerInvariant();
+                }
+                searchString = searchString[..rankIndexAt].Trim().ToLowerInvariant();
+            }
+
+            // If taxonomic rank is not valid, the normal search will be used instead
+            if (!string.IsNullOrEmpty(rank))
+            {
+                string rankValue;
+                if (Constants.TaxonCategoriesNbToEn.TryGetValue(rank, out rankValue))
+                {
+                    if (Enum.TryParse(typeof(AlienSpeciesAssessment2023ScientificNameRank), rankValue, true, out var newRank))
+                    {
+                        AlienSpeciesAssessment2023ScientificNameRank rankEnum = (AlienSpeciesAssessment2023ScientificNameRank)newRank;
+                        return query.Where(x => x.NameHiearchy.Any(y => y.ScientificNameRank == rankEnum && y.ScientificName.ToLowerInvariant() == searchString));
+                    }
+                }
+            }
+
+            // Normal search
+            searchString = searchString.Trim().ToLowerInvariant();
             var containsSubSpecies = query.Where(x =>
                 !string.IsNullOrEmpty(x.VernacularName) &&
-                x.VernacularName.ToLowerInvariant().Contains(searchString.ToLowerInvariant())).Select(x => x.ScientificName.ScientificName).ToArray();
+                x.VernacularName.ToLowerInvariant().Contains(searchString)).Select(x => x.ScientificName.ScientificName).ToArray();
 
             return query.Where(x =>
-                x.ScientificName.ScientificName.ToLowerInvariant().Contains(searchString.ToLowerInvariant()) ||
+                x.ScientificName.ScientificName.ToLowerInvariant().Contains(searchString) ||
                 containsSubSpecies.Any(hit => x.ScientificName.ScientificName.Contains(hit)) || // Search on species also includes sub species
                 !string.IsNullOrEmpty(x.VernacularName) &&
-                x.VernacularName.ToLowerInvariant().Contains(searchString.ToLowerInvariant()) ||
-                x.NameHiearchy.Any(x => x.ScientificName.ToLowerInvariant().Contains(searchString.ToLowerInvariant())) ||
-                x.SpeciesGroup.ToLowerInvariant().Contains(searchString.ToLowerInvariant()));
+                x.VernacularName.ToLowerInvariant().Contains(searchString) ||
+                x.NameHiearchy.Any(x => x.ScientificName.ToLowerInvariant().Contains(searchString)) ||
+                x.SpeciesGroup.ToLowerInvariant().Contains(searchString));
         }
 
         private static IQueryable<AlienSpeciesAssessment2023> ApplyCategoryChange(string[] changes, IQueryable<AlienSpeciesAssessment2023> query)

--- a/Assessments.Frontend.Web/Infrastructure/Helpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Helpers.cs
@@ -207,7 +207,7 @@ namespace Assessments.Frontend.Web.Infrastructure
             {
                 if (Constants.TaxonCategoriesNbToEn.TryGetValue(rank, out string rankValue))
                 {
-                    return query.Where(x => x.VurdertVitenskapeligNavnHierarki.Replace('/', ' ').Split().Reverse().Skip(1).ToList()[0].ToLowerInvariant() == name);
+                    return query.Where(x => x.VurdertVitenskapeligNavnHierarki.Replace('/', ' ').Split().Reverse().Skip(1).ToList().Any(y => y.ToLowerInvariant() == name));
                 }
             }
 

--- a/Assessments.Frontend.Web/wwwroot/js/search.js
+++ b/Assessments.Frontend.Web/wwwroot/js/search.js
@@ -86,18 +86,23 @@ const formatListElements = (el, searchstring) => {
     return name;
 }
 
-function makeListItem(icon, listname, speciesGroup, category, right_action, notassesment, el, id, matchedname, addclass) {
+function makeListItem(icon, listname, speciesGroup, category, right_action, notassesment, el, id, matchedname) {
     const li = document.createElement("li");
-    li.tabIndex = 0;    
+    let searchString = el.ScientificName;
+    li.tabIndex = 0;
+
+    if (el.TaxonCategory != taxonCategories[22] || el.TaxonCategory != taxonCategories[23] || el.TaxonCategory != taxonCategories[24] || el.TaxonCategory != taxonCategories[25]) {
+        searchString += ` (${el.TaxonCategory})`;
+    } 
 
     if (notassesment) {
         li.classList.add("search_autocomplete");      
         li.onclick = () => {
-            searchForTaxa(el.ScientificName);
+            searchForTaxa(searchString);
         }
         li.onkeyup = (e) => {
             if (e.code === "Enter") {
-                searchForTaxa(el.ScientificName);
+                searchForTaxa(searchString);
             }
         }
         li.innerHTML = icon + listname + speciesGroup + category + right_action;
@@ -116,8 +121,8 @@ function makeListItem(icon, listname, speciesGroup, category, right_action, nota
     autocompleteList.appendChild(li);
 }
 
-function searchForTaxa(sciname) {
-    searchField.value = sciname;
+function searchForTaxa(searchString) {
+    searchField.value = searchString;
     document.getElementById("search_and_filter_form").submit();
 }
 
@@ -145,7 +150,7 @@ const createList = (json,searchstring) => {
             for (let i in assessments) {
                 // For each assessment in a taxonomic item
                 const id = assessments[i].id;
-                let addclass, matchedname = "";
+                let matchedname = "";
 
                 if (el.matchedname) {
                     // IF Speciesname does not match the search string, add comparison 
@@ -153,7 +158,6 @@ const createList = (json,searchstring) => {
                     let name = el.PopularName + " " + el.ScientificName;
                     if (!name.includes(el.matchedname)) {        
                         matchedname = "<span class='search_matchedname'>" + '"' + el.matchedname + '"' + "</span>";
-                        addclass = "synonymgrid";                        
                     }
                 }
                 right_action = `<span class="material-icons right_icon">keyboard_arrow_right</span>`;
@@ -180,7 +184,7 @@ const createList = (json,searchstring) => {
                         right_action = '<span class="right_action">' + areaname + "</span >" + right_action;
                     }
                 }                
-                makeListItem(icon, listname, speciesGroup, category, right_action, false, el, id, matchedname, addclass);
+                makeListItem(icon, listname, speciesGroup, category, right_action, false, el, id, matchedname);
             }
         } 
     });

--- a/Assessments.Frontend.Web/wwwroot/js/tableOfContents.js
+++ b/Assessments.Frontend.Web/wwwroot/js/tableOfContents.js
@@ -4,12 +4,12 @@ const tableOfContentsSmallScreen = document.getElementById('tableOfContentsSmall
 const tableOfContentsOuter = document.getElementById('tableOfContentsOuter');
 
 const hideTableOfContentsSmallScreen = () => {
-    tableOfContentsSmallScreen.classList.add('table-of-contents-small-screen-show');
-    tableOfContentsOuter.classList.add('table-of-contents-sticky');
+    tableOfContentsSmallScreen?.classList.add('table-of-contents-small-screen-show');
+    tableOfContentsOuter?.classList.add('table-of-contents-sticky');
 }
 
 const showTableOfContentButton = () => {
-    tableOfContentButton.classList.remove('table-of-contents-small-screen-button-hide');
+    tableOfContentButton?.classList.remove('table-of-contents-small-screen-button-hide');
 }
 
 const initializeTableOfContents = () => {


### PR DESCRIPTION
Fixes #1150 
I fremmedartslista kan man søke på ulike taksonomiske ranker og få korrekt svar. 
I rødlista kan man også forsøke, og svarene blir stort sett korrekte, men her er det ingen skille mellom de ulike taksonomiske rankene. Søker man på "Allium (rike)" får man treff hos alle vurderinger som har noe som matcher "Allium" i sin taksonomiske sti. I praksis funker det nok bra da. 