### PR TITLE
Feature/table adjustments

### DIFF
--- a/Assessments.Frontend.Web/Infrastructure/Constants.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Constants.cs
@@ -342,7 +342,7 @@ namespace Assessments.Frontend.Web.Infrastructure
         public const string ImpactedNatureTypesDescriptionSvalbard = "Naturtyper arten er observert i og/eller som er potensielle habitater for arten på Svalbard. Hvis arten fører til endringer i naturtypen er det angitt.";
         public const string ImpactedNatureTypesCurrentTableTitle = "Truede, sjeldne eller øvrige naturtyper arten er observert i. ";
         public const string ImpactedNatureTypesFutureTableTitle = "Truede, sjeldne eller øvrige naturtyper som er potensielle habitater for arten i Norge. ";
-        public const string ImpactedNatureTypesCurrentTableDescription = "Oversikten viser anslått kolonisert areal (C-kriteriet) i de naturtypene arten er  observert i, samt artens påvirkning i naturtypen og anslått andel av naturtypens areal som blir påvirket (F- og G-kriteriet).";
+        public const string ImpactedNatureTypesCurrentTableDescription = "Tabellen viser anslått kolonisert areal (C-kriteriet) i de naturtypene arten er  observert i, samt artens påvirkning i naturtypen og anslått andel av naturtypens areal som blir påvirket (F- og G-kriteriet).";
         public const string ImpactedNatureTypesFutureTableDescription = "Oversikten viser anslått kolonisert areal (C-kriteriet) i de naturtypene arten regnes med å observeres i innen 50 år eller 5 generasjoner (det av tallene som er størst), samt artens framtidige påvirkning i naturtypen og anslått andel av naturtypens areal som vil bli påvirket (F- og G-kriteriet).";
         public const string ImpactedNatureTypesTableColumn1 = "naturtype";
         public const string ImpactedNatureTypesTableColumn2 = "tidshorisont";
@@ -471,9 +471,20 @@ namespace Assessments.Frontend.Web.Infrastructure
         public const string model = "Modell";
         public const string sitesListed = "Lokalitetene i datafila er oppført";
 
-        /*Tables*/
-        public const string keyStoneSpeciesTable = "Nøkkelart?";
-        public const string redListCategoryTable = "Kategori <br/>Rødlista 2021";
+        /*Criteria Tables*/
+        public const string keyStoneSpeciesTableColumn = "Nøkkelart?";
+        public const string redListCategoryTableColumn = "Kategori <br/>Rødlista 2021";
+        public const string criteriaDSpeciesTableTitle = "Artens negative effekter på trua arter eller nøkkelarter.";
+        public const string criteriaDSpeciesTableDescription = "Tabellen viser hvilken type interaksjon den fremmede arten har med stedegne trua arter eller nøkkelarter, samt interaksjonens styre og omfang. Kun effekter som er dokumentert i Norge eller i utlandet (for arten selv eller en sammenlignbar art), eller som sannsynlig vil opptre i Norge i løpet av 50 år, er inkludert.";
+        public const string criteriaESpeciesTableTitle = "Artens negative effekter på stedegne arter (ikke trua eller sjelden).";
+        public const string criteriaESpeciesTableDescription = "Tabellen viser hvilken type interaksjon den fremmede arten har med stedegne arter, samt interaksjonens styre og omfang. Kun effekter som er dokumentert i Norge eller i utlandet (for arten selv eller en sammenlignbar art), eller som sannsynlig vil opptre i Norge i løpet av 50 år, er inkludert.";
+        public const string criteriaFNaturetypesTableTitle = "Truede eller sjeldne naturtyper som påvirkes av arten.";
+        public const string criteriaGNaturetypesTableTitle = "Naturtyper (ikke trua eller sjelden) som påvirkes av arten.";
+        public const string criteriaFAndGNaturetypesTableDescription = "Tabellen viser hvilke(n) naturtype(r) som påvirkes av den fremmede arten nå eller i framtida. Type tilstandsendring, hvor stor del av naturtypearealet som påvirkes og vurderingsgrunnlag er gitt for hver naturtype. Se retningslinjene for beskrivelse av tydelig tilstandsendring.";
+        public const string criteriaHIntrogressionTableTitle = "Overføring av genetisk materiale.";
+        public const string criteriaHIntrogressionTableDescription = "Tabellen viser hvilke stedegne arter som blir, eller kan bli, genetisk forurenset av den fremmede arten. Med genetisk forurensning menes introgresjon, hybridisering alene er ikke tilstrekkelig. Kun genetisk forurensing som er dokumentert eller sannsynlig er inkludert.";
+        public const string criteriaIParasitesTableTitle = "Overføring av parasitter og patogener.";
+        public const string criteriaIParasitesTableDescription = "Tabellen viser hvilke parasitter eller patogener (inkludert bakterier og virus) arten er vurdert å overføre til stedegne verter, om parasitten er kjent for verten eller ei, samt om parasitten er fremmed eller stedegen. Den økologiske effekten av overføringen kan ikke være større enn den økologiske effekten parasitten selv vurderes å ha etter kriteriene D til H. Kun overføringer av parasitter og patogener som er dokumentert eller sannsynlig er inkludert.";
 
         public const string FigureMainText = "Her finner du resultater fra Fremmedartslista 2023 presentert i figurer. Figurene er reaktive, og viser kun resultater for det utvalget du har gjort i filteret. Om ingen filterutvalg er gjort, vises resultater for alle risikovurderte arter, både for Fastlands-Norge og Svalbard. Arter som ikke er risikovurderte (NR-arter) er ekskludert fra datagrunnlaget i alle figurer, det samme gjelder underarter og kultivarer som er inkludert i vurderingen av moderarten.";
 

--- a/Assessments.Frontend.Web/Infrastructure/Constants.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Constants.cs
@@ -471,6 +471,10 @@ namespace Assessments.Frontend.Web.Infrastructure
         public const string model = "Modell";
         public const string sitesListed = "Lokalitetene i datafila er oppført";
 
+        /*Tables*/
+        public const string keyStoneSpeciesTable = "Nøkkelart?";
+        public const string redListCategoryTable = "Kategori <br/>Rødlista 2021";
+
         public const string FigureMainText = "Her finner du resultater fra Fremmedartslista 2023 presentert i figurer. Figurene er reaktive, og viser kun resultater for det utvalget du har gjort i filteret. Om ingen filterutvalg er gjort, vises resultater for alle risikovurderte arter, både for Fastlands-Norge og Svalbard. Arter som ikke er risikovurderte (NR-arter) er ekskludert fra datagrunnlaget i alle figurer, det samme gjelder underarter og kultivarer som er inkludert i vurderingen av moderarten.";
 
         public const string figureCategoryStart = "Antall vurderinger i hver av de fem risikokategoriene, fra";

--- a/Assessments.Frontend.Web/Infrastructure/Constants.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Constants.cs
@@ -410,13 +410,6 @@ namespace Assessments.Frontend.Web.Infrastructure
         public const string adjustedTo = "Med bakgrunn i retningslinjene ble skår og/eller usikkerhet justert til gjeldende verdier ";
         public const string adjustedUncertainty = "Begrunnelse for justering av skår og/eller usikkerhet:";
 
-        public const string demoKeyNumbers = "Demografiske nøkkeltall";
-        public const string currentPopSize = "Nåværende populasjonsstørrelse (N, i antall individer):";
-        public const string growthRate = "Vekstrate";
-        public const string environmentVar = "Miljøvarians";
-        public const string demographicVar = "Demografisk varians";
-        public const string sustainability = "Bæreevne (K, i antall individer): ";
-        public const string extinctLimit = "Terskel for kvasiutdøing (C, i antall individer): ";
         public const string years = "år";
         public const string to = "til";
         public const string on = "på";
