### PR TITLE
add HasEffectWithoutReproduction to doorknocker icon assessments

### DIFF
--- a/Assessments.Frontend.Web/Models/PartialViewModels.cs
+++ b/Assessments.Frontend.Web/Models/PartialViewModels.cs
@@ -358,6 +358,8 @@ namespace Assessments.Frontend.Web.Models
 
             public string EvaluationContext { get; set; }
 
+            public bool HasEffectWithoutReproduction { get; set; } = false;
+
             public string Category { get; set; }
 
             public string CategoryShort { get; set; }

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/ListPartials/_View.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/ListPartials/_View.cshtml
@@ -9,6 +9,7 @@
         CategoryShort = x.Category.ToString(),
         Id = x.Id,
         IsDoorKnocker = x.AlienSpeciesCategory == Assessments.Mapping.AlienSpecies.Model.Enums.AlienSpeciecAssessment2023AlienSpeciesCategory.DoorKnocker,
+        HasEffectWithoutReproduction = x.AlienSpeciesCategory == Assessments.Mapping.AlienSpecies.Model.Enums.AlienSpeciecAssessment2023AlienSpeciesCategory.EffectWithoutReproduction,
         ScientificNameFormatted = x.ScientificName.ScientificNameFormatted,
         SpeciesGroup = x.SpeciesGroup,
         SpeciesGroupIconUrl = AlienSpeciesHelpers.GetSpeciesGroup(SpeciesGroups.AlienSpecies2023SpeciesGroups.Filters, x.SpeciesGroup)?.ImageUrl,

--- a/Assessments.Frontend.Web/Views/Shared/_ListView.cshtml
+++ b/Assessments.Frontend.Web/Views/Shared/_ListView.cshtml
@@ -17,7 +17,7 @@
     {
         @foreach (var item in Model.Results)
         {
-            var showIsDoorKnocker = @Model.AssessmentType == Assessments.Frontend.Web.Infrastructure.Enums.AssessmentType.AlienSpecies2023 && item.IsDoorKnocker;
+            var showIsDoorKnockerOrHasEffectWithoutReproduction = @Model.AssessmentType == Assessments.Frontend.Web.Infrastructure.Enums.AssessmentType.AlienSpecies2023 && (item.IsDoorKnocker || item.HasEffectWithoutReproduction);
 
             <li class="list @item.SpeciesGroup.ToLower() @item.EvaluationContext @( Model.AssessmentType == Assessments.Frontend.Web.Infrastructure.Enums.AssessmentType.AlienSpecies2023 ? doorknockerClass : string.Empty )">
                 <a asp-action="Detail" asp-route-id="@item.Id">
@@ -39,7 +39,7 @@
                     </span>
 
                     <span is-visible="Model.AssessmentType == Assessments.Frontend.Web.Infrastructure.Enums.AssessmentType.AlienSpecies2023" class="mobile_hide list_doorknocker">
-                        <span is-visible="showIsDoorKnocker">
+                        <span is-visible="showIsDoorKnockerOrHasEffectWithoutReproduction">
                             <span class="material-symbols-outlined">
                                 door_open
                             </span>


### PR DESCRIPTION
Fixes #1171 
Legger til HasEffectWithoutReproduction som også får dørstokkikon.