### PR TITLE
move menu button from right to left side on mobile devices

### DIFF
--- a/Assessments.Frontend.Web/wwwroot/css/site.css
+++ b/Assessments.Frontend.Web/wwwroot/css/site.css
@@ -444,11 +444,14 @@ option {
     .sidebarmenu button,
     .title_header .sidebarmenu {
         display: block;
-        height:0px;
+        height: 0px;
+        left: 0;
+        right: initial;
     }
 
     .sidebarmenu button {
-        margin-left: auto;
+        margin-left: initial !important;
+        position: relative;
     }
 
     .sidebarmenu {


### PR DESCRIPTION
Flytter meny-knappen til venstre side i henhold til punkt 1 på issue #555 