@@ -458,15 +451,25 @@ namespace Assessments.Frontend.Web.Infrastructure
 
         public class AlienSpeciesTables
         {
-            /*Generel*/
-            public const string TimehorizonTableColumn = "Tidshorisont";
+            /*General*/
+            public const string TimeHorizonTableColumn = "Tidshorisont";
             public const string BackgroundTableColumn = "Vurderings<span>&#8208;</span><br/>grunnlag";
 
-            /*A and B*/
+            /*Criteria A and B*/
+            public const string CriteriaAMedianLifespanNumericalEstimationTableTitle = "Artens demografiske nøkkeltall.";
+            public const string CriteriaAMedianLifespanNumericalEstimationTableDescription = "Tabellen viser artens demografiske nøkkeltall brukt for å estimere den fremmede artens levetid i Norge. Les mer om parameterne i ";
+            public const string CriteriaANumericalEstimationTableLinkText = "retningslinjene";
+            public const string CurrentPopSize = "Nåværende populasjonsstørrelse (N, i antall individer)";
+            public const string GrowthRate = "Vekstrate";
+            public const string EnvironmentVar = "Miljøvarians";
+            public const string DemographicVar = "Demografisk varians";
+            public const string CarryingCapasity = "Bæreevne (K, i antall individer)";
+            public const string QuasiExtinctionThreshold = "Terskel for kvasiutdøing (C, i antall individer)";
+
             public const string CriteriaBExpansionSpeedSpatioTemporalParameterTableTitle = "Modell og parametere.";
             public const string CriteriaBExpansionSpeedSpatioTemporalParameterTableDescription = "Tabellen viser hvilke parametere og antagelser som er brukt for estimering av ekspansjonshastighet. Les mer om metoden her: ";
-            public const string ExpansionSpeedParameterColumn1 = "Parameter";
-            public const string ExpansionSpeedParameterColumn2 = "Verdi";
+            public const string MedianLifespanAndExpansionSpeedParameterColumn1 = "Parameter";
+            public const string MedianLifespanAndExpansionSpeedParameterColumn2 = "Verdi";
             public const string AreaDarkNumbers = "forekomstarealets mørketall";
             public const string Model = "modell";
             public const string SitesListed = "lokalitetene i datafila er oppført";

--- a/Assessments.Frontend.Web/Infrastructure/Constants.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Constants.cs
@@ -340,17 +340,7 @@ namespace Assessments.Frontend.Web.Infrastructure
 
         public const string ImpactedNatureTypesDescription = "Naturtyper arten er observert i og/eller som er potensielle habitater for arten i Norge. Hvis arten fører til endringer i naturtypen er det angitt.";
         public const string ImpactedNatureTypesDescriptionSvalbard = "Naturtyper arten er observert i og/eller som er potensielle habitater for arten på Svalbard. Hvis arten fører til endringer i naturtypen er det angitt.";
-        public const string ImpactedNatureTypesCurrentTableTitle = "Truede, sjeldne eller øvrige naturtyper arten er observert i. ";
-        public const string ImpactedNatureTypesFutureTableTitle = "Truede, sjeldne eller øvrige naturtyper som er potensielle habitater for arten i Norge. ";
-        public const string ImpactedNatureTypesCurrentTableDescription = "Tabellen viser anslått kolonisert areal (C-kriteriet) i de naturtypene arten er  observert i, samt artens påvirkning i naturtypen og anslått andel av naturtypens areal som blir påvirket (F- og G-kriteriet).";
-        public const string ImpactedNatureTypesFutureTableDescription = "Oversikten viser anslått kolonisert areal (C-kriteriet) i de naturtypene arten regnes med å observeres i innen 50 år eller 5 generasjoner (det av tallene som er størst), samt artens framtidige påvirkning i naturtypen og anslått andel av naturtypens areal som vil bli påvirket (F- og G-kriteriet).";
-        public const string ImpactedNatureTypesTableColumn1 = "naturtype";
-        public const string ImpactedNatureTypesTableColumn2 = "tidshorisont";
-        public const string ImpactedNatureTypesTableColumn3 = "kolonisert <br/>areal (%)";
-        public const string ImpactedNatureTypesTableColumn4 = "tydelig <br/>tilstandsendring";
-        public const string ImpactedNatureTypesTableColumn5 = "tydelig <br/>påvirka <br/>areal (%)";
-        public const string ImpactedNatureTypesTableColumn6 = "vurderingsgrunnlag";
-
+        
         public const string CategoryChangeNotAssessed2018 = "Denne arten er risikovurdert for første gang i 2023.";
         public const string CategoryChangeShowSameAs2018 = "Denne arten er vurdert til samme risikokategori som i Fremmedartslista 2018 (forrige revisjon).";
         public const string CategoryChangeReasonsForChangeDescription = "Utfyllende beskrivelse av årsaken(e) for endret risikokategori:";
@@ -379,8 +369,8 @@ namespace Assessments.Frontend.Web.Infrastructure
         public const string furtherSpreadWaysTableDescription = "Følgende aktuelle, fortidige og sannsynlig fremtidige spredningsveier fra norsk natur til norsk natur er angitt for arten.  ";
         public const string noFurtherSpreadWays = "Det er ikke angitt spredningsmåter i norsk natur for denne arten";
 
-
         /* Criteria Explanation */
+
         public const string speciesEvaluatedTo = "Arten er vurdert til ";
         public const string noRisk = "ingen kjent risiko";
         public const string noRiskExplanation = "NK og har dermed ingen avgjørende kriterier.";
@@ -428,13 +418,11 @@ namespace Assessments.Frontend.Web.Infrastructure
         public const string sustainability = "Bæreevne (K, i antall individer): ";
         public const string extinctLimit = "Terskel for kvasiutdøing (C, i antall individer): ";
         public const string years = "år";
-        public const string yearCaps = "År";
         public const string to = "til";
         public const string on = "på";
         public const string whichIs = "som er";
         public const string downTo = "ned mot";
         public const string upTo = "opp mot";
-        public const string corrected = "korrigert for tiltak";
         public const string mPerYear = "m/år";
         public const string speciesHas = "Arten har";
         public const string medianLifeEst = "Basert på de demografiske nøkkeltallene er det beste anslaget for artens mediane levetid i Norge estimert til ";
@@ -444,7 +432,7 @@ namespace Assessments.Frontend.Web.Infrastructure
         public const string lowEstimate = "lavt anslag";
         public const string highEstimate = "høyt anslag";
 
-        public const string expansionSpeed = "Ekspansjonshastighet";
+        
         public const string expansionSpeedGuess = "Det beste anslaget på artens ekspansjonshastighet er";
         public const string expansionSpeedIs = "er ekspansjonshastigheten anslått til";
         public const string expansionSpeedEst = "er ekspansjonshastigheten estimert til";
@@ -453,38 +441,91 @@ namespace Assessments.Frontend.Web.Infrastructure
         public const string isScore = "Dette tilsvarer skår";
         public const string atBCrit = "på B-kriteriet";
         public const string methodDescriptionUnaidedFuture = "Denne estimeringsmetoden anslår ekspansjonshastigheten ut fra forventet endring i forekomstareal framover i tid.";
-        public const string methodDescriptionReproducingUnaided = "Denne estimeringsmetoden anslår ekspansjonshastigheten ut fra endringen i forekomstareal mellom to år tilbake i tid, hvor antall år mellom første og andre år, er på mellom 10 og 20 år. Følgende data ligger til grunn:";
         public const string commentData = "Kommentar til datagrunnlaget:";
         public const string basedOnIncrease = "Basert på økningen i artens forekomstareal i perioden fra";
         public const string andA = "og et";
         public const string darkNumber = "mørketall på";
-        public const string knownArea = "Kjent forekomstareal";
-        public const string areaDarkNumbers = "Forekomstarealets mørketall";
-        public const string average = "Gjennomsnittlig (m/år)";
+        
+        
+       
 
         public const string noEcoEffect = "Arten har ingen kjent økologisk effekt og har dermed ingen utslag på kriterier på effektaksen.";
         public const string effectAfterCriterium = "Økologiske effekter etter kriterium";
         public const string evaluatedAsUnlikely = "er vurdert som fraværende (usannsynlige)";
 
-        public const string spatioTemporalTableTitle = "Parametervalg for estimering av ekspansjonshastighet ";
-        public const string readMoreMethod = "les mer om metoden her";
-        public const string model = "Modell";
-        public const string sitesListed = "Lokalitetene i datafila er oppført";
+        
 
-        /*Criteria Tables*/
-        public const string keyStoneSpeciesTableColumn = "Nøkkelart?";
-        public const string redListCategoryTableColumn = "Kategori <br/>Rødlista 2021";
-        public const string criteriaDSpeciesTableTitle = "Artens negative effekter på trua arter eller nøkkelarter.";
-        public const string criteriaDSpeciesTableDescription = "Tabellen viser hvilken type interaksjon den fremmede arten har med stedegne trua arter eller nøkkelarter, samt interaksjonens styre og omfang. Kun effekter som er dokumentert i Norge eller i utlandet (for arten selv eller en sammenlignbar art), eller som sannsynlig vil opptre i Norge i løpet av 50 år, er inkludert.";
-        public const string criteriaESpeciesTableTitle = "Artens negative effekter på stedegne arter (ikke trua eller sjelden).";
-        public const string criteriaESpeciesTableDescription = "Tabellen viser hvilken type interaksjon den fremmede arten har med stedegne arter, samt interaksjonens styre og omfang. Kun effekter som er dokumentert i Norge eller i utlandet (for arten selv eller en sammenlignbar art), eller som sannsynlig vil opptre i Norge i løpet av 50 år, er inkludert.";
-        public const string criteriaFNaturetypesTableTitle = "Truede eller sjeldne naturtyper som påvirkes av arten.";
-        public const string criteriaGNaturetypesTableTitle = "Naturtyper (ikke trua eller sjelden) som påvirkes av arten.";
-        public const string criteriaFAndGNaturetypesTableDescription = "Tabellen viser hvilke(n) naturtype(r) som påvirkes av den fremmede arten nå eller i framtida. Type tilstandsendring, hvor stor del av naturtypearealet som påvirkes og vurderingsgrunnlag er gitt for hver naturtype. Se retningslinjene for beskrivelse av tydelig tilstandsendring.";
-        public const string criteriaHIntrogressionTableTitle = "Overføring av genetisk materiale.";
-        public const string criteriaHIntrogressionTableDescription = "Tabellen viser hvilke stedegne arter som blir, eller kan bli, genetisk forurenset av den fremmede arten. Med genetisk forurensning menes introgresjon, hybridisering alene er ikke tilstrekkelig. Kun genetisk forurensing som er dokumentert eller sannsynlig er inkludert.";
-        public const string criteriaIParasitesTableTitle = "Overføring av parasitter og patogener.";
-        public const string criteriaIParasitesTableDescription = "Tabellen viser hvilke parasitter eller patogener (inkludert bakterier og virus) arten er vurdert å overføre til stedegne verter, om parasitten er kjent for verten eller ei, samt om parasitten er fremmed eller stedegen. Den økologiske effekten av overføringen kan ikke være større enn den økologiske effekten parasitten selv vurderes å ha etter kriteriene D til H. Kun overføringer av parasitter og patogener som er dokumentert eller sannsynlig er inkludert.";
+
+        public class AlienSpeciesTables
+        {
+            /*Generel*/
+            public const string TimehorizonTableColumn = "Tidshorisont";
+            public const string BackgroundTableColumn = "Vurderings<span>&#8208;</span><br/>grunnlag";
+
+            /*A and B*/
+            public const string CriteriaBExpansionSpeedSpatioTemporalParameterTableTitle = "Modell og parametere.";
+            public const string CriteriaBExpansionSpeedSpatioTemporalParameterTableDescription = "Tabellen viser hvilke parametere og antagelser som er brukt for estimering av ekspansjonshastighet. Les mer om metoden her: ";
+            public const string ExpansionSpeedParameterColumn1 = "Parameter";
+            public const string ExpansionSpeedParameterColumn2 = "Verdi";
+            public const string AreaDarkNumbers = "forekomstarealets mørketall";
+            public const string Model = "modell";
+            public const string SitesListed = "lokalitetene i datafila er oppført";
+            public const string CriteriaBExpansionSpeedSpatioTemporalResultTableTitle = "Artens ekspansjonshastighet.";
+            public const string CriteriaBExpansionSpeedSpatioTemporalResultTableDescription = "Tabellen viser artens estimerte ekspansjonshastighet (m/år) med bakgrunn i parametervalgene angitt over, samt datasett med tid- og stedfesta observasjoner av arten.";
+            public const string ExpansionSpeedResultColumn1 = "Ekspansjonshastighet";
+            public const string ExpansionSpeedResultColumn2 = "Estimert verdi (m/år)";
+            public const string AverageExpansionSpeedRow = "beste anslag";
+            public const string LowExpansionSpeedRow = "lavt anslag";
+            public const string HighExpansionSpeedRow = "høyt anslag";
+
+            public const string CriteriaBExpansionSpeedIncreaseAOOTableTitle = "Artens endring i forekomstareal.";
+            public const string CriteriaBExpansionSpeedIncreaseAOOTableDescription = "Tabellen viser artens kjente forekomstareal ved to ulike år.";
+            public const string ExpansionSpeedAOOColumn1 = "År";
+            public const string ExpansionSpeedAOOKnownArea = "Kjent forekomstareal (km<sup>2</sup>)";
+            public const string ExpansionSpeedAOOKnownAreaCorrected = "Kjent forekomstareal (km<sup>2</sup>) <br/>korrigert for tiltak";
+
+            /*Criteria D, E, H and I*/
+            public const string CriteriaDSpeciesNaturetypesTableTitle = "Artens negative effekter på grupper av arter (inkludert trua arter eller nøkkelarter).";
+            public const string CriteriaDSpeciesNaturetypesTableDescription = "Tabellen viser hvilken type interaksjon den fremmede arten har med grupper av stedegne arter (hvor minst én av artene er trua eller nøkkelart), samt interaksjonens styre og omfang. Den negative interaksjonen med stedegne arter er gitt for hver naturtype. Kun effekter som er dokumentert i Norge eller i utlandet (for arten selv eller en sammenlignbar art), eller som sannsynlig vil opptre i Norge i løpet av 50 år, er inkludert.";
+            public const string CriteriaESpeciesNaturetypesTableTitle = "Artens negative effekter på grupper av stedegne arter.";
+            public const string CriteriaESpeciesNaturetypesTableDescription = "Tabellen viser hvilken type interaksjon den fremmede arten har med grupper av stedegne arter, samt interaksjonens styre og omfang. Den negative interaksjonen med stedegne arter er gitt for hver naturtype. Kun effekter som er dokumentert i Norge eller i utlandet (for arten selv eller en sammenlignbar art), eller som sannsynlig vil opptre i Norge i løpet av 50 år, er inkludert.";
+            public const string CriteriaDSpeciesTableTitle = "Artens negative effekter på trua arter eller nøkkelarter.";
+            public const string CriteriaDSpeciesTableDescription = "Tabellen viser hvilken type interaksjon den fremmede arten har med stedegne trua arter eller nøkkelarter, samt interaksjonens styre og omfang. Kun effekter som er dokumentert i Norge eller i utlandet (for arten selv eller en sammenlignbar art), eller som sannsynlig vil opptre i Norge i løpet av 50 år, er inkludert.";
+
+            public const string CriteriaESpeciesTableTitle = "Artens negative effekter på stedegne arter (ikke trua eller sjelden).";
+            public const string CriteriaESpeciesTableDescription = "Tabellen viser hvilken type interaksjon den fremmede arten har med stedegne arter, samt interaksjonens styre og omfang. Kun effekter som er dokumentert i Norge eller i utlandet (for arten selv eller en sammenlignbar art), eller som sannsynlig vil opptre i Norge i løpet av 50 år, er inkludert.";
+
+            public const string CriteriaHIntrogressionTableTitle = "Overføring av genetisk materiale.";
+            public const string CriteriaHIntrogressionTableDescription = "Tabellen viser hvilke stedegne arter som blir, eller kan bli, genetisk forurenset av den fremmede arten. Med genetisk forurensning menes introgresjon, hybridisering alene er ikke tilstrekkelig. Kun genetisk forurensing som er dokumentert eller sannsynlig er inkludert.";
+            public const string CriteriaIParasitesTableTitle = "Overføring av parasitter og patogener.";
+            public const string CriteriaIParasitesTableDescription = "Tabellen viser hvilke parasitter eller patogener (inkludert bakterier og virus) arten er vurdert å overføre til stedegne verter, om parasitten er kjent for verten eller ei, samt om parasitten er fremmed eller stedegen. Den økologiske effekten av overføringen kan ikke være større enn den økologiske effekten parasitten selv vurderes å ha etter kriteriene D til H. Kun overføringer av parasitter og patogener som er dokumentert eller sannsynlig er inkludert.";
+
+            public const string KeyStoneSpeciesTableColumn = "Nøkkelart?";
+            public const string RedListCategoryTableColumn = "Kategori <br/>Rødlista 2021";
+            public const string InteractionStrengthTableColumn = "Interaksjonens styrke";
+            public const string ScaleTableColumn = "Geografisk omfang";
+            public const string InteractionTypeTableColumn = "Type interaksjon";
+            public const string NaturetypeDAndETableColumn1 = "Påvirkede <br/>arter i";
+            public const string NaturetypeDAndETableColumn2 = "Nøkkelarter <br/>eller truede <br/>arter?";
+
+            /*Criteria C, F, G and impacted naturetypes*/
+            public const string CriteriaCNaturetypesTableTitle = "Artens koloniserte naturtypeareal.";
+            public const string CriteriaCNaturetypesTableDescription = "Tabellen viser hvilke(n) naturtype(r) den fremmede arten koloniserer nå eller i framtida. Andel kolonisert areal (%) av totalt naturtypeareal og vurderingsgrunnlag er gitt for hver naturtype.";
+            public const string CriteriaFNaturetypesTableTitle = "Artens negative effekter på truede eller sjeldne naturtyper.";
+            public const string CriteriaGNaturetypesTableTitle = "Artens negative effekter på naturtyper (ikke trua eller sjelden).";
+            public const string CriteriaFAndGNaturetypesTableDescription = "Tabellen viser hvilke(n) naturtype(r) som påvirkes av den fremmede arten nå eller i framtida. Type tilstandsendring, hvor stor del av naturtypearealet som påvirkes og vurderingsgrunnlag er gitt for hver naturtype. Se retningslinjene for beskrivelse av tydelig tilstandsendring.";
+            public const string ImpactedNatureTypesCurrentTableTitle = "Truede, sjeldne eller øvrige naturtyper arten er observert i. ";
+            public const string ImpactedNatureTypesFutureTableTitle = "Truede, sjeldne eller øvrige naturtyper som er potensielle habitater for arten i Norge. ";
+            public const string ImpactedNatureTypesCurrentTableDescription = "Tabellen viser anslått kolonisert areal (C-kriteriet) i de naturtypene arten er  observert i, samt artens påvirkning i naturtypen og anslått andel av naturtypens areal som blir påvirket (F- og G-kriteriet).";
+            public const string ImpactedNatureTypesFutureTableDescription = "Oversikten viser anslått kolonisert areal (C-kriteriet) i de naturtypene arten regnes med å observeres i innen 50 år eller 5 generasjoner (det av tallene som er størst), samt artens framtidige påvirkning i naturtypen og anslått andel av naturtypens areal som vil bli påvirket (F- og G-kriteriet).";
+            public const string NaturetypeNameTableColumn = "naturtype";
+            public const string ColonizedAreaTableColumn = "kolonisert <br/>areal (%)";
+            public const string StateChangeTableColumn = "tydelig <br/>tilstandsendring";
+            public const string AffectedAreaTableColumn = "tydelig <br/>påvirka <br/>areal (%)";
+            public const string ImpactedNatureTypesTableColumn6 = "vurderingsgrunnlag";
+
+        }
+        
 
         public const string FigureMainText = "Her finner du resultater fra Fremmedartslista 2023 presentert i figurer. Figurene er reaktive, og viser kun resultater for det utvalget du har gjort i filteret. Om ingen filterutvalg er gjort, vises resultater for alle risikovurderte arter, både for Fastlands-Norge og Svalbard. Arter som ikke er risikovurderte (NR-arter) er ekskludert fra datagrunnlaget i alle figurer, det samme gjelder underarter og kultivarer som er inkludert i vurderingen av moderarten.";
 

--- a/Assessments.Frontend.Web/Infrastructure/Helpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Helpers.cs
@@ -252,7 +252,7 @@ namespace Assessments.Frontend.Web.Infrastructure
 
         public static string removeLineBreaksForMobile(string text)
         {
-            return text.Replace("<br/>", "");
+            return text.Replace("<br/>", "").Replace("<span>&#8208;</span>", "");
         }
 
         public static Dictionary<string, string> GetAllTaxonRanks()

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_CriteriaExplanation.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_CriteriaExplanation.cshtml
@@ -315,7 +315,7 @@
              </caption>
             <tr>
                 <th>@Constants.AlienSpeciesTables.NaturetypeNameTableColumn</th>
-                <th>@Constants.AlienSpeciesTables.TimehorizonTableColumn</th>
+                <th>@Constants.AlienSpeciesTables.TimeHorizonTableColumn</th>
                 <th>@Html.Raw(@Constants.AlienSpeciesTables.StateChangeTableColumn)</th>
                 <th>@Html.Raw(@Constants.AlienSpeciesTables.AffectedAreaTableColumn)</th>
                 <th>@Html.Raw(@Constants.AlienSpeciesTables.BackgroundTableColumn)</th>
@@ -459,29 +459,36 @@
                 </p>                                
                 <div is-visible="showNumericalEstimation">
                     <table class="big-data-table" is-visible="showNumericalEstimation">
-                        <caption class="table-title"><b>@Constants.demoKeyNumbers</b></caption>
+                        <caption class="table-title">
+                            <b>@Constants.AlienSpeciesTables.CriteriaAMedianLifespanNumericalEstimationTableTitle</b>
+                            @Constants.AlienSpeciesTables.CriteriaAMedianLifespanNumericalEstimationTableDescription<a href="https://www.artsdatabanken.no/Files/42948/" target="_blank">@Constants.AlienSpeciesTables.CriteriaANumericalEstimationTableLinkText</a>.
+                        </caption>
+                        <tr>
+                            <th>@Constants.AlienSpeciesTables.MedianLifespanAndExpansionSpeedParameterColumn1</th>
+                            <th>@Constants.AlienSpeciesTables.MedianLifespanAndExpansionSpeedParameterColumn2</th>
+                        </tr>
                         <tr is-visible="assessment.MedianLifetimeNumericalEstimationPopulationSize != 0">
-                            <td>@Constants.currentPopSize </td>
+                            <td>@Constants.AlienSpeciesTables.CurrentPopSize </td>
                             <td>@assessment.MedianLifetimeNumericalEstimationPopulationSize.ToString("N0")</td>
                         </tr>
                         <tr is-visible="assessment.MedianLifetimeNumericalEstimationGrowthRate != 0">
-                            <td>@Constants.growthRate (&lambda;): </td>
+                            <td>@Constants.AlienSpeciesTables.GrowthRate (&lambda;) </td>
                             <td>@assessment.MedianLifetimeNumericalEstimationGrowthRate.ToString("N0")</td>
                         </tr>
                         <tr is-visible="assessment.MedianLifetimeNumericalEstimationEnvironmentalVariance != null">
-                            <td>@Constants.environmentVar (&sigma;<sub>e</sub><sup>2</sup>): </td>
+                            <td>@Constants.AlienSpeciesTables.EnvironmentVar (&sigma;<sub>e</sub><sup>2</sup>) </td>
                             <td>@assessment.MedianLifetimeNumericalEstimationEnvironmentalVariance?.ToString("N0")</td>
                         </tr>
                         <tr is-visible="assessment.MedianLifetimeNumericalEstimationDemographicVariance != null">
-                            <td>@Constants.demographicVar (&sigma;<sub>d</sub><sup>2</sup>): </td>
+                            <td>@Constants.AlienSpeciesTables.DemographicVar (&sigma;<sub>d</sub><sup>2</sup>) </td>
                             <td>@assessment.MedianLifetimeNumericalEstimationDemographicVariance?.ToString("N0")</td>
                         </tr>
                         <tr is-visible="assessment.MedianLifetimeNumericalEstimationCarryingCapacity != null">
-                            <td>@Constants.sustainability</td>
+                            <td>@Constants.AlienSpeciesTables.CarryingCapasity</td>
                             <td>@assessment.MedianLifetimeNumericalEstimationCarryingCapacity?.ToString("N0")</td>
                         </tr>
                         <tr is-visible="assessment.MedianLifetimeNumericalEstimationExtinctionThreshold != null">
-                            <td>@Constants.extinctLimit</td>
+                            <td>@Constants.AlienSpeciesTables.QuasiExtinctionThreshold</td>
                             <td>@assessment.MedianLifetimeNumericalEstimationExtinctionThreshold?.ToString("N0")</td>
                         </tr>
                     </table>
@@ -493,7 +500,7 @@
                 <div is-visible="showViableAnalysis">
                     <p>@Constants.modelAndProgram @assessment.MedianLifetimeViabilityAnalysisDescription</p>
                     <table class="big-data-table">
-                        <caption class="table-title">@Constants.demoKeyNumbers</caption>
+                        <caption class="table-title">@Constants.AlienSpeciesTables.CriteriaAMedianLifespanNumericalEstimationTableTitle</caption>
                         <tr is-visible="assessment.MedianLifetimeBestEstimate != 0">
                             <td>@Constants.estMedianLifeSpanThisYear: </td>
                             <td>@assessment.MedianLifetimeBestEstimate.ToString("N0")</td>
@@ -524,8 +531,8 @@
                         @Constants.AlienSpeciesTables.CriteriaBExpansionSpeedSpatioTemporalParameterTableDescription <a href="https://view.nina.no/expansion/" target="_blank">@Constants.expansion</a>.
                         </caption>
                         <tr>
-                            <th>@Constants.AlienSpeciesTables.ExpansionSpeedParameterColumn1</th>
-                            <th>@Constants.AlienSpeciesTables.ExpansionSpeedParameterColumn2</th>
+                            <th>@Constants.AlienSpeciesTables.MedianLifespanAndExpansionSpeedParameterColumn1</th>
+                            <th>@Constants.AlienSpeciesTables.MedianLifespanAndExpansionSpeedParameterColumn2</th>
                         </tr>
                         <tr is-visible="!string.IsNullOrEmpty(assessment.ExpansionSpeedSpatioTemporalDatasetDarkFigureRange)">
                             <td>@Constants.AlienSpeciesTables.AreaDarkNumbers</td>
@@ -635,7 +642,7 @@
                         </caption>
                         <tr>
                             <th>@Constants.AlienSpeciesTables.NaturetypeNameTableColumn</th>
-                            <th>@Constants.AlienSpeciesTables.TimehorizonTableColumn</th>
+                            <th>@Constants.AlienSpeciesTables.TimeHorizonTableColumn</th>
                             <th>@Html.Raw(@Constants.AlienSpeciesTables.ColonizedAreaTableColumn)</th>
                             <th>@Html.Raw(@Constants.AlienSpeciesTables.BackgroundTableColumn)</th>
                         </tr>

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_CriteriaExplanation.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_CriteriaExplanation.cshtml
@@ -117,14 +117,26 @@
         return true;
     }
 
