### PR TITLE
Feature/adjust tables

### DIFF
--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_Map2018.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_Map2018.cshtml
@@ -66,7 +66,7 @@
 
                     <span>
                         <br />
-                        <b>Kjent utberedelse</b>
+                        <b>Kjent utbredelse</b>
                         <br />
                         <span is-visible="knownToday.Count == 0">Arten er ikke kjent i noen områder</span>
                         @{
@@ -74,7 +74,7 @@
                         }
                         <br />
                         <br />
-                        <b>Antatt utberedelse</b>
+                        <b>Antatt utbredelse</b>
                         <br />
                         <span is-visible="assumedToday.Count == 0 && knownToday.Count == 0">Det antas at arten ikke finnes i noen områder</span>
                         <span is-visible="assumedToday.Count == 0 && knownToday.Count > 0">Arten er antatt å kun finnes i de kjente områdene</span>
@@ -86,7 +86,7 @@
                 else
                 {
                     makeFormattedList(@Model.RegionOccurrences);
-                    <span is-visible="Model.RegionOccurrences.Count == 0">Det antas ingen utberedelse om 50 år <!-- TODO: Hide map? --></span>
+                    <span is-visible="Model.RegionOccurrences.Count == 0">Det antas ingen utbredelse om 50 år <!-- TODO: Hide map? --></span>
                 }
             }
         </span>
@@ -97,11 +97,11 @@
         <table class="map-legend">
             <tr>
                 <td class="indicator is_known_today"></td>
-                <td>Kjent utberedelse</td>
+                <td>Kjent utbredelse</td>
             </tr>
             <tr>
                 <td class="indicator is_assumed"></td>
-                <td>Antatt utberedelse</td>
+                <td>Antatt utbredelse</td>
             </tr>
             <tr>
                 <td class="indicator no_occurrence"></td>

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_MapWaterAreas.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_MapWaterAreas.cshtml
@@ -40,11 +40,11 @@
     <div is-visible="Model.ShowLegend">
         <table class="map-legend">
             <tr is-visible="Model.MapText == Constants.AlienSpecies2023KnownOrAssumedOccurrence">
-                <td>Kjent utberedelse</td>
+                <td>Kjent utbredelse</td>
                 <td class="indicator is_known_today"></td>
             </tr>
             <tr>
-                <td>Antatt utberedelse</td>
+                <td>Antatt utbredelse</td>
                 <td class="indicator is_assumed"></td>
             </tr>
             <tr>

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_MapWaterRegions.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_MapWaterRegions.cshtml
@@ -41,11 +41,11 @@
         <table class="map-legend">
             <tr is-visible="Model.MapText == Constants.AlienSpecies2023KnownOrAssumedOccurrence">
                 <td class="indicator is_known_today"></td>
-                <td>Kjent utberedelse</td>
+                <td>Kjent utbredelse</td>
             </tr>
             <tr>
                 <td class="indicator is_assumed"></td>
-                <td>Antatt utberedelse</td>
+                <td>Antatt utbredelse</td>
             </tr>
             <tr>
                 <td class="indicator no_occurrence"></td>

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RegionalSpread.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RegionalSpread.cshtml
@@ -100,23 +100,23 @@
                 </tr>
                 <tr>
                     <td>Kjent</td>
-                    <td><b class="only_mobile">I dag:</b> @Model.AreaOfOccupancyKnown km<sup>2</sup></td>
+                    <td>@Model.AreaOfOccupancyKnown km<sup>2</sup></td>
                     <td></td>
                 </tr>
                 <tr>
                     <td>Antatt lavt anslag</td>
-                    <td><b class="only_mobile">I dag:</b> @Model.AreaOfOccupancyTotalLow km<sup>2</sup></td>
-                    <td><b class="only_mobile">Fremtidig (50 år):</b> @Model.AreaOfOccupancyFutureLow km<sup>2</sup></td>
+                    <td>@Model.AreaOfOccupancyTotalLow km<sup>2</sup></td>
+                    <td>@Model.AreaOfOccupancyFutureLow km<sup>2</sup></td>
                 </tr>
                 <tr>
                     <td>Antatt beste anslag</td>
