### PR TITLE
Feature/styling tables

### DIFF
--- a/Assessments.Frontend.Web/Infrastructure/Constants.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Constants.cs
@@ -544,6 +544,12 @@ namespace Assessments.Frontend.Web.Infrastructure
             public const string FirstObsTableColumn2 = "Årstall for første observasjon";
             public const string FirstObsTableColumn3 = "Usikkerhet i årstall <br/>(> ± 5 år)";
 
+            /*Vedlegg*/
+            public const string AttachmentsTableTitle = "Filvedlegg til vurderingen.";
+            public const string AttachmentsTableDescription = "Tabellen viser filer som inngår som datagrunnlag for vurderingen av den fremmede arten. Hvert vedlegg inkluderer en lenke for nedlasting.";
+            public const string AttachmentsTableColumn1 = "Filnavn";
+            public const string AttachmentsTableColumn2 = "Beskrivelse";
+            public const string AttachmentsTableColumn3 = "Lenke for nedlasting";
         }
 
 

--- a/Assessments.Frontend.Web/Infrastructure/Constants.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Constants.cs
@@ -537,8 +537,15 @@ namespace Assessments.Frontend.Web.Infrastructure
             public const string AooDoorknockersTableColumn3 = "Antall ytterligere introduksjoner til norsk natur";
             public const string AooDoorknockersTableColumn4 = "Forekomstareal etter 10 år";
 
+            /*First observation*/
+            public const string FirstObsTableTitle = "Artens første observasjoner.";
+            public const string FirstObsTableDescription = "Tabellen viser årstall for første observasjonen av arten for hver aktuelle etableringsstatus.";
+            public const string FirstObsTableColumn1 = "Etableringsstatus";
+            public const string FirstObsTableColumn2 = "Årstall for første observasjon";
+            public const string FirstObsTableColumn3 = "Usikkerhet i årstall <br/>(> ± 5 år)";
+
         }
-        
+
 
         public const string FigureMainText = "Her finner du resultater fra Fremmedartslista 2023 presentert i figurer. Figurene er reaktive, og viser kun resultater for det utvalget du har gjort i filteret. Om ingen filterutvalg er gjort, vises resultater for alle risikovurderte arter, både for Fastlands-Norge og Svalbard. Arter som ikke er risikovurderte (NR-arter) er ekskludert fra datagrunnlaget i alle figurer, det samme gjelder underarter og kultivarer som er inkludert i vurderingen av moderarten.";
 

--- a/Assessments.Frontend.Web/Infrastructure/Constants.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Constants.cs
@@ -454,6 +454,9 @@ namespace Assessments.Frontend.Web.Infrastructure
             /*General*/
             public const string TimeHorizonTableColumn = "Tidshorisont";
             public const string BackgroundTableColumn = "Vurderings<span>&#8208;</span><br/>grunnlag";
+            public const string AverageRow = "beste anslag";
+            public const string LowRow = "lavt anslag";
+            public const string HighRow = "høyt anslag";
 
             /*Criteria A and B*/
             public const string CriteriaAMedianLifespanNumericalEstimationTableTitle = "Artens demografiske nøkkeltall.";
@@ -477,9 +480,6 @@ namespace Assessments.Frontend.Web.Infrastructure
             public const string CriteriaBExpansionSpeedSpatioTemporalResultTableDescription = "Tabellen viser artens estimerte ekspansjonshastighet (m/år) med bakgrunn i parametervalgene angitt over, samt datasett med tid- og stedfesta observasjoner av arten.";
             public const string ExpansionSpeedResultColumn1 = "Ekspansjonshastighet";
             public const string ExpansionSpeedResultColumn2 = "Estimert verdi (m/år)";
-            public const string AverageExpansionSpeedRow = "beste anslag";
-            public const string LowExpansionSpeedRow = "lavt anslag";
-            public const string HighExpansionSpeedRow = "høyt anslag";
 
             public const string CriteriaBExpansionSpeedIncreaseAOOTableTitle = "Artens endring i forekomstareal.";
             public const string CriteriaBExpansionSpeedIncreaseAOOTableDescription = "Tabellen viser artens kjente forekomstareal ved to ulike år.";