-    void GetSpeciesTableDesktop(List<AlienSpeciesAssessment2023SpeciesSpeciesInteraction> impacts)
+    void GetSpeciesTableDesktop(List<AlienSpeciesAssessment2023SpeciesSpeciesInteraction> impacts, bool shouldBeThreatened)
     {
         <table class="big-data-table">
-            <caption class="table-title">Artens negative effekter på øvrige stedegne arter</caption>
+            <caption class="table-title">
+                @if (shouldBeThreatened)
+                {
+                    <b>@Constants.criteriaDSpeciesTableTitle</b>
+                    @Constants.criteriaDSpeciesTableDescription
+                }
+                @if (!shouldBeThreatened)
+                {
+                    <b>@Constants.criteriaESpeciesTableTitle</b>
+                    @Constants.criteriaESpeciesTableDescription
+                } 
+                
+            </caption>
             <tr>
                 <th>Stedegen art</th>
-                <th>@Html.Raw(@Constants.redListCategoryTable)</th>
-                <th>@Constants.keyStoneSpeciesTable</th>
+                <th>@Html.Raw(@Constants.redListCategoryTableColumn)</th>
+                <th>@Constants.keyStoneSpeciesTableColumn</th>
                 <th>Interaksjonens styrke</th>
                 <th>Geografisk omfang</th>
                 <th>Type interaksjon</th>
@@ -165,11 +177,11 @@
             <table class="big-data-table">
                 <caption class="table-title">Stedegen art: @impact.VernacularName @Html.Raw(Helpers.FormatScientificNameElement(impact.ScientificName)) @impact.ScientificNameAuthor</caption>
                 <tr>
-                    <td>@Html.Raw(@Constants.redListCategoryTable)</td>
+                    <td>@Html.Raw(@Constants.redListCategoryTableColumn)</td>
                     <td>@impact.RedListCategory - @impact.RedListCategory.DisplayName()</td>
                 </tr>
                 <tr>
-                    <td>@Constants.keyStoneSpeciesTable</td>
+                    <td>@Constants.keyStoneSpeciesTableColumn</td>
                     <td>@(impact.KeyStoneSpecie ? "ja" : "nei")</td>
                 </tr>
                 <tr>
@@ -278,7 +290,17 @@
     void GetFGTable(bool shouldBeThreatened)
     {
         <table class="big-data-table">
-            <caption class="table-title">Naturtyper som påvirkes av arten</caption>
+             <caption class="table-title">
+                @if (shouldBeThreatened)
+                {
+                    <b>@Constants.criteriaFNaturetypesTableTitle</b>
+                }
+                @if (!shouldBeThreatened)
+                {
+                    <b>@Constants.criteriaGNaturetypesTableTitle</b>
+                } 
+                @Constants.criteriaFAndGNaturetypesTableDescription
+             </caption>
             <tr>
                 <th>Naturtype</th>
                 <th>Tidshorisont</th>
@@ -633,12 +655,9 @@
             }
             <div class="collapsible_content">
                 <div is-visible="@assessment.SpeciesSpeciesInteractionsThreatenedSpecies != null && @assessment.SpeciesSpeciesInteractionsThreatenedSpecies.Count() != 0">
-                    <p>
-                        Arten er vurdert å ha følgende negative interaksjoner (type interaksjon) med følgende truede arter og nøkkelarter. Kun effekter som er dokumentert i Norge; eller i utlandet (enten for arten selv eller for en nært beslektet og sammenlignbar art), hvor effekten er sannsynlig å opptre i Norge i løpet av 50 år, er inkludert.
-                    </p>
                     <div class="mobile_hide">
                         @{
-                            GetSpeciesTableDesktop(assessment.SpeciesSpeciesInteractionsThreatenedSpecies);
+                            GetSpeciesTableDesktop(assessment.SpeciesSpeciesInteractionsThreatenedSpecies, true);
                         }
                     </div>
                     <div class="only_mobile">
@@ -682,12 +701,9 @@
             }
             <div class="collapsible_content">
                 <div is-visible="@assessment.SpeciesSpeciesInteractions  != null && @assessment.SpeciesSpeciesInteractions .Count() != 0">