-                    <td><b class="only_mobile">I dag:</b> @Model.AreaOfOccupancyTotalBest km<sup>2</sup></td>
-                    <td><b class="only_mobile">Fremtidig (50 år):</b> @Model.AreaOfOccupancyFutureBest km<sup>2</sup></td>
+                    <td>@Model.AreaOfOccupancyTotalBest km<sup>2</sup></td>
+                    <td>@Model.AreaOfOccupancyFutureBest km<sup>2</sup></td>
                 </tr>
                 <tr>
                     <td>Antatt høyt anslag</td>
-                    <td><b class="only_mobile">I dag:</b> @Model.AreaOfOccupancyTotalHigh km<sup>2</sup></td>
-                    <td><b class="only_mobile">Fremtidig (50 år):</b> @Model.AreaOfOccupancyFutureHigh km<sup>2</sup></td>
+                    <td>@Model.AreaOfOccupancyTotalHigh km<sup>2</sup></td>
+                    <td>@Model.AreaOfOccupancyFutureHigh km<sup>2</sup></td>
                 </tr>
             </table>
 
@@ -154,21 +154,21 @@
                 </tr>
                 <tr>
                     <td>@Constants.AlienSpeciesTables.LowRow</td>
-                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn2:</b>@Model.RiskAssessmentOccurrences1Low </td>
-                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn3:</b>@Model.RiskAssessmentIntroductionsLow </td>
-                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn4:</b>@Model.AreaOfOccupancyFutureLow  km<sup>2</sup></td>
+                    <td>@Model.RiskAssessmentOccurrences1Low </td>
+                    <td>@Model.RiskAssessmentIntroductionsLow </td>
+                    <td>@Model.AreaOfOccupancyFutureLow  km<sup>2</sup></td>
                 </tr>
                 <tr>
                     <td>@Constants.AlienSpeciesTables.AverageRow</td>
-                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn2:</b>@Model.RiskAssessmentOccurrences1Best </td>
-                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn3:</b>@Model.RiskAssessmentIntroductionsBest </td>
-                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn4:</b>@Model.AreaOfOccupancyFutureBest  km<sup>2</sup></td>
+                    <td>@Model.RiskAssessmentOccurrences1Best </td>
+                    <td>@Model.RiskAssessmentIntroductionsBest </td>
+                    <td>@Model.AreaOfOccupancyFutureBest  km<sup>2</sup></td>
                 </tr>
                 <tr>
                     <td>@Constants.AlienSpeciesTables.HighRow</td>
-                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn2:</b>@Model.RiskAssessmentOccurrences1High </td>
-                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn3:</b>@Model.RiskAssessmentIntroductionsHigh </td>
-                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn4:</b>@Model.AreaOfOccupancyFutureHigh km<sup>2</sup></td>
+                    <td>@Model.RiskAssessmentOccurrences1High </td>
+                    <td>@Model.RiskAssessmentIntroductionsHigh </td>
+                    <td>@Model.AreaOfOccupancyFutureHigh km<sup>2</sup></td>
                 </tr>
             </table>
 

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RegionalSpread.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RegionalSpread.cshtml
@@ -78,47 +78,13 @@
     </div>
     
     <div id="domestic_spread">
-        <div id="show_occurence_area">
+        <b id="show_occurence_area">
             <h3>Forekomstareal</h3>
             <p>
                 Forekomstarealet til en @Helpers.FixSpeciesLevel("{art}", Model.NameRank) tilsvarer antallet forekomster (2 km x 2 km ruter) der @Helpers.FixSpeciesLevel("{art}en", Model.NameRank) lever.
                 <a href="https://www.artsdatabanken.no/Pages/342783">Les mer om forekomstareal her.</a>
             </p>