@@ -520,12 +520,22 @@ namespace Assessments.Frontend.Web.Infrastructure
             public const string ImpactedNatureTypesCurrentTableTitle = "Truede, sjeldne eller øvrige naturtyper arten er observert i. ";
             public const string ImpactedNatureTypesFutureTableTitle = "Truede, sjeldne eller øvrige naturtyper som er potensielle habitater for arten i Norge. ";
             public const string ImpactedNatureTypesCurrentTableDescription = "Tabellen viser anslått kolonisert areal (C-kriteriet) i de naturtypene arten er  observert i, samt artens påvirkning i naturtypen og anslått andel av naturtypens areal som blir påvirket (F- og G-kriteriet).";
-            public const string ImpactedNatureTypesFutureTableDescription = "Oversikten viser anslått kolonisert areal (C-kriteriet) i de naturtypene arten regnes med å observeres i innen 50 år eller 5 generasjoner (det av tallene som er størst), samt artens framtidige påvirkning i naturtypen og anslått andel av naturtypens areal som vil bli påvirket (F- og G-kriteriet).";
+            public const string ImpactedNatureTypesFutureTableDescription = "Tabellen viser anslått kolonisert areal (C-kriteriet) i de naturtypene arten regnes med å observeres i innen 50 år eller 5 generasjoner (det av tallene som er størst), samt artens framtidige påvirkning i naturtypen og anslått andel av naturtypens areal som vil bli påvirket (F- og G-kriteriet).";
             public const string NaturetypeNameTableColumn = "naturtype";
             public const string ColonizedAreaTableColumn = "kolonisert <br/>areal (%)";
             public const string StateChangeTableColumn = "tydelig <br/>tilstandsendring";
             public const string AffectedAreaTableColumn = "tydelig <br/>påvirka <br/>areal (%)";
             public const string ImpactedNatureTypesTableColumn6 = "vurderingsgrunnlag";
+
+            /*area of occupancy (AOO)*/
+            public const string AooTableTitle = "Artens forekomstareal.";
+            public const string AooTableDescription = "Tabellen viser artens kjente og antatte forekomstareal i dag og i fremtiden.";
+            public const string AooTableDescription2 = "Kjent forekomstareal er basert på perioden ";
+            public const string AooDoorknockersTableDescription = "Tabellen viser anslag på antall forekomster, med utgangspunkt i én introduksjon, og antallet ytterligere introduksjoner i løpet av en periode på 10 år. Anslag på artens forekomstareal 10 år etter første introduksjon er gitt.";
+            public const string AooTableColumn1 = "Anslag";
+            public const string AooDoorknockersTableColumn2 = "Antall forekomster fra én introduksjon";
+            public const string AooDoorknockersTableColumn3 = "Antall ytterligere introduksjoner til norsk natur";
+            public const string AooDoorknockersTableColumn4 = "Forekomstareal etter 10 år";
 
         }
         

--- a/Assessments.Frontend.Web/Infrastructure/Constants.cs
+++ b/Assessments.Frontend.Web/Infrastructure/Constants.cs
@@ -511,7 +511,7 @@ namespace Assessments.Frontend.Web.Infrastructure
             public const string NaturetypeDAndETableColumn1 = "Påvirkede <br/>arter i";
             public const string NaturetypeDAndETableColumn2 = "Nøkkelarter <br/>eller truede <br/>arter?";
 
-            /*Criteria C, F, G and impacted naturetypes*/
+            /*Criteria C, F, G and impacted naturetypes (incl. microhabitats)*/
             public const string CriteriaCNaturetypesTableTitle = "Artens koloniserte naturtypeareal.";
             public const string CriteriaCNaturetypesTableDescription = "Tabellen viser hvilke(n) naturtype(r) den fremmede arten koloniserer nå eller i framtida. Andel kolonisert areal (%) av totalt naturtypeareal og vurderingsgrunnlag er gitt for hver naturtype.";
             public const string CriteriaFNaturetypesTableTitle = "Artens negative effekter på truede eller sjeldne naturtyper.";