-                    <p>
-                        Arten er vurdert å ha følgende negative interaksjoner (type interaksjon) med øvrige stedegne arter, dvs. arter som hverken er truede eller nøkkelarter . Kun effekter som er dokumentert i Norge; eller i utlandet (enten for arten selv eller for en nært beslektet og sammenlignbar art), hvor effekten er sannsynlig å opptre i Norge i løpet av 50 år, er inkludert.
-                    </p>
                     <div class="mobile_hide">
                         @{
-                            GetSpeciesTableDesktop(assessment.SpeciesSpeciesInteractions);
+                            GetSpeciesTableDesktop(assessment.SpeciesSpeciesInteractions, false);
                         }
                     </div>
                     <div class="only_mobile">
@@ -767,11 +783,14 @@
                 <div class="collapsible_content">
                     <div>
                         <table class="big-data-table" is-visible="showHTable">
-                            <caption class="table-title"><b>Overføring av genetisk materiale.</b>  Tabellen viser hvilke stedegne arter den fremmede arten er vurdert å føre til genetisk forurensning av. Med genetisk forurensning menes introgresjon, hybridisering alene er ikke tilstrekkelig. Kun genetisk forurensing som er dokumentert eller sannsynlig er inkludert.</caption>
+                            <caption class="table-title">
+                                <b>@Constants.criteriaHIntrogressionTableTitle</b>
+                                @Constants.criteriaHIntrogressionTableDescription 
+                            </caption>
                             <tr>
                                 <th>Stedegen art</th>