-
-            <table class="big-data-table hideonmobile" is-visible="isAlienSpecie || isRegionallyAlien">
-                <caption class="table-title">
-                    <b>@Constants.AlienSpeciesTables.AooTableTitle</b>
-                    @Constants.AlienSpeciesTables.AooTableDescription 
-                    @if(showAreaOfOccupancyYearRange) {@Constants.AlienSpeciesTables.AooTableDescription2}@Model.AreaOfOccupancyKnownYearOne til @Model.AreaOfOccupancyKnownYearTwo.
-                </caption>
-                <tr>
-                    <th>Forekomstareal</th>
-                    <th>I dag </th>
-                    <th>Fremtidig (50 år)</th>
-                </tr>
-                <tr>
-                    <td>kjent  </td>
-                    <td>@Model.AreaOfOccupancyKnown km<sup>2</sup></td>
-                    <td></td>
-                </tr>
-                <tr>
-                    <td>antatt lavt anslag</td>
-                    <td>@Model.AreaOfOccupancyTotalLow km<sup>2</sup></td>
-                    <td>@Model.AreaOfOccupancyFutureLow km<sup>2</sup></td>
-                </tr>
-                <tr>
-                    <td>antatt beste anslag</td>
-                    <td>@Model.AreaOfOccupancyTotalBest km<sup>2</sup></td>
-                    <td>@Model.AreaOfOccupancyFutureBest km<sup>2</sup></td>
-                </tr>
-                <tr>
-                    <td>antatt høyt anslag</td>
-                    <td>@Model.AreaOfOccupancyTotalHigh km<sup>2</sup></td>
-                    <td>@Model.AreaOfOccupancyFutureHigh km<sup>2</sup></td>
-                </tr>
-            </table>
-
-            <table class="big-data-table only_mobile" is-visible="isAlienSpecie || isRegionallyAlien">
+            <table class="big-data-table" is-visible="isAlienSpecie || isRegionallyAlien">
                 <caption class="table-title">
                     <b>@Constants.AlienSpeciesTables.AooTableTitle</b>
                     @Constants.AlienSpeciesTables.AooTableDescription
@@ -134,23 +100,23 @@
                 </tr>
                 <tr>
                     <td>Kjent</td>
-                    <td>I dag: @Model.AreaOfOccupancyKnown km<sup>2</sup></td>
+                    <td><b class="only_mobile">I dag:</b> @Model.AreaOfOccupancyKnown km<sup>2</sup></td>
                     <td></td>
                 </tr>
                 <tr>
                     <td>Antatt lavt anslag</td>
-                    <td>I dag: @Model.AreaOfOccupancyTotalLow km<sup>2</sup></td>
-                    <td>Fremtidig (50 år): @Model.AreaOfOccupancyFutureLow km<sup>2</sup></td>
+                    <td><b class="only_mobile">I dag:</b> @Model.AreaOfOccupancyTotalLow km<sup>2</sup></td>
+                    <td><b class="only_mobile">Fremtidig (50 år):</b> @Model.AreaOfOccupancyFutureLow km<sup>2</sup></td>
                 </tr>
                 <tr>
                     <td>Antatt beste anslag</td>
-                    <td>I dag: @Model.AreaOfOccupancyTotalBest km<sup>2</sup></td>
-                    <td>Fremtidig (50 år): @Model.AreaOfOccupancyFutureBest km<sup>2</sup></td>
+                    <td><b class="only_mobile">I dag:</b> @Model.AreaOfOccupancyTotalBest km<sup>2</sup></td>
+                    <td><b class="only_mobile">Fremtidig (50 år):</b> @Model.AreaOfOccupancyFutureBest km<sup>2</sup></td>
                 </tr>
                 <tr>
                     <td>Antatt høyt anslag</td>
-                    <td>I dag: @Model.AreaOfOccupancyTotalHigh km<sup>2</sup></td>
-                    <td>Fremtidig (50 år): @Model.AreaOfOccupancyFutureHigh km<sup>2</sup></td>
+                    <td><b class="only_mobile">I dag:</b> @Model.AreaOfOccupancyTotalHigh km<sup>2</sup></td>
+                    <td><b class="only_mobile">Fremtidig (50 år):</b> @Model.AreaOfOccupancyFutureHigh km<sup>2</sup></td>
                 </tr>
             </table>
 