@@ -526,6 +526,10 @@ namespace Assessments.Frontend.Web.Infrastructure
             public const string StateChangeTableColumn = "tydelig <br/>tilstandsendring";
             public const string AffectedAreaTableColumn = "tydelig <br/>påvirka <br/>areal (%)";
             public const string ImpactedNatureTypesTableColumn6 = "vurderingsgrunnlag";
+            public const string MicroHabitatsTableTitle = "Artens livsmedier.";
+            public const string MicroHabitatsTableDescription = "Tabellen viser hvilke livsmedier den fremmede arten bruker nå eller i framtida. Hvis arten bruker en annen art som livsmedium er dette gitt.";
+            public const string MicroHabitatsTableColumn1 = "Livsmedium";
+            public const string MicroHabitatsTableColumn2 = "Art/Takson";
 
             /*area of occupancy (AOO)*/
             public const string AooTableTitle = "Artens forekomstareal.";

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_Attachments.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_Attachments.cshtml
@@ -3,11 +3,15 @@
 <div class="page_section_header">
     <h2 id="@nameof(Constants.HeadingsNo.Attachments)">@Constants.HeadingsNo.Attachments</h2>
 </div>
-<table class="numbers-table align-normal">
+<table class="big-data-table">
+    <caption class="table-title">
+        <b>@Constants.AlienSpeciesTables.AttachmentsTableTitle</b>
+        @Constants.AlienSpeciesTables.AttachmentsTableDescription 
+    </caption>
     <tr>