-                                <th>@Html.Raw(@Constants.redListCategoryTable)</th>
-                                <th>@Constants.keyStoneSpeciesTable</th>
+                                <th>@Html.Raw(@Constants.redListCategoryTableColumn)</th>
+                                <th>@Constants.keyStoneSpeciesTableColumn</th>
                                 <th>Geografisk omfang</th>
                                 <th>Vurderingsgrunnlag</th>
                             </tr>
@@ -815,11 +834,14 @@
                 <div class="collapsible_content">
                     <div>
                         <table class="big-data-table" is-visible="showITable">
-                            <caption class="table-title"><b>Overføring av parasitter og patogener.</b> Tabellen viser hvilke parasitter eller patogener (inkludert bakterier og virus) arten er vurdert å overføre til stedegne verter, om parasitten er kjent for verten eller ei, samt om parasitten er fremmed eller stedegen. Den økologiske effekten av overføringen kan ikke være større enn den økologiske effekten parasitten selv vurderes å ha etter kriteriene D til H. Kun overføringer av parasitter og patogener som er dokumentert eller sannsynlig er inkludert. </caption>
+                            <caption class="table-title">
+                                <b>@Constants.criteriaIParasitesTableTitle</b>
+                                @Constants.criteriaIParasitesTableDescription 
+                            </caption>
                             <tr>
                                 <th>Stedegen art</th>
-                                <th>@Html.Raw(@Constants.redListCategoryTable)</th>
-                                <th>@Constants.keyStoneSpeciesTable</th>
+                                <th>@Html.Raw(@Constants.redListCategoryTableColumn)</th>
+                                <th>@Constants.keyStoneSpeciesTableColumn</th>
                                 <th>Parasittens vitenskapelige navn</th>
                                 <th>Parasittens status</th>
                                 <th>Parasittens delkategori</th>

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_CriteriaExplanation.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_CriteriaExplanation.cshtml
@@ -123,26 +123,26 @@
             <caption class="table-title">
                 @if (shouldBeThreatened)
                 {
-                    <b>@Constants.criteriaDSpeciesTableTitle</b>
-                    @Constants.criteriaDSpeciesTableDescription
+                    <b>@Constants.AlienSpeciesTables.CriteriaDSpeciesTableTitle</b>
+                    @Constants.AlienSpeciesTables.CriteriaDSpeciesTableDescription
                 }
                 @if (!shouldBeThreatened)
                 {
-                    <b>@Constants.criteriaESpeciesTableTitle</b>
-                    @Constants.criteriaESpeciesTableDescription
+                    <b>@Constants.AlienSpeciesTables.CriteriaESpeciesTableTitle</b>
+                    @Constants.AlienSpeciesTables.CriteriaESpeciesTableDescription
                 } 
                 
             </caption>
             <tr>
                 <th>Stedegen art</th>