@@ -174,6 +140,7 @@
                     <partial name="/Views/AlienSpecies/2023/AssessmentPartials/_MapWaterAreas.cshtml" model="isAssumedInFuture" />
                 </div>
             </div>
+
             <table class="big-data-table" is-visible="isDoorKnockerOrEffectNoRep">
                 <caption class="table-title">
                     <b>@Constants.AlienSpeciesTables.AooTableTitle</b>
@@ -187,23 +154,24 @@
                 </tr>
                 <tr>
                     <td>@Constants.AlienSpeciesTables.LowRow</td>
-                    <td>@Model.RiskAssessmentOccurrences1Low </td>
-                    <td>@Model.RiskAssessmentIntroductionsLow </td>
-                    <td>@Model.AreaOfOccupancyFutureLow  km<sup>2</sup></td>
+                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn2:</b>@Model.RiskAssessmentOccurrences1Low </td>
+                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn3:</b>@Model.RiskAssessmentIntroductionsLow </td>
+                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn4:</b>@Model.AreaOfOccupancyFutureLow  km<sup>2</sup></td>
                 </tr>
                 <tr>
                     <td>@Constants.AlienSpeciesTables.AverageRow</td>
-                    <td>@Model.RiskAssessmentOccurrences1Best </td>
-                    <td>@Model.RiskAssessmentIntroductionsBest </td>
-                    <td>@Model.AreaOfOccupancyFutureBest  km<sup>2</sup></td>
+                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn2:</b>@Model.RiskAssessmentOccurrences1Best </td>
+                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn3:</b>@Model.RiskAssessmentIntroductionsBest </td>
+                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn4:</b>@Model.AreaOfOccupancyFutureBest  km<sup>2</sup></td>
                 </tr>
                 <tr>
                     <td>@Constants.AlienSpeciesTables.HighRow</td>
-                    <td>@Model.RiskAssessmentOccurrences1High </td>
-                    <td>@Model.RiskAssessmentIntroductionsHigh </td>
-                    <td>@Model.AreaOfOccupancyFutureHigh km<sup>2</sup></td>
+                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn2:</b>@Model.RiskAssessmentOccurrences1High </td>
+                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn3:</b>@Model.RiskAssessmentIntroductionsHigh </td>
+                    <td><b class="only_mobile">@Constants.AlienSpeciesTables.AooDoorknockersTableColumn4:</b>@Model.AreaOfOccupancyFutureHigh km<sup>2</sup></td>
                 </tr>
             </table>
+
             <p is-visible="!Options.Value.AlienSpecies2023.IsHearing && (isDoorKnocker || isEffectWithoutReproduction)">Andel av antatt forekomstareal i sterkt endra natur er på @Model.AreaOfOccupancyInStronglyAlteredEcosystems.DisplayName().</p>
             <div is-visible="@isDoorKnockerOrEffectNoRep">
                 <h3>Regionvis utbredelse</h3>
@@ -244,34 +212,34 @@
                                     <span class="collapse_water_area water-area-no-js">Alle vannområder</span>
                                 </td>
                                 <td>
-                                    <span is-visible="waterRegion.IsKnown"><span class="material-icons success">done</span>Ja</span>
-                                    <span is-visible="!waterRegion.IsKnown"><span class="material-icons error">close</span>Nei</span>
+                                    <span is-visible="waterRegion.IsKnown"><b class="only_mobile">Kjent utbredelse:</b><span class="material-icons success">done</span>Ja</span>
+                                    <span is-visible="!waterRegion.IsKnown"><b class="only_mobile">Kjent utbredelse:</b><span class="material-icons error">close</span>Nei</span>
                                 </td>
                                 <td>
