### PR TITLE
Bugfix - fix figure counts

### DIFF
--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/StatisticsHelper.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/StatisticsHelper.cs
@@ -286,15 +286,11 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
 
             var uniqueIntroductionPathwaysPerSpecies = new List<string>();
 
-            var introductionPathwaysSpecies = _query.Select(y => new
-            {
-                introductionAndSpreadPathways = y.IntroductionAndSpreadPathways.Where(z => z.IntroductionSpread == AlienSpeciesAssessment2023IntroductionPathway.IntroductionSpread.Introduction).Select(z => z.Category).ToArray(),
-                id = y.Id
-            }).ToList(); 
+            var introductionPathwaysSpecies = _query.Select(y =>  y.IntroductionAndSpreadPathways.Where(z => z.IntroductionSpread == AlienSpeciesAssessment2023IntroductionPathway.IntroductionSpread.Introduction).Select(z => z.Category).ToArray()).ToList();
 
-            foreach (var id in introductionPathwaysSpecies)
+            foreach (var speciesPathways in introductionPathwaysSpecies)
             {
-                var uniquePathways = id.introductionAndSpreadPathways.Distinct().ToList();
+                var uniquePathways = speciesPathways.Distinct().ToList();
                 uniqueIntroductionPathwaysPerSpecies.AddRange( uniquePathways );
             };
 

--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/StatisticsHelper.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/StatisticsHelper.cs
@@ -284,6 +284,20 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
 
             var barCharts = new List<BarChart>();
 
+            var uniqueIntroductionPathwaysPerSpecies = new List<string>();
+
+            var introductionPathwaysSpecies = _query.Select(y => new
+            {
+                introductionAndSpreadPathways = y.IntroductionAndSpreadPathways.Where(z => z.IntroductionSpread == AlienSpeciesAssessment2023IntroductionPathway.IntroductionSpread.Introduction).Select(z => z.Category).ToArray(),
+                id = y.Id
+            }).ToList(); 
+
+            foreach (var id in introductionPathwaysSpecies)
+            {
+                var uniquePathways = id.introductionAndSpreadPathways.Distinct().ToList();
+                uniqueIntroductionPathwaysPerSpecies.AddRange( uniquePathways );
+            };
+
             foreach (var spreadWay in allMainSpreadWays)
             {
                 var barChart = new BarChart()
@@ -292,7 +306,7 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
                     Data = _unfilteredQuery.SelectMany(x => x.IntroductionAndSpreadPathways.Where(y => y.IntroductionSpread == AlienSpeciesAssessment2023IntroductionPathway.IntroductionSpread.Introduction && y.MainCategory == spreadWay)).DistinctBy(x => x.Category).Select(x => new BarChart.BarChartData()
                     {
                         Name = x.Category,
-                        Count = _query.SelectMany(y => y.IntroductionAndSpreadPathways.DistinctBy(z => z.Category)).Where(z => z.Category == x.Category && z.IntroductionSpread == AlienSpeciesAssessment2023IntroductionPathway.IntroductionSpread.Introduction).Count()
+                        Count = uniqueIntroductionPathwaysPerSpecies.Where(item => x.Category.Equals(item)).Count()
                     }).OrderBy(x => x.Name).ToList()
                 };
                 barCharts.Add(barChart);

--- a/Assessments.Frontend.Web/Infrastructure/AlienSpecies/StatisticsHelper.cs
+++ b/Assessments.Frontend.Web/Infrastructure/AlienSpecies/StatisticsHelper.cs
@@ -119,7 +119,7 @@ namespace Assessments.Frontend.Web.Infrastructure.AlienSpecies
                 Data = distinctSpeciesGroups.Where(x => x is not AlienSpeciesAssessment2023SpeciesGroups.Unknown && !algae.Contains(x) && !crayfish.Contains(x) && !insects.Contains(x)).Select(x => new BarChart.BarChartData
                 {
                     Name = x.DisplayName(),
-                    Count = _query.Where(y => y.SpeciesGroup == x).Count()
+                    Count = _query.Where(y => y.SpeciesGroup.DisplayName() == x.DisplayName()).Count()
                 }).ToList()
             };
 


### PR DESCRIPTION
Closes #1403 

Denne pr'en løser de to siste check-boksene i issue #1403: 

1. Feil i detaljert spredningsfigur, som skal telle hver spredningsvei én gang per vurdering. 
2. Feil i tellingen på antall vurderinger i enkelte artsgrupper i artsgruppe-figuren.