### PR TITLE
fix too narrow width on list icon species group text

### DIFF
--- a/Assessments.Frontend.Web/wwwroot/css/listview.css
+++ b/Assessments.Frontend.Web/wwwroot/css/listview.css
@@ -156,7 +156,7 @@ li a span.element_icon {
     display: flex;
     flex-direction: column;
     height: 58px;
-    min-width: 51px;
+    min-width: 55px;
 }
 
 /* ANYTHING GRID */
@@ -216,6 +216,10 @@ li a span.element_icon {
     hyphens: auto;
     overflow-wrap: break-word;
     padding: 0px 10px;
+}
+
+.element_icon.list_cell {
+    padding: 0 5px;
 }
 
 .main_list_view .amfibier,


### PR DESCRIPTION
![image](https://github.com/Artsdatabanken/assessments-frontend/assets/15391193/51f63d0f-4464-43d4-99f9-be3a58caea9e)
Artsgruppenavnet går nå kun på to linjer:
![image](https://github.com/Artsdatabanken/assessments-frontend/assets/15391193/9bad6e49-30b8-462d-8400-1057fec376e2)