-                                    <span is-visible="waterRegion.IsAssumedToday"><span class="material-icons success">done</span>Ja</span>
-                                    <span is-visible="!waterRegion.IsAssumedToday"><span class="material-icons error">close</span>Nei</span>
+                                    <span is-visible="waterRegion.IsAssumedToday"><b class="only_mobile">Antatt utbredelse i dag:</b><span class="material-icons success">done</span>Ja</span>
+                                    <span is-visible="!waterRegion.IsAssumedToday"><b class="only_mobile">Antatt utbredelse i dag:</b><span class="material-icons error">close</span>Nei</span>
                                 </td>
                                 <td>
-                                    <span is-visible="waterRegion.IsAssumedInFuture"><span class="material-icons success">done</span>Ja</span>
-                                    <span is-visible="!waterRegion.IsAssumedInFuture"><span class="material-icons error">close</span>Nei</span>
+                                    <span is-visible="waterRegion.IsAssumedInFuture"><b class="only_mobile">Antatt utbredelse om 50 år:</b><span class="material-icons success">done</span>Ja</span>
+                                    <span is-visible="!waterRegion.IsAssumedInFuture"><b class="only_mobile">Antatt utbredelse om 50 år:</b><span class="material-icons error">close</span>Nei</span>
                                 </td>
                             </tr>
                             foreach (var waterArea in waterRegion.WaterAreas)
                             {
                                 <tr class="@waterRegion.WaterRegionName.Replace(" ", "_") water-area">
                                     <td>@waterArea.WaterRegionName</td>
-                                    <td>@waterArea.Name</td>
+                                    <td><b class="only_mobile">Vannområde:</b>@waterArea.Name</td>
                                     <td>
-                                        <span is-visible="waterArea.IsKnown"><span class="material-icons success">done</span>Ja</span>
-                                        <span is-visible="!waterArea.IsKnown"><span class="material-icons error">close</span>Nei</span>
+                                        <span is-visible="waterArea.IsKnown"><b class="only_mobile">Kjent utbredelse:</b><span class="material-icons success">done</span>Ja</span>
+                                        <span is-visible="!waterArea.IsKnown"><b class="only_mobile">Kjent utbredelse:</b><span class="material-icons error">close</span>Nei</span>
                                     </td>
                                     <td>
-                                        <span is-visible="waterArea.IsAssumedToday"><span class="material-icons success">done</span>Ja</span>
-                                        <span is-visible="!waterArea.IsAssumedToday"><span class="material-icons error">close</span>Nei</span>
+                                        <span is-visible="waterArea.IsAssumedToday"><b class="only_mobile">Antatt utbredelse i dag:</b><span class="material-icons success">done</span>Ja</span>
+                                        <span is-visible="!waterArea.IsAssumedToday"><b class="only_mobile">Antatt utbredelse i dag:</b><span class="material-icons error">close</span>Nei</span>
                                     </td>
                                     <td>
-                                        <span is-visible="waterArea.IsAssumedInFuture"><span class="material-icons success">done</span>Ja</span>
-                                        <span is-visible="!waterArea.IsAssumedInFuture"><span class="material-icons error">close</span>Nei</span>
+                                        <span is-visible="waterArea.IsAssumedInFuture"><b class="only_mobile">Antatt utbredelse om 50 år:</b><span class="material-icons success">done</span>Ja</span>
+                                        <span is-visible="!waterArea.IsAssumedInFuture"><b class="only_mobile">Antatt utbredelse om 50 år:</b><span class="material-icons error">close</span>Nei</span>
                                     </td>
                                 </tr>
                             }

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RegionalSpread.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RegionalSpread.cshtml
@@ -84,7 +84,8 @@
                 Forekomstarealet til en @Helpers.FixSpeciesLevel("{art}", Model.NameRank) tilsvarer antallet forekomster (2 km x 2 km ruter) der @Helpers.FixSpeciesLevel("{art}en", Model.NameRank) lever.
                 <a href="https://www.artsdatabanken.no/Pages/342783">Les mer om forekomstareal her.</a>
             </p>