-                <th>@Html.Raw(@Constants.redListCategoryTableColumn)</th>
-                <th>@Constants.keyStoneSpeciesTableColumn</th>
-                <th>Interaksjonens styrke</th>
-                <th>Geografisk omfang</th>
-                <th>Type interaksjon</th>
+                <th>@Html.Raw(@Constants.AlienSpeciesTables.RedListCategoryTableColumn)</th>
+                <th>@Constants.AlienSpeciesTables.KeyStoneSpeciesTableColumn</th>
+                <th>@Constants.AlienSpeciesTables.InteractionStrengthTableColumn</th>
+                <th>@Constants.AlienSpeciesTables.ScaleTableColumn</th>
+                <th>@Constants.AlienSpeciesTables.InteractionTypeTableColumn</th>
                 @if (impacts.Any(x => x.Background.Count() != 0))
                 {
-                    <th>Vurderingsgrunnlag</th>
+                    <th>@Html.Raw(@Constants.AlienSpeciesTables.BackgroundTableColumn)</th>
                 }
             </tr>
             @foreach (var impact in impacts)
@@ -177,11 +177,11 @@
             <table class="big-data-table">
                 <caption class="table-title">Stedegen art: @impact.VernacularName @Html.Raw(Helpers.FormatScientificNameElement(impact.ScientificName)) @impact.ScientificNameAuthor</caption>
                 <tr>
-                    <td>@Html.Raw(@Constants.redListCategoryTableColumn)</td>
+                    <td>@Html.Raw(@Constants.AlienSpeciesTables.RedListCategoryTableColumn)</td>
                     <td>@impact.RedListCategory - @impact.RedListCategory.DisplayName()</td>
                 </tr>
                 <tr>
-                    <td>@Constants.keyStoneSpeciesTableColumn</td>
+                    <td>@Constants.AlienSpeciesTables.KeyStoneSpeciesTableColumn</td>
                     <td>@(impact.KeyStoneSpecie ? "ja" : "nei")</td>
                 </tr>
                 <tr>
@@ -214,17 +214,29 @@
         }
     }
 
