### PR TITLE
Bugfix/nr regionally alien

### DIFF
--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/QueryHelpers.cs
@@ -330,8 +330,8 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
                 {
                     assessments = regionFilter switch
                     {
-                        nameof(RegionallyAlien.RegionallyAlienEnum.Rae) => query.Where(x => x.AlienSpeciesCategory != AlienSpeciecAssessment2023AlienSpeciesCategory.RegionallyAlien),
-                        nameof(RegionallyAlien.RegionallyAlienEnum.Rai) => query.Where(x => x.AlienSpeciesCategory == AlienSpeciecAssessment2023AlienSpeciesCategory.RegionallyAlien),
+                        nameof(RegionallyAlien.RegionallyAlienEnum.Rae) => query.Where(x => x.AlienSpeciesCategory != AlienSpeciecAssessment2023AlienSpeciesCategory.RegionallyAlien && x.AlienSpeciesCategory != AlienSpeciecAssessment2023AlienSpeciesCategory.RegionallyAlienEstablishedBefore1800),
+                        nameof(RegionallyAlien.RegionallyAlienEnum.Rai) => query.Where(x => x.AlienSpeciesCategory == AlienSpeciecAssessment2023AlienSpeciesCategory.RegionallyAlien || x.AlienSpeciesCategory == AlienSpeciecAssessment2023AlienSpeciesCategory.RegionallyAlienEstablishedBefore1800),
                         _ => null
                     };
                 }

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_AssessmentReasoning.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_AssessmentReasoning.cshtml
@@ -6,7 +6,7 @@
     var showAlienStatusExplanation = !string.IsNullOrEmpty(Model.AlienStatusExplanation);
     var showChangedFromAlienDescription = !string.IsNullOrEmpty(Model.ChangedFromAlienDescription) && (!string.IsNullOrEmpty(Model.AlienStatusExplanation) && Model.AlienStatusExplanation != Model.ChangedFromAlienDescription || string.IsNullOrEmpty(Model.AlienStatusExplanation));
     var showConnectedToHigherLowerTaxonDescription = Model.AlienSpeciesCategory == Assessments.Mapping.AlienSpecies.Model.Enums.AlienSpeciecAssessment2023AlienSpeciesCategory.TaxonEvaluatedAtAnotherLevel;
-    var showUncertaintyEstablishmentTimeDescription = Model.AlienSpeciesCategory == Assessments.Mapping.AlienSpecies.Model.Enums.AlienSpeciecAssessment2023AlienSpeciesCategory.UncertainBefore1800;
+    var showUncertaintyEstablishmentTimeDescription = Model.AlienSpeciesCategory == Assessments.Mapping.AlienSpecies.Model.Enums.AlienSpeciecAssessment2023AlienSpeciesCategory.UncertainBefore1800 || Model.AlienSpeciesCategory == Assessments.Mapping.AlienSpecies.Model.Enums.AlienSpeciecAssessment2023AlienSpeciesCategory.RegionallyAlienEstablishedBefore1800;
     var isMisidentified = Model.AlienSpeciesCategory == Assessments.Mapping.AlienSpecies.Model.Enums.AlienSpeciecAssessment2023AlienSpeciesCategory.MisIdentified;
     var isAllBubTaxaAssessedSeparately = Model.AlienSpeciesCategory == Assessments.Mapping.AlienSpecies.Model.Enums.AlienSpeciecAssessment2023AlienSpeciesCategory.AllSubTaxaAssessedSeparately;
     var isHybridWithoutOwnRiskAssessment = Model.AlienSpeciesCategory == Assessments.Mapping.AlienSpecies.Model.Enums.AlienSpeciecAssessment2023AlienSpeciesCategory.HybridWithoutOwnRiskAssessment;


### PR DESCRIPTION
Fixes #1261 
- Lagt til begrunnelse
- Ørret dukker opp i filteret. Vi introduserte en ny kategori "RegionallyAlienEstablishedBefore1800" etter at filteret ble lagd, og filteret hadde ikke blitt oppdatert etter dette. 