-            <table class="big-data-table" is-visible="isAlienSpecie || isRegionallyAlien">
+
+            <table class="big-data-table hideonmobile" is-visible="isAlienSpecie || isRegionallyAlien">
                 <caption class="table-title">
                     <b>@Constants.AlienSpeciesTables.AooTableTitle</b>
                     @Constants.AlienSpeciesTables.AooTableDescription 
@@ -96,26 +97,63 @@
                     <th>Fremtidig (50 år)</th>
                 </tr>
                 <tr>
-                    <td>Kjent  </td>
+                    <td>kjent  </td>
                     <td>@Model.AreaOfOccupancyKnown km<sup>2</sup></td>
                     <td></td>
                 </tr>
                 <tr>
-                    <td>Antatt lavt anslag</td>
+                    <td>antatt lavt anslag</td>
                     <td>@Model.AreaOfOccupancyTotalLow km<sup>2</sup></td>
                     <td>@Model.AreaOfOccupancyFutureLow km<sup>2</sup></td>
                 </tr>
                 <tr>
-                    <td>Antatt beste anslag</td>
+                    <td>antatt beste anslag</td>
                     <td>@Model.AreaOfOccupancyTotalBest km<sup>2</sup></td>
                     <td>@Model.AreaOfOccupancyFutureBest km<sup>2</sup></td>
                 </tr>
                 <tr>
-                    <td>Antatt høyt anslag</td>
+                    <td>antatt høyt anslag</td>
                     <td>@Model.AreaOfOccupancyTotalHigh km<sup>2</sup></td>
                     <td>@Model.AreaOfOccupancyFutureHigh km<sup>2</sup></td>
                 </tr>
             </table>
+
+            <table class="big-data-table only_mobile" is-visible="isAlienSpecie || isRegionallyAlien">
+                <caption class="table-title">
+                    <b>@Constants.AlienSpeciesTables.AooTableTitle</b>
+                    @Constants.AlienSpeciesTables.AooTableDescription
+                    @if (showAreaOfOccupancyYearRange)
+                    {
+                        @Constants.AlienSpeciesTables.AooTableDescription2
+                    }@Model.AreaOfOccupancyKnownYearOne til @Model.AreaOfOccupancyKnownYearTwo.
+                </caption>
+                <tr>
+                    <th>Forekomstareal</th>
+                    <th>I dag </th>
+                    <th>Fremtidig (50 år)</th>
+                </tr>
+                <tr>
+                    <td>Kjent</td>
+                    <td>I dag: @Model.AreaOfOccupancyKnown km<sup>2</sup></td>
+                    <td></td>
+                </tr>
+                <tr>
+                    <td>Antatt lavt anslag</td>
+                    <td>I dag: @Model.AreaOfOccupancyTotalLow km<sup>2</sup></td>
+                    <td>Fremtidig (50 år): @Model.AreaOfOccupancyFutureLow km<sup>2</sup></td>
+                </tr>
+                <tr>
+                    <td>Antatt beste anslag</td>
+                    <td>I dag: @Model.AreaOfOccupancyTotalBest km<sup>2</sup></td>
+                    <td>Fremtidig (50 år): @Model.AreaOfOccupancyFutureBest km<sup>2</sup></td>
+                </tr>
+                <tr>
+                    <td>Antatt høyt anslag</td>
+                    <td>I dag: @Model.AreaOfOccupancyTotalHigh km<sup>2</sup></td>
+                    <td>Fremtidig (50 år): @Model.AreaOfOccupancyFutureHigh km<sup>2</sup></td>
+                </tr>
+            </table>
+
             <p is-visible="@(!string.IsNullOrEmpty(Model.ArtskartObservationChangesDescription))">@Html.Raw(Model.ArtskartObservationChangesDescription)</p>
             <p is-visible="!Options.Value.AlienSpecies2023.IsHearing && (isAlienSpecie || isRegionallyAlien)">Andel av kjent forekomstareal i sterkt endra natur er på @Model.AreaOfOccupancyInStronglyAlteredEcosystems.DisplayName().</p>
             <div is-visible="@isAlienSpecie">