-    void GetNatureTypeTableDesktop(List<AlienSpeciesAssessment2023SpeciesNaturetypeInteraction> impacts)
+    void GetNatureTypeTableDesktop(List<AlienSpeciesAssessment2023SpeciesNaturetypeInteraction> impacts, bool shouldBeThreatened)
     {
         <table class="big-data-table">
-            <caption class="table-title">Artens negative effekter på grupper av arter (samfunn)</caption>
+            <caption class="table-title">
+                @if (shouldBeThreatened)
+                {
+                    <b>@Constants.AlienSpeciesTables.CriteriaDSpeciesNaturetypesTableTitle</b>
+                    @Constants.AlienSpeciesTables.CriteriaDSpeciesNaturetypesTableDescription
+                }
+                @if (!shouldBeThreatened)
+                {
+                    <b>@Constants.AlienSpeciesTables.CriteriaESpeciesNaturetypesTableTitle</b>
+                    @Constants.AlienSpeciesTables.CriteriaESpeciesNaturetypesTableDescription
+                } 
+                
+            </caption>
             <tr>
-                <th>Berørt naturtype (med gruppen av påvirkede arter)</th>
-                <th>Påvirkes nøkkelarter eller truede arter?</th>
-                <th>Interaksjonens styrke</th>
-                <th>Geografisk omfang</th>
-                <th>Type interaksjon</th>
-                <th>Vurderingsgrunnlag</th>
+                <th>@Html.Raw(Constants.AlienSpeciesTables.NaturetypeDAndETableColumn1)</th>
+                <th>@Html.Raw(Constants.AlienSpeciesTables.NaturetypeDAndETableColumn2)</th>
+                <th>@Constants.AlienSpeciesTables.InteractionStrengthTableColumn</th>
+                <th>@Constants.AlienSpeciesTables.ScaleTableColumn</th>
+                <th>@Constants.AlienSpeciesTables.InteractionTypeTableColumn</th>
+                <th>@Html.Raw(Constants.AlienSpeciesTables.BackgroundTableColumn)</th>
             </tr>
             @foreach (var impact in impacts)
             {
@@ -293,20 +305,20 @@
              <caption class="table-title">
                 @if (shouldBeThreatened)
                 {
-                    <b>@Constants.criteriaFNaturetypesTableTitle</b>
+                    <b>@Constants.AlienSpeciesTables.CriteriaFNaturetypesTableTitle</b>
                 }
                 @if (!shouldBeThreatened)
                 {
-                    <b>@Constants.criteriaGNaturetypesTableTitle</b>
+                    <b>@Constants.AlienSpeciesTables.CriteriaGNaturetypesTableTitle</b>
                 } 
-                @Constants.criteriaFAndGNaturetypesTableDescription
+                @Constants.AlienSpeciesTables.CriteriaFAndGNaturetypesTableDescription
              </caption>
             <tr>
-                <th>Naturtype</th>
-                <th>Tidshorisont</th>
-                <th>Tydelig tilstandsendring</th>
-                <th>Tydelig påvirka areal (%)</th>
-                <th>Vurderingsgrunnlag</th>
+                <th>@Constants.AlienSpeciesTables.NaturetypeNameTableColumn</th>
+                <th>@Constants.AlienSpeciesTables.TimehorizonTableColumn</th>
+                <th>@Html.Raw(@Constants.AlienSpeciesTables.StateChangeTableColumn)</th>
+                <th>@Html.Raw(@Constants.AlienSpeciesTables.AffectedAreaTableColumn)</th>
+                <th>@Html.Raw(@Constants.AlienSpeciesTables.BackgroundTableColumn)</th>
             </tr>
             @foreach (var natureType in assessment.ImpactedNatureTypes.Where(x => x.IsThreatened == shouldBeThreatened && HasAffectedArea(x.AffectedArea)))
             {
@@ -367,7 +379,7 @@
     void GetEstimationMethod(string estimationMethod)
     {
         <span class="estimation-method">
-            <b>@Constants.estimationMethod</b><br/>
+            @Constants.estimationMethod 
             <span>@estimationMethod</span>
         </span>
     }
@@ -505,48 +517,64 @@
             <div class="collapsible_content">
                 @{GetEstimationMethod(assessment.ExpansionSpeedEstimationMethod.DisplayName().ToLowerInvariant());}
                 <div is-visible="isSpatiotemporalDataset">
+                    <br />
                     <table class="big-data-table">
                         <caption class="table-title">
-                            @Constants.spatioTemporalTableTitle                            
-                            (@Constants.readMoreMethod: <a href="https://view.nina.no/expansion/" target="_blank">@Constants.expansion</a>)
+                         <b>@Constants.AlienSpeciesTables.CriteriaBExpansionSpeedSpatioTemporalParameterTableTitle</b> 
+                        @Constants.AlienSpeciesTables.CriteriaBExpansionSpeedSpatioTemporalParameterTableDescription <a href="https://view.nina.no/expansion/" target="_blank">@Constants.expansion</a>.
                         </caption>
+                        <tr>
+                            <th>@Constants.AlienSpeciesTables.ExpansionSpeedParameterColumn1</th>
+                            <th>@Constants.AlienSpeciesTables.ExpansionSpeedParameterColumn2</th>
+                        </tr>
                         <tr is-visible="!string.IsNullOrEmpty(assessment.ExpansionSpeedSpatioTemporalDatasetDarkFigureRange)">
-                            <td>@Constants.areaDarkNumbers: </td>
+                            <td>@Constants.AlienSpeciesTables.AreaDarkNumbers</td>
                             <td>@assessment.ExpansionSpeedSpatioTemporalDatasetDarkFigureRange</td>
                         </tr>
                         <tr is-visible="!string.IsNullOrEmpty(assessment.ExpansionSpeedSpatioTemporalDatasetModel.DisplayName())">
-                            <td>@Constants.model: </td>
-                            <td>@assessment.ExpansionSpeedSpatioTemporalDatasetModel.DisplayName()</td>
+                            <td>@Constants.AlienSpeciesTables.Model</td>
+                            <td>@assessment.ExpansionSpeedSpatioTemporalDatasetModel.DisplayName().ToLower()</td>
                         </tr>
                         <tr is-visible="!string.IsNullOrEmpty(assessment.ExpansionSpeedSpatioTemporalDatasetOccurrenceListing.DisplayName())">
-                            <td>@Constants.sitesListed: </td>
+                            <td>@Constants.AlienSpeciesTables.SitesListed</td>
                             <td>@assessment.ExpansionSpeedSpatioTemporalDatasetOccurrenceListing.DisplayName()</td>
                         </tr>
                     </table>
                     <br />
                     <table class="big-data-table">
-                        <caption class="table-title">@Constants.expansionSpeed</caption>
+                        <caption class="table-title">
+                            <b>@Constants.AlienSpeciesTables.CriteriaBExpansionSpeedSpatioTemporalResultTableTitle</b>
+                            @Constants.AlienSpeciesTables.CriteriaBExpansionSpeedSpatioTemporalResultTableDescription
+                        </caption>
                         <tr>
-                            <td>@Constants.average: </td>
+                            <th>@Constants.AlienSpeciesTables.ExpansionSpeedResultColumn1</th>
+                            <th>@Constants.AlienSpeciesTables.ExpansionSpeedResultColumn2</th>
+                        </tr>
+                        <tr>
+                            <td>@Constants.AlienSpeciesTables.AverageExpansionSpeedRow </td>
                             <td>@assessment.ExpansionSpeedBestEstimate.ToString("N0")</td>
                         </tr>
                         <tr>
-                            <td>@Constants.average @Constants.lowEstimate: </td>
+                            <td>@Constants.AlienSpeciesTables.LowExpansionSpeedRow </td>
                             <td>@assessment.ExpansionSpeedLowEstimate.ToString("N0")</td>
                         </tr>
                         <tr>
-                            <td>@Constants.average @Constants.highEstimate: </td>
+                            <td>@Constants.AlienSpeciesTables.HighExpansionSpeedRow </td>
                             <td>@assessment.ExpansionSpeedHighEstimate.ToString("N0")</td>
                         </tr>
                     </table>
                 </div>
                 <div is-visible="isEstimatedIncreaseInAOOReproducingUnaided">
-                    <p>@Constants.methodDescriptionReproducingUnaided</p>
+                    <br />
                     <table class="big-data-table">
+                        <caption class="table-title">
+                            <b>@Constants.AlienSpeciesTables.CriteriaBExpansionSpeedIncreaseAOOTableTitle</b>
+                            @Constants.AlienSpeciesTables.CriteriaBExpansionSpeedIncreaseAOOTableDescription
+                        </caption>
                         <tr>
-                            <th>@Constants.yearCaps</th>
-                            <th>@Constants.knownArea (km<sup>2</sup>)</th>
-                            <th>@Constants.knownArea (km<sup>2</sup>) @Constants.corrected</th>
+                            <th>@Constants.AlienSpeciesTables.ExpansionSpeedAOOColumn1</th>
+                            <th>@Html.Raw(@Constants.AlienSpeciesTables.ExpansionSpeedAOOKnownArea)</th>
+                            <th>@Html.Raw(@Constants.AlienSpeciesTables.ExpansionSpeedAOOKnownAreaCorrected)</th>
                         </tr>
                         <tr>
                             <td>@assessment.ExpansionSpeedEstimatedIncreaseInAOOFirstYear</td>
@@ -601,12 +629,15 @@
                 }
                 <div class="collapsible_content">
                     <table class="big-data-table">
-                        <caption class="table-title"><b>Kolonisert naturtypeareal.</b> Anslått prosentandel kolonisert areal i de naturtypene arten er observert i eller regnes med å observeres i innen 50 år eller 5 generasjoner. </caption>
+                        <caption class="table-title">
+                            <b>@Constants.AlienSpeciesTables.CriteriaCNaturetypesTableTitle</b>
+                            @Constants.AlienSpeciesTables.CriteriaCNaturetypesTableDescription
+                        </caption>
                         <tr>
-                            <th>Naturtype</th>
-                            <th>Tidshorisont</th>
-                            <th>Tydelig påvirka areal (%)</th>
-                            <th>Vurderingsgrunnlag</th>
+                            <th>@Constants.AlienSpeciesTables.NaturetypeNameTableColumn</th>
+                            <th>@Constants.AlienSpeciesTables.TimehorizonTableColumn</th>
+                            <th>@Html.Raw(@Constants.AlienSpeciesTables.ColonizedAreaTableColumn)</th>
+                            <th>@Html.Raw(@Constants.AlienSpeciesTables.BackgroundTableColumn)</th>
                         </tr>
                         @foreach (var natureType in assessment.ImpactedNatureTypes)
                         {
@@ -667,12 +698,9 @@
                     </div>
                 </div>
                 <div is-visible="@assessment.SpeciesNaturetypeInteractionsThreatenedSpecies != null && @assessment.SpeciesNaturetypeInteractionsThreatenedSpecies.Count() != 0">
-                    <p>
-                        Arten er vurdert å ha følgende negative interaksjoner (type interaksjon) med grupper av arter som inkluderer truede arter eller nøkkelarter i følgende naturtyper. Kun effekter som er dokumentert i Norge; eller i utlandet (enten for arten selv eller for en nært beslektet og sammenlignbar art), hvor effekten er sannsynlig å opptre i Norge i løpet av 50 år, er inkludert.
-                    </p>
                     <div class="mobile_hide">
                         @{
-                            GetNatureTypeTableDesktop(assessment.SpeciesNaturetypeInteractionsThreatenedSpecies);
+                            GetNatureTypeTableDesktop(assessment.SpeciesNaturetypeInteractionsThreatenedSpecies, true);
                         }
                     </div>
                     <div class="only_mobile">
@@ -713,12 +741,9 @@
                     </div>
                 </div>
                 <div is-visible="@assessment.SpeciesNaturetypeInteractions != null && @assessment.SpeciesNaturetypeInteractions.Count() != 0">
-                    <p>
-                        Arten er vurdert å ha følgende negative interaksjoner (type interaksjon) med grupper av arter i følgende naturtyper. Kun effekter som er dokumentert i Norge; eller i utlandet (enten for arten selv eller for en nært beslektet og sammenlignbar art), hvor effekten er sannsynlig å opptre i Norge i løpet av 50 år, er inkludert.
-                    </p>
                     <div class="mobile_hide">
                         @{
-                            GetNatureTypeTableDesktop(assessment.SpeciesNaturetypeInteractions);
+                            GetNatureTypeTableDesktop(assessment.SpeciesNaturetypeInteractions, false);
                         }
                     </div>
                     <div class="only_mobile">
@@ -784,13 +809,13 @@
                     <div>
                         <table class="big-data-table" is-visible="showHTable">
                             <caption class="table-title">
-                                <b>@Constants.criteriaHIntrogressionTableTitle</b>
-                                @Constants.criteriaHIntrogressionTableDescription 
+                                <b>@Constants.AlienSpeciesTables.CriteriaHIntrogressionTableTitle</b>
+                                @Constants.AlienSpeciesTables.CriteriaHIntrogressionTableDescription 
                             </caption>
                             <tr>
                                 <th>Stedegen art</th>
-                                <th>@Html.Raw(@Constants.redListCategoryTableColumn)</th>
-                                <th>@Constants.keyStoneSpeciesTableColumn</th>
+                                <th>@Html.Raw(@Constants.AlienSpeciesTables.RedListCategoryTableColumn)</th>
+                                <th>@Constants.AlienSpeciesTables.KeyStoneSpeciesTableColumn</th>
                                 <th>Geografisk omfang</th>
                                 <th>Vurderingsgrunnlag</th>
                             </tr>
@@ -835,13 +860,13 @@
                     <div>
                         <table class="big-data-table" is-visible="showITable">
                             <caption class="table-title">
-                                <b>@Constants.criteriaIParasitesTableTitle</b>
-                                @Constants.criteriaIParasitesTableDescription 
+                                <b>@Constants.AlienSpeciesTables.CriteriaIParasitesTableTitle</b>
+                                @Constants.AlienSpeciesTables.CriteriaIParasitesTableDescription 
                             </caption>
                             <tr>
                                 <th>Stedegen art</th>
-                                <th>@Html.Raw(@Constants.redListCategoryTableColumn)</th>
-                                <th>@Constants.keyStoneSpeciesTableColumn</th>
+                                <th>@Html.Raw(@Constants.AlienSpeciesTables.RedListCategoryTableColumn)</th>
+                                <th>@Constants.AlienSpeciesTables.KeyStoneSpeciesTableColumn</th>
                                 <th>Parasittens vitenskapelige navn</th>
                                 <th>Parasittens status</th>
                                 <th>Parasittens delkategori</th>

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_CriteriaExplanation.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_CriteriaExplanation.cshtml
@@ -123,8 +123,8 @@
             <caption class="table-title">Artens negative effekter på øvrige stedegne arter</caption>
             <tr>
                 <th>Stedegen art</th>
-                <th>Kategori i Rødlista 2021</th>
-                <th>Er arten en nøkkelart?</th>
+                <th>@Html.Raw(@Constants.redListCategoryTable)</th>
+                <th>@Constants.keyStoneSpeciesTable</th>
                 <th>Interaksjonens styrke</th>
                 <th>Geografisk omfang</th>
                 <th>Type interaksjon</th>
@@ -165,11 +165,11 @@
             <table class="big-data-table">
                 <caption class="table-title">Stedegen art: @impact.VernacularName @Html.Raw(Helpers.FormatScientificNameElement(impact.ScientificName)) @impact.ScientificNameAuthor</caption>
                 <tr>
-                    <td>kategori i Rødlista 2021</td>
+                    <td>@Html.Raw(@Constants.redListCategoryTable)</td>
                     <td>@impact.RedListCategory - @impact.RedListCategory.DisplayName()</td>
                 </tr>
                 <tr>
-                    <td>er arten en nøkkelart?</td>
+                    <td>@Constants.keyStoneSpeciesTable</td>
                     <td>@(impact.KeyStoneSpecie ? "ja" : "nei")</td>
                 </tr>
                 <tr>
@@ -770,8 +770,8 @@
                             <caption class="table-title"><b>Overføring av genetisk materiale.</b>  Tabellen viser hvilke stedegne arter den fremmede arten er vurdert å føre til genetisk forurensning av. Med genetisk forurensning menes introgresjon, hybridisering alene er ikke tilstrekkelig. Kun genetisk forurensing som er dokumentert eller sannsynlig er inkludert.</caption>
                             <tr>
                                 <th>Stedegen art</th>
-                                <th>Kategori i Rødlista 2021</th>
-                                <th>Er arten en nøkkelart?</th>
+                                <th>@Html.Raw(@Constants.redListCategoryTable)</th>
+                                <th>@Constants.keyStoneSpeciesTable</th>
                                 <th>Geografisk omfang</th>
                                 <th>Vurderingsgrunnlag</th>
                             </tr>
@@ -818,8 +818,8 @@
                             <caption class="table-title"><b>Overføring av parasitter og patogener.</b> Tabellen viser hvilke parasitter eller patogener (inkludert bakterier og virus) arten er vurdert å overføre til stedegne verter, om parasitten er kjent for verten eller ei, samt om parasitten er fremmed eller stedegen. Den økologiske effekten av overføringen kan ikke være større enn den økologiske effekten parasitten selv vurderes å ha etter kriteriene D til H. Kun overføringer av parasitter og patogener som er dokumentert eller sannsynlig er inkludert. </caption>
                             <tr>
                                 <th>Stedegen art</th>
-                                <th>Kategori i Rødlista 2021</th>
-                                <th>Er arten en nøkkelart?</th>
+                                <th>@Html.Raw(@Constants.redListCategoryTable)</th>
+                                <th>@Constants.keyStoneSpeciesTable</th>
                                 <th>Parasittens vitenskapelige navn</th>
                                 <th>Parasittens status</th>
                                 <th>Parasittens delkategori</th>

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_ImpactedNatureTypes.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_ImpactedNatureTypes.cshtml
@@ -19,20 +19,20 @@
     {
         <table class="big-data-table nature-table-setup">
             <tr>
-                <th>@Constants.ImpactedNatureTypesTableColumn1 </th>
-                <th>@Html.Raw(Constants.ImpactedNatureTypesTableColumn3) </th>
-                <th>@Html.Raw(Constants.ImpactedNatureTypesTableColumn4) </th>
-                <th>@Html.Raw(Constants.ImpactedNatureTypesTableColumn5) </th>
-                <th>@Constants.ImpactedNatureTypesTableColumn6 </th>
+                <th>@Constants.AlienSpeciesTables.NaturetypeNameTableColumn </th>
+                <th>@Html.Raw(Constants.AlienSpeciesTables.ColonizedAreaTableColumn) </th>
+                <th>@Html.Raw(Constants.AlienSpeciesTables.StateChangeTableColumn) </th>
+                <th>@Html.Raw(Constants.AlienSpeciesTables.AffectedAreaTableColumn) </th>
+                <th>@Html.Raw(@Constants.AlienSpeciesTables.BackgroundTableColumn) </th>
             </tr>
             @{
                 foreach (var natureType in natureTypesList)
                 {
                     <tr>
-                        <td><b class="only_mobile">@Constants.ImpactedNatureTypesTableColumn1:</b>@natureType.Name</td>
-                        <td><b class="only_mobile">@Helpers.removeLineBreaksForMobile(Constants.ImpactedNatureTypesTableColumn3):</b>@natureType.ColonizedArea</td>
+                        <td><b class="only_mobile">@Constants.AlienSpeciesTables.NaturetypeNameTableColumn:</b>@natureType.Name</td>
+                        <td><b class="only_mobile">@Helpers.removeLineBreaksForMobile(Constants.AlienSpeciesTables.ColonizedAreaTableColumn):</b>@natureType.ColonizedArea</td>
                         <td>
-                            <b class="only_mobile">@removeLineBreaksForMobile(Constants.ImpactedNatureTypesTableColumn4):</b>
+                            <b class="only_mobile">@removeLineBreaksForMobile(Constants.AlienSpeciesTables.StateChangeTableColumn):</b>
                             @{
                                 if (natureType.StateChange != null)
                                 {
@@ -47,9 +47,9 @@
                                 }
                             }
                         </td>
-                        <td><b class="only_mobile">@removeLineBreaksForMobile(Constants.ImpactedNatureTypesTableColumn5):</b>@natureType.AffectedArea</td>
+                        <td><b class="only_mobile">@removeLineBreaksForMobile(Constants.AlienSpeciesTables.AffectedAreaTableColumn):</b>@natureType.AffectedArea</td>
                         <td>
-                            <b class="only_mobile">@Constants.ImpactedNatureTypesTableColumn6:</b>
+                            <b class="only_mobile">@Helpers.removeLineBreaksForMobile(@Constants.AlienSpeciesTables.BackgroundTableColumn):</b>
                             @{
                                 <ul>
                                     @{
@@ -85,16 +85,16 @@
         <div is-visible="showNatureTypes">
             <div is-visible="hasCurrentTimeHorizonTypes">
                 <p class="big-data-table table-description">
-                    <b>@Constants.ImpactedNatureTypesCurrentTableTitle</b>
-                    @Constants.ImpactedNatureTypesCurrentTableDescription
+                    <b>@Constants.AlienSpeciesTables.ImpactedNatureTypesCurrentTableTitle</b>
+                    @Constants.AlienSpeciesTables.ImpactedNatureTypesCurrentTableDescription
                 </p>
                 @{ GetNatureTypeTable(natureTypes.Where(x => x.TimeHorizon == AlienSpeciesAssessment2023TimeHorizon.now)); }
             </div>
             <br>
             <div is-visible="hasFutureTimeHorizonTypes">
                 <p class="big-data-table table-description">
-                    <b>@Constants.ImpactedNatureTypesFutureTableTitle</b>
-                    @Constants.ImpactedNatureTypesFutureTableDescription
+                    <b>@Constants.AlienSpeciesTables.ImpactedNatureTypesFutureTableTitle</b>
+                    @Constants.AlienSpeciesTables.ImpactedNatureTypesFutureTableDescription
                 </p>
                 @{ GetNatureTypeTable(natureTypes.Where(x => x.TimeHorizon == AlienSpeciesAssessment2023TimeHorizon.future)); }
             </div>

--- a/Assessments.Frontend.Web/wwwroot/css/alienSpecies.css
+++ b/Assessments.Frontend.Web/wwwroot/css/alienSpecies.css
@@ -90,9 +90,9 @@ ul {
     list-style-position: inside;
 }
 
-li ul{
+/*li ul{
     margin-left:8px;
-}
+}*/
 
 /* MAP FOR FA ONLY */
 .double_map{


### PR DESCRIPTION
Tabell-titler og beskrivelser er lagt til for alle tabeller under kriterier (A til I). Enkelte kolonnenavn er også endret. #1253
Tabelltekstene er i sin helhet flyttet ut til Constants-fila - under egen klasse  "AlienSpeciesTables". Tidligere lå bare et utvalg av tekstene i den fila.

Closes #1253 
Closes #920 