-        <td><b>Filnavn</b></td>
-        <td><b>Beskrivelse</b></td>
-        <td><b>Lenke for nedlasting</b></td>
+        <th>@Constants.AlienSpeciesTables.AttachmentsTableColumn1</th>
+        <th>@Constants.AlienSpeciesTables.AttachmentsTableColumn2</th>
+        <th>@Constants.AlienSpeciesTables.AttachmentsTableColumn3</th>
     </tr>
     @foreach (var attachment in Model.Attachments)
     {

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_CriteriaExplanation.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_CriteriaExplanation.cshtml
@@ -558,15 +558,15 @@
                             <th>@Constants.AlienSpeciesTables.ExpansionSpeedResultColumn2</th>
                         </tr>
                         <tr>
-                            <td>@Constants.AlienSpeciesTables.AverageExpansionSpeedRow </td>
+                            <td>@Constants.AlienSpeciesTables.AverageRow </td>
                             <td>@assessment.ExpansionSpeedBestEstimate.ToString("N0")</td>
                         </tr>
                         <tr>
-                            <td>@Constants.AlienSpeciesTables.LowExpansionSpeedRow </td>
+                            <td>@Constants.AlienSpeciesTables.LowRow </td>
                             <td>@assessment.ExpansionSpeedLowEstimate.ToString("N0")</td>
                         </tr>
                         <tr>
-                            <td>@Constants.AlienSpeciesTables.HighExpansionSpeedRow </td>
+                            <td>@Constants.AlienSpeciesTables.HighRow </td>
                             <td>@assessment.ExpansionSpeedHighEstimate.ToString("N0")</td>
                         </tr>
                     </table>

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_ImpactedNatureTypes.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_ImpactedNatureTypes.cshtml
@@ -105,12 +105,15 @@
             <p>
                 For noen arter er det mer riktig å angi <a href="https://www.artsdatabanken.no/Pages/137826/Livsmedium">livsmedium</a> enn naturtyper. Et eksempel er parasittiske arter som lever i og på dyr, eller arter som lever i dyremøkk, og hvor naturtypen dyret eller møkka befinner seg i betyr lite. Livsmedium har ingen effekter på artens risikokategori.
             </p>
-            <table class="numbers-table">
-                <caption class="table-title"><b>Artens livsmedium.</b>For hvert livsmedium er det angitt om situasjonen gjelder i dag eller i fremtiden (tidshorisont). Hvis arten bruker en annen art som livsmedium er dette angitt (art/takson). </caption>
+            <table class="big-data-table">
+                <caption class="table-title">
+                    <b>@Constants.AlienSpeciesTables.MicroHabitatsTableTitle</b>
+                    @Constants.AlienSpeciesTables.MicroHabitatsTableDescription 
+                </caption>
                 <tr>
-                    <td>Livsmedium</td>
-                    <td>Art/Takson</td>
-                    <td>Tidshorisont</td>
+                    <th>@Constants.AlienSpeciesTables.MicroHabitatsTableColumn1</th>
+                    <th>@Constants.AlienSpeciesTables.MicroHabitatsTableColumn2</th>
+                    <th>@Constants.AlienSpeciesTables.TimeHorizonTableColumn</th>
                 </tr>
                 @foreach (var habitat in Model.Assessment.MicroHabitat)
                 {

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_KnowMore.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_KnowMore.cshtml
@@ -86,12 +86,15 @@
         </div>
         <div is-visible="showFirstObservation">
             <h3>Første observasjon av arten @( isRegionallyAlien ? "der den er regionalt fremmed" : areaText )</h3>
-            <table is-visible="Model.Assessment.YearsFirstRecord.ObservedEstablishmentInNorway.Count > 0" class="numbers-table small-table">
-                <tbody>
+            <table is-visible="Model.Assessment.YearsFirstRecord.ObservedEstablishmentInNorway.Count > 0" class="big-data-table">
+                <caption class="table-title">
+                    <b>@Constants.AlienSpeciesTables.FirstObsTableTitle</b>
+                    @Constants.AlienSpeciesTables.FirstObsTableDescription 
+                </caption>
                     <tr>
-                        <td>Første observasjon av:</td>
-                        <td>Årstall</td>
-                        <td>Usikkerhet i årstall (> ± 5 år)</td>
+                        <th>@Constants.AlienSpeciesTables.FirstObsTableColumn1</th>
+                        <th>@Constants.AlienSpeciesTables.FirstObsTableColumn2</th>
+                        <th>@Html.Raw(@Constants.AlienSpeciesTables.FirstObsTableColumn3)</th>
                     </tr>
                     @foreach(var record in Model.Assessment.YearsFirstRecord.ObservedEstablishmentInNorway)
                     {
@@ -101,7 +104,6 @@
                             <td>@( record.isUncertaintyYear ? "Ja" : "Nei" )</td>
                         </tr>
                     }
-                </tbody>
             </table>
             <p is-visible="!string.IsNullOrEmpty(Model.Assessment.YearsFirstRecord.Description)">
                 @Html.Raw(Model.Assessment.YearsFirstRecord.Description)

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RegionalSpread.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RegionalSpread.cshtml
@@ -82,14 +82,18 @@
             <h3>Forekomstareal</h3>
             <p>
                 Forekomstarealet til en @Helpers.FixSpeciesLevel("{art}", Model.NameRank) tilsvarer antallet forekomster (2 km x 2 km ruter) der @Helpers.FixSpeciesLevel("{art}en", Model.NameRank) lever.
-                <a href="https://www.artsdatabanken.no/FAL/Begreper">Les mer om forekomstareal her.</a>
+                <a href="https://www.artsdatabanken.no/Pages/342783">Les mer om forekomstareal her.</a>
             </p>
-            <p is-visible="showAreaOfOccupancyYearRange">Kjent forekomstareal er basert på perioden @Model.AreaOfOccupancyKnownYearOne til @Model.AreaOfOccupancyKnownYearTwo.</p>
-            <table class="numbers-table" is-visible="isAlienSpecie || isRegionallyAlien">
+            <table class="big-data-table" is-visible="isAlienSpecie || isRegionallyAlien">
+                <caption class="table-title">
+                    <b>@Constants.AlienSpeciesTables.AooTableTitle</b>
+                    @Constants.AlienSpeciesTables.AooTableDescription 
+                    @if(showAreaOfOccupancyYearRange) {@Constants.AlienSpeciesTables.AooTableDescription2}@Model.AreaOfOccupancyKnownYearOne til @Model.AreaOfOccupancyKnownYearTwo.
+                </caption>
                 <tr>
                     <th>Forekomstareal</th>
                     <th>I dag </th>
-                    <th>Fremtidig (50 år) </th>
+                    <th>Fremtidig (50 år)</th>
                 </tr>
                 <tr>
                     <td>Kjent  </td>
@@ -132,27 +136,31 @@
                     <partial name="/Views/AlienSpecies/2023/AssessmentPartials/_MapWaterAreas.cshtml" model="isAssumedInFuture" />
                 </div>
             </div>
-            <table class="numbers-table" is-visible="isDoorKnockerOrEffectNoRep">
+            <table class="big-data-table" is-visible="isDoorKnockerOrEffectNoRep">
+                <caption class="table-title">
+                    <b>@Constants.AlienSpeciesTables.AooTableTitle</b>
+                    @Constants.AlienSpeciesTables.AooDoorknockersTableDescription
+                </caption>
                 <tr>
-                    <th>Antatt i løpet av en periode på 10 år</th>
-                    <th>Antall forekomster fra én introduksjon  </th>
-                    <th>Antall ytterligere introduksjoner til norsk natur </th>
-                    <th>Forekomstareal etter 10 år </th>
+                    <th>@Constants.AlienSpeciesTables.AooTableColumn1</th>
+                    <th>@Constants.AlienSpeciesTables.AooDoorknockersTableColumn2</th>
+                    <th>@Constants.AlienSpeciesTables.AooDoorknockersTableColumn3</th>
+                    <th>@Constants.AlienSpeciesTables.AooDoorknockersTableColumn4</th>
                 </tr>
                 <tr>
-                    <td>Lavt anslag</td>
+                    <td>@Constants.AlienSpeciesTables.LowRow</td>
                     <td>@Model.RiskAssessmentOccurrences1Low </td>
                     <td>@Model.RiskAssessmentIntroductionsLow </td>
                     <td>@Model.AreaOfOccupancyFutureLow  km<sup>2</sup></td>
                 </tr>
                 <tr>
-                    <td>Beste anslag</td>
+                    <td>@Constants.AlienSpeciesTables.AverageRow</td>
                     <td>@Model.RiskAssessmentOccurrences1Best </td>
                     <td>@Model.RiskAssessmentIntroductionsBest </td>
                     <td>@Model.AreaOfOccupancyFutureBest  km<sup>2</sup></td>
                 </tr>
                 <tr>
-                    <td>Høyt anslag</td>
+                    <td>@Constants.AlienSpeciesTables.HighRow</td>
                     <td>@Model.RiskAssessmentOccurrences1High </td>
                     <td>@Model.RiskAssessmentIntroductionsHigh </td>
                     <td>@Model.AreaOfOccupancyFutureHigh km<sup>2</sup></td>

--- a/Assessments.Frontend.Web/wwwroot/css/assessment.css
+++ b/Assessments.Frontend.Web/wwwroot/css/assessment.css
@@ -846,6 +846,7 @@ span.area i {
     border: 1px solid grey;
     width: 100%;
     table-layout: fixed;
+    margin-bottom: 20px;
 }
 
 .darktheme .big-data-table {


### PR DESCRIPTION
closes #1254

Gjenværende tabeller (se nevnte issue) har fått rett type tabell-layout, og beskrivelser (manglet stort sett fra før) er lagt til for samtlige tabeller i Constants-fila. Beskrivelsene ble laget "on the fly" uten "oppskrift" i et eget issue... 