@@ -181,15 +219,15 @@
                 </p>
             </div>
             <div is-visible="isRegionallyAlien">
-                <table class="numbers-table">
+                <table class="big-data-table">
                     <caption class="table-title">Vannregioner hvor arten har enten kjent utbredelse, antatt utbredelse i dag eller antatt utbredelse om 50 år.</caption>
                     <tbody>
                         <tr>
-                            <td>Vannregion</td>
-                            <td is-visible="hasWaterAreas">Vannområde</td>
-                            <td>Kjent utbredelse</td>
-                            <td>Antatt utbredelse i dag</td>
-                            <td>Antatt utbredelse om 50 år</td>
+                            <th>Vannregion</th>
+                            <th is-visible="hasWaterAreas">Vannområde</th>
+                            <th>Kjent utbredelse</th>
+                            <th>Antatt utbredelse i dag</th>
+                            <th>Antatt utbredelse om 50 år</th>
                         </tr>
                         @foreach (var waterRegion in waterRegionsRegionallyAlien)
                         {

--- a/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RegionalSpread.cshtml
+++ b/Assessments.Frontend.Web/Views/AlienSpecies/2023/AssessmentPartials/_RegionalSpread.cshtml
@@ -78,7 +78,7 @@
     </div>
     
     <div id="domestic_spread">
-        <b id="show_occurence_area">
+        <div id="show_occurence_area">
             <h3>Forekomstareal</h3>
             <p>
                 Forekomstarealet til en @Helpers.FixSpeciesLevel("{art}", Model.NameRank) tilsvarer antallet forekomster (2 km x 2 km ruter) der @Helpers.FixSpeciesLevel("{art}en", Model.NameRank) lever.

--- a/Assessments.Frontend.Web/Views/Shared/_Criteriabar.cshtml
+++ b/Assessments.Frontend.Web/Views/Shared/_Criteriabar.cshtml
@@ -26,7 +26,7 @@
             <div class="category_item">
                 <span>B</span>
             </div>
-            <span class="tag">Begrenset utberedelse</span>
+            <span class="tag">Begrenset utbredelse</span>
         </li>
         <li class="@setActive("C", @Model.CriteriaSummarized)">
             <div class="category_item">

--- a/Assessments.Frontend.Web/wwwroot/css/assessment.css
+++ b/Assessments.Frontend.Web/wwwroot/css/assessment.css
@@ -1103,7 +1103,7 @@ table caption.table-title {
     font-size: 22.5px;
 }
 
-.water-area-hide,
+tr.water-area-hide,
 .collapse_water_area.water-area-hide,
 .water-area-hide.material-icons {
     display: none;
@@ -1132,4 +1132,27 @@ table caption.table-title {
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
+}
+
+@media only screen and (max-width: 750px) {
+    .water-area {
+        margin-top: -8px;
+    }
+
+    .water-area td:first-child {
+        display: none;
+    }
+
+    .water-area td:nth-child(2) {
+        background: rgba(128, 128, 128,0.6)
+    }
+
+    .water-area td:nth-child(2) b {
+        color: #262F31;
+    }
+
+    .collapse_water_area button {
+        background: #555;
+        color: white;
+    }
 }

--- a/Assessments.Frontend.Web/wwwroot/css/bnw.css
+++ b/Assessments.Frontend.Web/wwwroot/css/bnw.css
@@ -595,3 +595,13 @@
 .darktheme .PagedList-pageCountAndLocation.disabled a {
     color: inherit;
 }
+
+@media only screen and (max-width: 750px) {
+    .darktheme .water-area td:nth-child(2) {
+        background: rgba(128, 128, 128,0.2)
+    }
+
+    .darktheme .water-area td:nth-child(2) b {
+        color: white;
+    }
+}


### PR DESCRIPTION
Fixes #1281 
Mobilvennligifiserer tabeller for regionalt fremmene arters regionvise utbredelse, både for vannregioner og vannområder.
Samme med tabell for artens anslag på forekomstareal.